### PR TITLE
Migrate legacy early-charge-incentive default through to a real policy

### DIFF
--- a/custom_components/haeo/migrations/tests/test_v1_3.py
+++ b/custom_components/haeo/migrations/tests/test_v1_3.py
@@ -764,6 +764,43 @@ async def test_async_migrate_entry_keeps_colliding_section_unique_ids_distinct(h
     assert registry.async_get_entity_id("number", DOMAIN, f"{entry.entry_id}_bat001_partition_percentage") is None
 
 
+async def test_async_migrate_entry_preserves_legacy_early_charge_incentive(hass: HomeAssistant) -> None:
+    """Legacy 0.001 charge-incentive migrates to a -$0.001 target=Battery policy.
+
+    Previously the migration silently dropped 0.001 as a "default" value;
+    with no implicit early-charge behaviour in the new optimizer that
+    would change existing installs' pull-free-power-into-storage
+    preference.  The migration now carries it through as a real policy.
+    """
+    entry = MockConfigEntry(domain=DOMAIN, title="Hub", data={CONF_NAME: "Hub"}, version=1, minor_version=0)
+    entry.add_to_hass(hass)
+
+    battery_subentry = _create_subentry(
+        {
+            CONF_ELEMENT_TYPE: battery.ELEMENT_TYPE,
+            CONF_NAME: "Bat",
+            CONF_CONNECTION: "bus",
+            SECTION_PRICING: {
+                CONF_PRICE_SOURCE_TARGET: {"type": "constant", "value": 0.0},
+                CONF_PRICE_TARGET_SOURCE: {"type": "constant", "value": 0.001},
+            },
+        },
+        subentry_type=battery.ELEMENT_TYPE,
+    )
+    hass.config_entries.async_add_subentry(entry, battery_subentry)
+
+    result = await v1_3.async_migrate_entry(hass, entry)
+
+    assert result is True
+    policy_subentry = next(s for s in entry.subentries.values() if s.subentry_type == "policy")
+    rules = policy_subentry.data[CONF_RULES]
+    assert len(rules) == 1
+    rule = rules[0]
+    assert rule["name"] == "Bat Charge"
+    assert rule["target"] == ["Bat"]
+    assert rule["price"] == {"type": "constant", "value": -0.001}
+
+
 async def test_async_migrate_entry_handles_non_constant_charge_price(hass: HomeAssistant) -> None:
     """Non-constant charge price keeps value and logs migration warning."""
     entry = MockConfigEntry(domain=DOMAIN, title="Hub", data={CONF_NAME: "Hub"}, version=1, minor_version=0)
@@ -804,6 +841,26 @@ async def test_async_migrate_entry_handles_non_constant_charge_price(hass: HomeA
 def test_is_default_policy_price_matches_known_defaults(element_type: str, field_name: str, value: float) -> None:
     """Default pricing constants are recognized and skipped by migration."""
     assert v1_3._is_default_policy_price(element_type, field_name, {"type": "constant", "value": value}) is True
+
+
+def test_is_default_policy_price_preserves_legacy_early_charge_incentive() -> None:
+    """The legacy 0.001 early-charge-incentive default must now migrate through.
+
+    The new optimizer has no built-in early-charge behaviour, so silently
+    dropping the legacy default would change existing installs' charging
+    preference. Migration negates the charge price into a policy, so a
+    legacy value of 0.001 becomes a -0.001 "*→Battery" rule that
+    preserves the original incentive to pull free upstream power into
+    storage even when export is unprofitable.
+    """
+    assert (
+        v1_3._is_default_policy_price(
+            "battery",
+            CONF_PRICE_TARGET_SOURCE,
+            {"type": "constant", "value": 0.001},
+        )
+        is False
+    )
 
 
 def test_is_default_policy_price_ignores_non_default_or_non_constant_values() -> None:

--- a/custom_components/haeo/migrations/v1_3.py
+++ b/custom_components/haeo/migrations/v1_3.py
@@ -27,7 +27,13 @@ _NONE_VALUE: dict[str, str] = {"type": "none"}
 _POLICIES_TITLE = "Policies"
 _DEFAULT_POLICY_PRICES: dict[tuple[str, str], frozenset[float]] = {
     (_BATTERY_TYPE, CONF_PRICE_SOURCE_TARGET): frozenset({0.0}),
-    (_BATTERY_TYPE, CONF_PRICE_TARGET_SOURCE): frozenset({0.0, 0.001, 0.01}),
+    # 0.001 was the legacy early-charge-incentive default; we migrate it
+    # through to a real -$0.001/kWh "*→Battery" policy rather than dropping
+    # it, because the new optimizer has no implicit early-charge behaviour
+    # and silently discarding the value would change existing installs'
+    # charging preference (they'd stop pulling free upstream power into
+    # storage when export is unprofitable).
+    (_BATTERY_TYPE, CONF_PRICE_TARGET_SOURCE): frozenset({0.0, 0.01}),
     (_SOLAR_TYPE, CONF_PRICE_SOURCE_TARGET): frozenset({0.0}),
 }
 UNIQUE_ID_PART_COUNT = 3


### PR DESCRIPTION
## Summary

The v1.3 migration previously listed `0.001` in its
`_DEFAULT_POLICY_PRICES[(battery, price_target_source)]` set, which
caused the legacy v0.3.3 `early_charge_incentive` default value to be
silently dropped during migration instead of being converted into a
policy.

That small incentive was doing meaningful work on `main`: it was the
only thing making the optimiser prefer storing free upstream solar over
leaving the battery at the minimum SoC required to cover the next
night's load.  Without it, any install whose export path is profitable
(however marginally) now leaves excess solar un-stored, because the
secondary tie-breaker only breaks ties at equal primary cost — it
doesn't compete with real export revenue, however small.

Remove `0.001` from the default set so it migrates through as a real
`target=[Battery], price=-0.001` rule.  `0.0` and `0.01` stay on the
default list unchanged (they never carried the early-charge semantics
and are still legitimately skippable).

## Why this is the right place for the fix

Investigation on scenario 6 (in an earlier thread) established that the
"battery doesn't fully charge from free solar" behaviour is actually
the correct multi-day optimum given only the prices the solver can
see — useful discharge is bounded by `load × night-length`, so
charging past ~`night_load / capacity` is locked-up capacity with no
productive outlet before the next solar day.  A small user-configurable
preference (expressed as a policy) is the right mechanism for
encouraging "fill the battery first anyway"; it was already in the
pre-1.3 schema as `early_charge_incentive` and the migration just
needs to carry it through instead of dropping it.

## Caveat

This fixes **new** migrations from pre-1.3 entries.  Installs that
already migrated to 1.3 under the old filter lost the incentive at
that point and will need to manually re-add a `target=[Battery],
price=-0.001` policy rule to restore the old behaviour.  Writing a
retroactive 1.4 migration to add it back was not in scope here —
happy to follow up if desired.

## Test plan

- [x] `uv run ruff check` on modified files.
- [x] `uv run pytest custom_components/haeo/migrations` — 55 passed (new unit test `test_is_default_policy_price_preserves_legacy_early_charge_incentive` and new integration test `test_async_migrate_entry_preserves_legacy_early_charge_incentive` cover both the filter and the end-to-end rule generation).
- [x] `uv run pytest` (full suite) — 1721 passed, 2 skipped.

Closes the discussion that led to #398 (now closed).

Made with [Cursor](https://cursor.com)