### PR TITLE
Deep copy subentry data and add noqa reasons

### DIFF
--- a/.github/instructions/python.instructions.md
+++ b/.github/instructions/python.instructions.md
@@ -119,27 +119,37 @@ See [typing philosophy](../../docs/developer-guide/typing.md) for detailed patte
 
 ### Lint suppressions
 
-Every `# noqa` comment must include an explicit reason explaining why the suppression is necessary and why there was no other choice.
+`# noqa` is a tool of last resort.
+Before adding one, try to restructure the code so the lint rule is satisfied naturally.
+Only suppress when there is genuinely no reasonable alternative.
+
+Every `# noqa` comment must include an explicit reason explaining why the suppression is necessary and why the code cannot be restructured to avoid it.
 The reason goes in parentheses after the rule code:
 
 ```python
-# ✅ Good
-from .internals import _private  # noqa: PLC0415 (avoid circular import with parent package)
+# ✅ Good - genuine need with reason
+raise ValueError(msg)  # noqa: TRY004 (ValueError is appropriate here, not TypeError)
 
 # ❌ Bad - no reason
-from .internals import _private  # noqa: PLC0415
+raise ValueError(msg)  # noqa: TRY004
+
+# ❌ Bad - could have been avoided by restructuring
+from .foo import bar  # noqa: PLC0415 (only needed here)
+# ↑ If the import works at module level, just move it there
 ```
 
 **Exception for deferred imports (PLC0415)**: Ruff's isort (`force-sort-within-sections`) strips inline reasons from import lines.
-For PLC0415, put the reason in a comment on the preceding line and keep the noqa bare:
+For PLC0415, put the reason on the preceding comment line and keep the noqa bare.
+The reason must explain a genuine constraint (circular import, conditional availability, etc.) — not just preference:
 
 ```python
-# ✅ Good - reason on preceding line, bare noqa
+# ✅ Good - genuine circular import, reason on preceding line
 # Avoid circular import with parent package
 from .internals import _private  # noqa: PLC0415
 
-# ❌ Bad - inline reason triggers isort I001
-from .internals import _private  # noqa: PLC0415 (avoid circular import with parent package)
+# ❌ Bad - no actual constraint, just move it to module level
+# Only used in one function
+from .internals import _private  # noqa: PLC0415
 ```
 
 ## Docstrings

--- a/.github/instructions/python.instructions.md
+++ b/.github/instructions/python.instructions.md
@@ -117,6 +117,31 @@ See [typing philosophy](../../docs/developer-guide/typing.md) for detailed patte
 - American English for all code and comments
 - Sentence case for messages
 
+### Lint suppressions
+
+Every `# noqa` comment must include an explicit reason explaining why the suppression is necessary and why there was no other choice.
+The reason goes in parentheses after the rule code:
+
+```python
+# ✅ Good
+from .internals import _private  # noqa: PLC0415 (avoid circular import with parent package)
+
+# ❌ Bad - no reason
+from .internals import _private  # noqa: PLC0415
+```
+
+**Exception for deferred imports (PLC0415)**: Ruff's isort (`force-sort-within-sections`) strips inline reasons from import lines.
+For PLC0415, put the reason in a comment on the preceding line and keep the noqa bare:
+
+```python
+# ✅ Good - reason on preceding line, bare noqa
+# Avoid circular import with parent package
+from .internals import _private  # noqa: PLC0415
+
+# ❌ Bad - inline reason triggers isort I001
+from .internals import _private  # noqa: PLC0415 (avoid circular import with parent package)
+```
+
 ## Docstrings
 
 - Required for all public functions and methods

--- a/config/transform_sensor.py
+++ b/config/transform_sensor.py
@@ -420,7 +420,7 @@ def main() -> int:
         logger.debug("Applied %s transform", args.transform_type)
 
         # Output to stdout (JSON only, no logging)
-        print(json.dumps(transformed))  # noqa: T201
+        print(json.dumps(transformed))  # noqa: T201 (CLI tool output to stdout)
         return 0
 
     except (FileNotFoundError, json.JSONDecodeError):

--- a/custom_components/haeo/__init__.py
+++ b/custom_components/haeo/__init__.py
@@ -160,6 +160,7 @@ async def _ensure_required_subentries(hass: HomeAssistant, hub_entry: ConfigEntr
     Creates a Network subentry (for optimization sensors) if missing.
     In non-advanced mode, also creates a Switchboard node if missing.
     """
+    # Avoid circular import with schema module
     from custom_components.haeo.core.schema.elements import ElementType  # noqa: PLC0415
     from custom_components.haeo.core.schema.elements.node import (  # noqa: PLC0415
         CONF_IS_SINK,

--- a/custom_components/haeo/coordinator/tests/test_coordinator.py
+++ b/custom_components/haeo/coordinator/tests/test_coordinator.py
@@ -244,6 +244,7 @@ def mock_runtime_data(hass: HomeAssistant, mock_hub_entry: MockConfigEntry) -> H
 
     The horizon_manager is a MagicMock - use _get_mock_horizon() to access mock methods.
     """
+    # Avoid circular import with entities and horizon modules
     from custom_components.haeo.entities.auto_optimize_switch import AutoOptimizeSwitch  # noqa: PLC0415
     from custom_components.haeo.horizon import HorizonManager  # noqa: PLC0415
 
@@ -1417,6 +1418,7 @@ def test_auto_optimize_enabled_raises_when_no_switch(
 ) -> None:
     """Auto-optimize raises error when no switch is available."""
     # Create runtime data without auto_optimize_switch
+    # Avoid circular import with horizon module
     from custom_components.haeo.horizon import HorizonManager  # noqa: PLC0415
 
     mock_horizon: Any = MagicMock(spec=HorizonManager)

--- a/custom_components/haeo/core/adapters/elements/policy.py
+++ b/custom_components/haeo/core/adapters/elements/policy.py
@@ -69,14 +69,14 @@ class PolicyAdapter:
     can_source: bool = False
     can_sink: bool = False
 
-    def model_elements(self, config: PolicyConfigData) -> list[ModelElementConfig]:  # noqa: ARG002
+    def model_elements(self, config: PolicyConfigData) -> list[ModelElementConfig]:  # noqa: ARG002 (required by adapter protocol — policy has no model elements)
         """Policy does not create model elements — policies are compiled separately."""
         return []
 
     def outputs(
         self,
-        name: str,  # noqa: ARG002
-        model_outputs: Mapping[str, Mapping[ModelOutputName, ModelOutputValue]],  # noqa: ARG002
+        name: str,  # noqa: ARG002 (required by adapter protocol — policy has no model outputs)
+        model_outputs: Mapping[str, Mapping[ModelOutputName, ModelOutputValue]],  # noqa: ARG002 (required by adapter protocol — policy has no model outputs)
         **_kwargs: Any,
     ) -> Mapping[PolicyDeviceName, Mapping[PolicyOutputName, OutputData]]:
         """Map model outputs to policy-specific output names."""

--- a/custom_components/haeo/core/data/loader/config_loader.py
+++ b/custom_components/haeo/core/data/loader/config_loader.py
@@ -144,7 +144,7 @@ def _default_for_hint(hint: FieldHint, forecast_times: Sequence[float]) -> _Sent
 
 
 def _resolve_field(
-    value: SchemaValue | bool,  # noqa: FBT001
+    value: SchemaValue | bool,  # noqa: FBT001 (bool is a valid schema field value from config flow)
     hint: FieldHint,
     sm: StateMachine,
     forecast_times: Sequence[float],

--- a/custom_components/haeo/core/data/loader/extractors/flow_power.py
+++ b/custom_components/haeo/core/data/loader/extractors/flow_power.py
@@ -54,7 +54,7 @@ class Parser:
             return False
 
         forecast_dict = state.attributes["forecast_dict"]
-        if not isinstance(forecast_dict, Mapping) or len(forecast_dict) < 2:  # noqa: PLR2004
+        if not isinstance(forecast_dict, Mapping) or len(forecast_dict) < 2:  # noqa: PLR2004 (minimum 2 entries needed to determine period length)
             return False
 
         return all(

--- a/custom_components/haeo/core/data/loader/extractors/utils/entity_metadata.py
+++ b/custom_components/haeo/core/data/loader/extractors/utils/entity_metadata.py
@@ -16,6 +16,7 @@ class EntityMetadata:
 
     def is_compatible_with(self, accepted_units: "UnitSpec | Sequence[UnitSpec]") -> bool:
         """Check if this entity's unit is compatible with the accepted units."""
+        # Avoid circular import with schema module
         from custom_components.haeo.core.schema.util import matches_unit_spec  # noqa: PLC0415
 
         if self.unit_of_measurement is None:

--- a/custom_components/haeo/core/data/loader/tests/test_time_series_loader_unit.py
+++ b/custom_components/haeo/core/data/loader/tests/test_time_series_loader_unit.py
@@ -68,7 +68,7 @@ def test_time_series_loader_available_invalid_value(monkeypatch: pytest.MonkeyPa
     monkeypatch.setattr(tsl, "load_sensors", fail_load_sensors)
 
     with pytest.raises(TypeError):
-        loader.available(sm=FakeStateMachine({}), value=cast(EntityValue, object()))  # noqa: TC006
+        loader.available(sm=FakeStateMachine({}), value=cast(EntityValue, object()))  # noqa: TC006 (cast needed to test runtime behavior with invalid type)
 
 
 @pytest.mark.asyncio

--- a/custom_components/haeo/core/model/element.py
+++ b/custom_components/haeo/core/model/element.py
@@ -188,7 +188,7 @@ class Element[OutputNameT: str]:
         """
         # Access the decorator's internal name to skip self in the dir() loop.
         # _name is set by ReactiveCost.__set_name__ and is not part of the public API.
-        this_method_name = type(self).cost._name  # type: ignore[attr-defined]  # noqa: SLF001
+        this_method_name = type(self).cost._name  # type: ignore[attr-defined]  # noqa: SLF001 (_name is set by ReactiveCost.__set_name__, not part of public API)
 
         costs: list[highs_linear_expression] = []
         for name in dir(type(self)):

--- a/custom_components/haeo/core/model/elements/segments/segment.py
+++ b/custom_components/haeo/core/model/elements/segments/segment.py
@@ -145,7 +145,7 @@ class Segment:
     def cost(self) -> highs_linear_expression | None:
         """Return aggregated primary cost expression from this segment."""
         # Access decorator's internal name to skip self in dir() loop
-        this_method_name = type(self).cost._name  # type: ignore[attr-defined]  # noqa: SLF001
+        this_method_name = type(self).cost._name  # type: ignore[attr-defined]  # noqa: SLF001 (_name is set by ReactiveCost.__set_name__, not part of public API)
 
         costs: list[highs_linear_expression] = []
         for name in dir(type(self)):

--- a/custom_components/haeo/core/model/network.py
+++ b/custom_components/haeo/core/model/network.py
@@ -227,11 +227,11 @@ class Network:
 
             if not isinstance(source_element, NetworkElement):
                 msg = f"Source element '{element_instance.source}' is not a network participant"
-                raise ValueError(msg)  # noqa: TRY004 value error is appropriate here
+                raise ValueError(msg)  # noqa: TRY004 (ValueError is appropriate here, not TypeError)
 
             if not isinstance(target_element, NetworkElement):
                 msg = f"Target element '{element_instance.target}' is not a network participant"
-                raise ValueError(msg)  # noqa: TRY004 value error is appropriate here
+                raise ValueError(msg)  # noqa: TRY004 (ValueError is appropriate here, not TypeError)
 
             source_element.register_connection(element_instance, "source")
             target_element.register_connection(element_instance, "target")

--- a/custom_components/haeo/core/model/output_data.py
+++ b/custom_components/haeo/core/model/output_data.py
@@ -41,7 +41,7 @@ class OutputData:
 
     def __init__(
         self,
-        type: OutputType,  # noqa: A002
+        type: OutputType,  # noqa: A002 (shadows builtin but matches OutputType field naming convention)
         unit: str | None,
         values: Sequence[Any] | Any,
         direction: Literal["+", "-"] | None = None,

--- a/custom_components/haeo/core/model/reactive/decorators.py
+++ b/custom_components/haeo/core/model/reactive/decorators.py
@@ -136,7 +136,7 @@ class ReactiveConstraint[R](ReactiveMethod[R]):
         # Extract shadow prices from the constraint using the solver
         cons = state["constraint"]
         arr = np.asarray(cons, dtype=object)
-        values = tuple(obj._solver.constrDuals(arr).flat)  # noqa: SLF001 # pyright: ignore[reportPrivateUsage]
+        values = tuple(obj._solver.constrDuals(arr).flat)  # noqa: SLF001 (tightly coupled reactive infrastructure requires solver access) # pyright: ignore[reportPrivateUsage]
         return OutputData(
             type=OutputType.SHADOW_PRICE,
             unit=self.unit,
@@ -175,7 +175,7 @@ class ReactiveConstraint[R](ReactiveMethod[R]):
             return expr  # type: ignore[return-value]
 
         # Get solver from element
-        solver: Highs = obj._solver  # noqa: SLF001 # pyright: ignore[reportPrivateUsage] (tightly coupled reactive infrastructure)
+        solver: Highs = obj._solver  # noqa: SLF001 (tightly coupled reactive infrastructure requires solver access) # pyright: ignore[reportPrivateUsage]
 
         # First call: create constraint(s) in solver
         if is_first_call:
@@ -204,12 +204,12 @@ class ReactiveConstraint[R](ReactiveMethod[R]):
         """
         if isinstance(existing, list):
             # Both existing and expr are lists - update element-wise
-            assert isinstance(expr, list), "Expression type must match existing constraint type"  # noqa: S101
+            assert isinstance(expr, list), "Expression type must match existing constraint type"  # noqa: S101 (runtime invariant check for constraint type consistency)
             for cons, exp in zip(existing, expr, strict=True):
                 self._update_single_constraint(solver, cons, exp)
         else:
             # Both existing and expr are single values
-            assert not isinstance(expr, list), "Expression type must match existing constraint type"  # noqa: S101
+            assert not isinstance(expr, list), "Expression type must match existing constraint type"  # noqa: S101 (runtime invariant check for constraint type consistency)
             self._update_single_constraint(solver, existing, expr)
 
     def _update_single_constraint(

--- a/custom_components/haeo/core/model/tests/test_data/__init__.py
+++ b/custom_components/haeo/core/model/tests/test_data/__init__.py
@@ -30,7 +30,7 @@ def highs_sequence(h: Highs, name: str, length: int) -> tuple[list[highs_var], H
 
 
 # Import modules after defining utilities to avoid circular imports
-from . import battery, connection, connection_segments, node, segments  # noqa: E402
+from . import battery, connection, connection_segments, node, segments  # noqa: E402 (must import after utility functions are defined)
 
 
 def _aggregate_element_cases() -> list[ElementTestCase]:

--- a/custom_components/haeo/core/schema/constant_value.py
+++ b/custom_components/haeo/core/schema/constant_value.py
@@ -16,7 +16,7 @@ class ConstantValue(TypedDict):
     value: float | bool
 
 
-def as_constant_value(value: float | bool) -> ConstantValue:  # noqa: FBT001
+def as_constant_value(value: float | bool) -> ConstantValue:  # noqa: FBT001 (bool is a valid constant value in the schema type system)
     """Create a constant schema value from a scalar."""
     return {"type": VALUE_TYPE_CONSTANT, "value": value}
 

--- a/custom_components/haeo/elements/field_schema.py
+++ b/custom_components/haeo/elements/field_schema.py
@@ -1,3 +1,3 @@
 """Field schema metadata utilities (re-exported from schema.field_schema)."""
 
-from custom_components.haeo.core.schema.field_schema import *  # noqa: F403
+from custom_components.haeo.core.schema.field_schema import *  # noqa: F403 (re-exporting entire public API for backwards compatibility)

--- a/custom_components/haeo/elements/tests/test_availability.py
+++ b/custom_components/haeo/elements/tests/test_availability.py
@@ -27,7 +27,7 @@ def test_schema_config_available_returns_false_for_unavailable_entity(
 ) -> None:
     """schema_config_available returns False when entity values are unavailable."""
 
-    def _fake_available(self: TimeSeriesLoader, *, sm: FakeStateMachine, value: Any) -> bool:  # noqa: ARG001
+    def _fake_available(self: TimeSeriesLoader, *, sm: FakeStateMachine, value: Any) -> bool:  # noqa: ARG001 (matches TimeSeriesLoader.available signature)
         return False
 
     monkeypatch.setattr(TimeSeriesLoader, "available", _fake_available)
@@ -43,7 +43,7 @@ def test_schema_config_available_handles_nested_entity(
     """schema_config_available returns True for nested entity values when available."""
     calls: list[Any] = []
 
-    def _fake_available(self: TimeSeriesLoader, *, sm: FakeStateMachine, value: Any) -> bool:  # noqa: ARG001
+    def _fake_available(self: TimeSeriesLoader, *, sm: FakeStateMachine, value: Any) -> bool:  # noqa: ARG001 (matches TimeSeriesLoader.available signature)
         calls.append(value)
         return True
 

--- a/custom_components/haeo/flows/element_flow.py
+++ b/custom_components/haeo/flows/element_flow.py
@@ -173,6 +173,7 @@ class ElementFlowMixin:
             List of element names that can be used as connection targets.
 
         """
+        # Avoid circular import with adapter registry, core constants, and schema module
         from custom_components.haeo.core.adapters.registry import ELEMENT_TYPES  # noqa: PLC0415
         from custom_components.haeo.core.const import ConnectivityLevel  # noqa: PLC0415
         from custom_components.haeo.core.schema.elements import ElementType  # noqa: PLC0415

--- a/custom_components/haeo/flows/tests/test_element_flows.py
+++ b/custom_components/haeo/flows/tests/test_element_flows.py
@@ -162,14 +162,14 @@ class FlowTestSubentryFlowHandler(ConfigSubentryFlow):
 
     async def async_step_user(
         self,
-        user_input: dict[str, Any] | None = None,  # noqa: ARG002
+        user_input: dict[str, Any] | None = None,  # noqa: ARG002 (required by ConfigSubentryFlow interface)
     ) -> SubentryFlowResult:
         """Handle user step for mock element."""
         return self.async_create_entry(title="Test", data={})
 
     async def async_step_reconfigure(
         self,
-        user_input: dict[str, Any] | None = None,  # noqa: ARG002
+        user_input: dict[str, Any] | None = None,  # noqa: ARG002 (required by ConfigSubentryFlow interface)
     ) -> SubentryFlowResult:
         """Handle reconfigure step for mock element."""
         return self.async_update_and_abort(self._get_entry(), self._get_reconfigure_subentry(), data={})
@@ -195,13 +195,13 @@ def flow_test_element_factory(monkeypatch: pytest.MonkeyPatch) -> FlowTestElemen
             _ = config
             return {}
 
-        def model_elements(self, config: Any) -> list[dict[str, Any]]:  # noqa: ARG002
+        def model_elements(self, config: Any) -> list[dict[str, Any]]:  # noqa: ARG002 (required by adapter protocol)
             return []
 
         def outputs(
             self,
-            name: str,  # noqa: ARG002
-            model_outputs: Mapping[str, Mapping[Any, OutputData]],  # noqa: ARG002
+            name: str,  # noqa: ARG002 (required by adapter protocol)
+            model_outputs: Mapping[str, Mapping[Any, OutputData]],  # noqa: ARG002 (required by adapter protocol)
             **_kwargs: Any,
         ) -> Mapping[str, Mapping[ElementOutputName, OutputData]]:
             return {}

--- a/custom_components/haeo/system_health.py
+++ b/custom_components/haeo/system_health.py
@@ -18,7 +18,7 @@ from .core.data.forecast_times import tiers_to_periods_seconds
 
 @callback
 def async_register(
-    hass: HomeAssistant,  # noqa: ARG001
+    hass: HomeAssistant,  # noqa: ARG001 (required by HA system health registration callback signature)
     register: system_health.SystemHealthRegistration,
 ) -> None:
     """Register system health callbacks."""

--- a/custom_components/haeo/util/__init__.py
+++ b/custom_components/haeo/util/__init__.py
@@ -1,5 +1,6 @@
 """Utility functions for HAEO."""
 
+import copy
 from typing import TYPE_CHECKING, Any
 
 from homeassistant.config_entries import ConfigSubentry
@@ -38,7 +39,7 @@ async def async_update_subentry_value(
         runtime_data.value_update_in_progress = True
 
     # Update subentry data with new value
-    new_data = dict(subentry.data)
+    new_data = copy.deepcopy(dict(subentry.data))
     set_nested_config_value_by_path(new_data, field_path, value)
 
     try:

--- a/custom_components/haeo/util/tests/test_update_subentry_value.py
+++ b/custom_components/haeo/util/tests/test_update_subentry_value.py
@@ -3,7 +3,7 @@
 from types import MappingProxyType
 from unittest.mock import Mock
 
-from homeassistant.config_entries import ConfigSubentry
+from homeassistant.config_entries import ConfigEntry, ConfigSubentry
 from homeassistant.core import HomeAssistant
 import pytest
 
@@ -84,3 +84,59 @@ async def test_flag_cleared_on_exception(
         )
 
     assert mock_runtime_data.value_update_in_progress is False
+
+
+async def test_nested_value_update_fires_listener(
+    hass: HomeAssistant,
+) -> None:
+    """Updating a nested field actually triggers the HA update listener.
+
+    A shallow copy of MappingProxyType shares nested containers, so
+    mutating via set_nested_config_value_by_path would silently modify
+    the original data.  async_update_subentry then sees no change and
+    skips the listener.
+    """
+    from pytest_homeassistant_custom_component.common import MockConfigEntry  # noqa: PLC0415
+
+    from custom_components.haeo.const import DOMAIN  # noqa: PLC0415
+    from custom_components.haeo.core.schema.constant_value import as_constant_value  # noqa: PLC0415
+
+    entry = MockConfigEntry(domain=DOMAIN, entry_id="nested_test")
+    entry.add_to_hass(hass)
+    entry.runtime_data = Mock()
+    entry.runtime_data.value_update_in_progress = False
+
+    subentry = ConfigSubentry(
+        data=MappingProxyType({
+            "rules": [
+                {"name": "r1", "price": as_constant_value(0.02)},
+            ],
+        }),
+        subentry_type="policy",
+        title="Policies",
+        unique_id=None,
+    )
+    hass.config_entries.async_add_subentry(entry, subentry)
+
+    listener_called = False
+
+    async def _listener(_hass: HomeAssistant, _entry: ConfigEntry) -> None:
+        nonlocal listener_called
+        listener_called = True
+
+    entry.add_update_listener(_listener)
+
+    await async_update_subentry_value(
+        hass=hass,
+        entry=entry,
+        subentry=subentry,
+        field_path=("rules", "0", "price"),
+        value=as_constant_value(0.10),
+    )
+    await hass.async_block_till_done()
+
+    assert listener_called, (
+        "Update listener must fire when a nested field changes. "
+        "A shallow copy of MappingProxyType shares nested containers, "
+        "causing async_update_subentry to see no change."
+    )

--- a/custom_components/haeo/util/tests/test_update_subentry_value.py
+++ b/custom_components/haeo/util/tests/test_update_subentry_value.py
@@ -96,6 +96,7 @@ async def test_nested_value_update_fires_listener(
     the original data.  async_update_subentry then sees no change and
     skips the listener.
     """
+    # Only needed in this test, not the module
     from pytest_homeassistant_custom_component.common import MockConfigEntry  # noqa: PLC0415
 
     from custom_components.haeo.const import DOMAIN  # noqa: PLC0415

--- a/custom_components/haeo/util/tests/test_update_subentry_value.py
+++ b/custom_components/haeo/util/tests/test_update_subentry_value.py
@@ -6,7 +6,10 @@ from unittest.mock import Mock
 from homeassistant.config_entries import ConfigEntry, ConfigSubentry
 from homeassistant.core import HomeAssistant
 import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 
+from custom_components.haeo.const import DOMAIN
+from custom_components.haeo.core.schema.constant_value import as_constant_value
 from custom_components.haeo.util import async_update_subentry_value
 
 
@@ -96,23 +99,19 @@ async def test_nested_value_update_fires_listener(
     the original data.  async_update_subentry then sees no change and
     skips the listener.
     """
-    # Only needed in this test, not the module
-    from pytest_homeassistant_custom_component.common import MockConfigEntry  # noqa: PLC0415
-
-    from custom_components.haeo.const import DOMAIN  # noqa: PLC0415
-    from custom_components.haeo.core.schema.constant_value import as_constant_value  # noqa: PLC0415
-
     entry = MockConfigEntry(domain=DOMAIN, entry_id="nested_test")
     entry.add_to_hass(hass)
     entry.runtime_data = Mock()
     entry.runtime_data.value_update_in_progress = False
 
     subentry = ConfigSubentry(
-        data=MappingProxyType({
-            "rules": [
-                {"name": "r1", "price": as_constant_value(0.02)},
-            ],
-        }),
+        data=MappingProxyType(
+            {
+                "rules": [
+                    {"name": "r1", "price": as_constant_value(0.02)},
+                ],
+            }
+        ),
         subentry_type="policy",
         title="Policies",
         unique_id=None,

--- a/docs/assets/branding/make_branding_pngs.py
+++ b/docs/assets/branding/make_branding_pngs.py
@@ -5,7 +5,7 @@
 #     "playwright>=1.40.0",
 # ]
 # ///
-# ruff: noqa: T201
+# ruff: noqa: T201 (CLI script that outputs progress to stdout)
 """Convert SVG files to PNG at various resolutions for Home Assistant brands repository."""
 
 import asyncio

--- a/tests/guides/primitives/haeo.py
+++ b/tests/guides/primitives/haeo.py
@@ -143,6 +143,7 @@ def _field_label(element_type: str, section_key: str, field_name: str) -> str:
 def _has_none_value(value_type: Any) -> bool:
     """Check if NoneValue is part of a union type annotation."""
     if isinstance(value_type, types.UnionType):
+        # Avoid circular import with schema module
         from custom_components.haeo.core.schema import NoneValue  # noqa: PLC0415
 
         return NoneValue in get_args(value_type)
@@ -220,6 +221,7 @@ def _fill_element_fields(
     Fields must be ordered by section (matching the form's top-to-bottom
     layout) to ensure correct section expansion behavior.
     """
+    # Avoid circular import with elements module
     from custom_components.haeo.elements import get_input_field_schema_info, get_input_fields  # noqa: PLC0415
 
     input_fields = get_input_fields(element_type)

--- a/tests/scenarios/conftest.py
+++ b/tests/scenarios/conftest.py
@@ -54,7 +54,7 @@ def expand_diagnostics_scenario() -> None:
             # Delete the unified file after successful split
             scenario_file.unlink()
 
-            print(f"Migrated {scenario_file.name} to split format in {scenario_path.name}")  # noqa: T201
+            print(f"Migrated {scenario_file.name} to split format in {scenario_path.name}")  # noqa: T201 (migration CLI output)
 
 
 class ScenarioData(TypedDict):
@@ -137,6 +137,6 @@ def scenario_data(scenario_path: Path) -> ScenarioData:
 
 
 @pytest.fixture
-def snapshot(snapshot):  # type: ignore[no-untyped-def]  # noqa: ANN001, ANN201
+def snapshot(snapshot):  # type: ignore[no-untyped-def]  # noqa: ANN001, ANN201 (pytest fixture override cannot add type hints without breaking syrupy)
     """Override the default snapshot fixture with custom ScenarioJSONExtension."""
     return snapshot.use_extension(ScenarioJSONExtension)

--- a/tests/scenarios/filter_states.py
+++ b/tests/scenarios/filter_states.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# ruff: noqa: T201
+# ruff: noqa: T201 (CLI script that outputs to stdout by design)
 
 """HAEO Scenario States Filter Script.
 
@@ -37,12 +37,12 @@ def fetch_home_assistant_states(url: str, token: str) -> list[dict[str, Any]]:
         print(states_url)
 
         # Create request with authorization header
-        req = urllib_request.Request(states_url)  # noqa: S310
+        req = urllib_request.Request(states_url)  # noqa: S310 (connecting to user-configured local HA instance)
         req.add_header("Authorization", f"Bearer {token}")
         req.add_header("Content-Type", "application/json")
 
         # Make the request
-        with urllib_request.urlopen(req) as response:  # noqa: S310
+        with urllib_request.urlopen(req) as response:  # noqa: S310 (connecting to user-configured local HA instance)
             raw = json.loads(response.read().decode("utf-8"))
 
         print(raw)

--- a/tests/scenarios/syrupy_json_extension.py
+++ b/tests/scenarios/syrupy_json_extension.py
@@ -19,8 +19,8 @@ _REPO_ROOT = Path(__file__).resolve().parents[2]
 def _prettier_format(file: Path) -> None:
     """Run prettier on a file to match committed formatting style."""
     try:
-        subprocess.run(  # noqa: S603
-            ["npx", "prettier", "--write", str(file)],  # noqa: S607
+        subprocess.run(  # noqa: S603 (invoking trusted npx/prettier tool)
+            ["npx", "prettier", "--write", str(file)],  # noqa: S607 (npx is a trusted first-party tool)
             cwd=_REPO_ROOT,
             capture_output=True,
             timeout=30,
@@ -192,7 +192,7 @@ class ScenarioJSONExtension(JSONSnapshotExtension):
     def write_snapshot(
         cls,
         *,
-        snapshot_location: str,  # noqa: ARG003
+        snapshot_location: str,  # noqa: ARG003 (required by syrupy interface)
         snapshots: list[tuple[SerializedData, PyTestLocation, SnapshotIndex]],
     ) -> None:
         """Write snapshot data directly to outputs.json.
@@ -220,8 +220,8 @@ class ScenarioJSONExtension(JSONSnapshotExtension):
     def read_snapshot(
         self,
         *,
-        index: SnapshotIndex = 0,  # noqa: ARG002
-        session_id: str,  # noqa: ARG002
+        index: SnapshotIndex = 0,  # noqa: ARG002 (required by syrupy interface)
+        session_id: str,  # noqa: ARG002 (required by syrupy interface)
         test_location: PyTestLocation,
     ) -> SerializableData:
         """Read snapshot data directly from outputs.json.

--- a/tools/assemble_docs.py
+++ b/tools/assemble_docs.py
@@ -75,8 +75,8 @@ def parse_tag(tag: str) -> Release | None:
 
 def fetch_releases(repo: str) -> list[Release]:
     """Return releases (newest first) that have a ``docs-<tag>.zip`` asset attached."""
-    result = subprocess.run(  # noqa: S603
-        ["gh", "api", f"repos/{repo}/releases", "--paginate"],  # noqa: S607
+    result = subprocess.run(  # noqa: S603 (invoking trusted gh CLI tool)
+        ["gh", "api", f"repos/{repo}/releases", "--paginate"],  # noqa: S607 (gh is a trusted first-party CLI tool)
         capture_output=True,
         text=True,
         check=True,
@@ -124,8 +124,8 @@ def download_docs(repo: str, tag: str, dest: Path) -> None:
     """Download the release's ``docs-<tag>.zip`` asset and extract it into ``dest``."""
     asset = docs_asset_name(tag)
     with tempfile.TemporaryDirectory() as td:
-        subprocess.run(  # noqa: S603
-            [  # noqa: S607
+        subprocess.run(  # noqa: S603 (invoking trusted gh CLI tool)
+            [  # noqa: S607 (gh is a trusted first-party CLI tool)
                 "gh",
                 "release",
                 "download",

--- a/tools/guide_fence.py
+++ b/tools/guide_fence.py
@@ -110,13 +110,13 @@ def _get_page_hash(md: object) -> str:
     sources = extract_sources(markdown)
     page_hash = compute_page_hash(sources)
 
-    md._guide_page_hash = page_hash  # type: ignore[attr-defined]  # noqa: SLF001
+    md._guide_page_hash = page_hash  # type: ignore[attr-defined]  # noqa: SLF001 (stashing state on mkdocs Markdown instance, no public API available)
     return page_hash
 
 
 def _find_block(source: str, page_hash: str) -> dict[str, object] | None:
     """Find the manifest block matching this source code by content hash."""
-    global _manifest_cache  # noqa: PLW0603
+    global _manifest_cache  # noqa: PLW0603 (module-level cache requires global reassignment)
     if _manifest_cache is None or _manifests_changed():
         _manifest_cache = _load_manifests()
     content_hash = compute_content_hash(page_hash, source)

--- a/tools/guide_runner.py
+++ b/tools/guide_runner.py
@@ -201,7 +201,7 @@ def _run_guide_silently(page: HAPage, hass: LiveHomeAssistant, guide_name: str) 
     with pause_screenshots():
         for block in ref_blocks:
             if block.captures:
-                exec(compile(block.source, f"<{guide_name} block {block.index}>", "exec"), namespace)  # noqa: S102
+                exec(compile(block.source, f"<{guide_name} block {block.index}>", "exec"), namespace)  # noqa: S102 (guide runner must execute user-authored code blocks)
 
 
 def build_exec_namespace(page: HAPage, hass: LiveHomeAssistant) -> dict[str, object]:
@@ -282,14 +282,14 @@ def run_blocks_for_mode(
                     if not block.captures:
                         # Setup blocks run without screenshot capture
                         with pause_screenshots():
-                            exec(compile(block.source, f"<guide-setup block {block.index}>", "exec"), namespace)  # noqa: S102
+                            exec(compile(block.source, f"<guide-setup block {block.index}>", "exec"), namespace)  # noqa: S102 (guide runner must execute user-authored code blocks)
                         continue
 
                     # Record screenshots before this block
                     before_count = len(ctx.screenshots)
 
                     # Execute the block in the shared namespace
-                    exec(compile(block.source, f"<guide block {block.index}>", "exec"), namespace)  # noqa: S102
+                    exec(compile(block.source, f"<guide block {block.index}>", "exec"), namespace)  # noqa: S102 (guide runner must execute user-authored code blocks)
 
                     # Collect screenshots produced by this block
                     all_names = list(ctx.screenshots.keys())
@@ -395,7 +395,7 @@ def main() -> None:
     """CLI entry point: run guide(s) from markdown files."""
     logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 
-    if len(sys.argv) < 2:  # noqa: PLR2004
+    if len(sys.argv) < 2:  # noqa: PLR2004 (CLI argument count check, not a meaningful constant)
         print("Usage: uv run python -m tools.guide_runner <markdown_file> [--force] [--headed]")
         sys.exit(1)
 


### PR DESCRIPTION
## Problem

`async_update_subentry_value` used `dict(subentry.data)` — a shallow copy of the `MappingProxyType` wrapper. Nested containers (lists, dicts inside rules etc.) were shared between the copy and the original. When `set_nested_config_value_by_path` modified a nested value, it mutated both in place. `async_update_subentry` then compared old and new, saw no difference, and skipped the update listener entirely.

This caused `value_update_in_progress` to get stuck at `True`. The next config flow change (add/edit/delete rule) was then swallowed by the update listener — it treated the change as a value-only update instead of scheduling a reload.

## Fix

Use `copy.deepcopy(dict(subentry.data))` so nested containers are fully independent before mutation.

## Test

Added `test_nested_value_update_fires_listener` which exercises the real HA update machinery (no mocks on `async_update_subentry`) and verifies the update listener fires when a nested field changes.

## Housekeeping

Added explicit reasons to all existing `# noqa` suppressions across the codebase, and updated `python.instructions.md` with a lint suppressions convention:

- `noqa` is a tool of last resort — restructure code first
- Every suppression must include a reason explaining the genuine constraint
- For `PLC0415` (deferred imports): reason on the preceding comment line, bare `noqa` on the import (ruff isort strips inline reasons)
- For all other rules: reason in parentheses after the rule code