### PR TITLE
Bump version to 0.4.0rc5

### DIFF
--- a/custom_components/haeo/manifest.json
+++ b/custom_components/haeo/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/hass-energy/haeo/issues",
   "requirements": ["highspy>=1.12.0", "numpy>=1.21.0"],
-  "version": "0.4.0rc4"
+  "version": "0.4.0rc5"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "haeo"
-version = "0.4.0rc4"
+version = "0.4.0rc5"
 description = "Home Assistant Energy Network Optimizer"
 readme = "README.md"
 requires-python = ">=3.13.2,<3.14"

--- a/uv.lock
+++ b/uv.lock
@@ -1050,7 +1050,7 @@ wheels = [
 
 [[package]]
 name = "haeo"
-version = "0.4.0rc4"
+version = "0.4.0rc5"
 source = { editable = "." }
 dependencies = [
     { name = "highspy" },


### PR DESCRIPTION
## Summary

Release candidate version bump only.

## Changes

- `pyproject.toml`: `0.4.0rc4` → `0.4.0rc5`
- `custom_components/haeo/manifest.json`: matching version (HA requirement)
- `uv.lock`: regenerated via `uv lock`

No functional code changes.

Made with [Cursor](https://cursor.com)