### PR TITLE
Fix battery undercharge partition acting as hard SOC clamp

### DIFF
--- a/custom_components/haeo/core/adapters/elements/battery.py
+++ b/custom_components/haeo/core/adapters/elements/battery.py
@@ -125,7 +125,15 @@ class BatteryAdapter:
         undercharge_percentage = undercharge.get(CONF_PARTITION_PERCENTAGE) if undercharge_cost is not None else None
         overcharge_percentage = overcharge.get(CONF_PARTITION_PERCENTAGE) if overcharge_cost is not None else None
 
-        lower_ratio = undercharge_percentage if undercharge_percentage is not None else min_charge_percentage
+        # When undercharge_percentage > min_charge_percentage (e.g. user sets undercharge=20%,
+        # leaves min at default 0%), use min_charge_percentage as the LP origin so that
+        # (a) initial SOC values below the undercharge boundary remain representable without
+        #     clamping, and (b) the soc_pricing threshold is positive and can activate.
+        lower_ratio = (
+            np.minimum(undercharge_percentage, min_charge_percentage)
+            if undercharge_percentage is not None
+            else min_charge_percentage
+        )
         upper_ratio = overcharge_percentage if overcharge_percentage is not None else max_charge_percentage
 
         lower_ratio_first = float(lower_ratio[0]) if isinstance(lower_ratio, np.ndarray) else float(lower_ratio)
@@ -151,9 +159,13 @@ class BatteryAdapter:
 
         soc_pricing_spec: SocPricingSegmentSpec | None = None
         if undercharge_percentage is not None and undercharge_cost is not None:
-            min_ratio_series = broadcast_to_sequence(min_charge_percentage, n_periods + 1)[1:]
             lower_ratio_series = broadcast_to_sequence(lower_ratio, n_periods + 1)[1:]
-            discharge_energy_threshold = (min_ratio_series - lower_ratio_series) * capacity[1:]
+            # Threshold = distance from LP origin to the soft preferred minimum.
+            # max() ensures this is positive regardless of which is larger.
+            preferred_min_series = broadcast_to_sequence(
+                np.maximum(undercharge_percentage, min_charge_percentage), n_periods + 1
+            )[1:]
+            discharge_energy_threshold = (preferred_min_series - lower_ratio_series) * capacity[1:]
             soc_pricing_spec = {
                 "segment_type": "soc_pricing",
                 "discharge_energy_threshold": discharge_energy_threshold,
@@ -275,7 +287,11 @@ def _calculate_total_energy(aggregate_energy: OutputData, config: BatteryConfigD
     undercharge = config.get(SECTION_UNDERCHARGE, {})
     undercharge_cost = undercharge.get(CONF_PARTITION_COST)
     undercharge_pct = undercharge.get(CONF_PARTITION_PERCENTAGE) if undercharge_cost is not None else None
-    unusable_ratio = undercharge_pct if undercharge_pct is not None else min_charge_percentage
+    unusable_ratio = (
+        np.minimum(undercharge_pct, min_charge_percentage)
+        if undercharge_pct is not None
+        else min_charge_percentage
+    )
 
     # Both energy values and capacity/ratios are now boundaries (n+1 values)
     inaccessible_energy = unusable_ratio * capacity

--- a/custom_components/haeo/core/adapters/elements/tests/test_battery_model.py
+++ b/custom_components/haeo/core/adapters/elements/tests/test_battery_model.py
@@ -55,6 +55,71 @@ class OutputsCase(TypedDict):
 
 CREATE_CASES: Sequence[CreateCase] = [
     {
+        "description": "Battery with initial SOC inside undercharge penalty zone",
+        "data": BatteryConfigData(
+            element_type=ElementType.BATTERY,
+            name="battery_soc_below_undercharge",
+            connection=as_connection_target("network"),
+            storage={
+                "capacity": np.array([10.0, 10.0]),
+                "initial_charge_percentage": 0.15,
+            },
+            limits={
+                "min_charge_percentage": np.array([0.0, 0.0]),
+                "max_charge_percentage": np.array([1.0, 1.0]),
+            },
+            power_limits={
+                "max_power_source_target": np.array([5.0]),
+                "max_power_target_source": np.array([5.0]),
+            },
+            pricing={"salvage_value": 0.0},
+            efficiency={
+                "efficiency_source_target": np.array([0.95]),
+                "efficiency_target_source": np.array([0.95]),
+            },
+            partitioning={},
+            undercharge={
+                "percentage": np.array([0.20, 0.20]),
+                "cost": np.array([0.05]),
+            },
+            overcharge={},
+        ),
+        "model": [
+            {
+                "element_type": MODEL_ELEMENT_TYPE_BATTERY,
+                "name": "battery_soc_below_undercharge",
+                "capacity": [10.0, 10.0],
+                "initial_charge": 1.5,
+                "salvage_value": 0.0,
+            },
+            {
+                "element_type": MODEL_ELEMENT_TYPE_CONNECTION,
+                "name": "battery_soc_below_undercharge:discharge",
+                "source": "battery_soc_below_undercharge",
+                "target": "network",
+                "segments": {
+                    "efficiency": {"segment_type": "efficiency", "efficiency": [0.95]},
+                    "power_limit": {"segment_type": "power_limit", "max_power": [5.0]},
+                    "soc_pricing": {
+                        "segment_type": "soc_pricing",
+                        "discharge_energy_threshold": [2.0],
+                        "discharge_energy_price": [0.05],
+                    },
+                },
+            },
+            {
+                "element_type": MODEL_ELEMENT_TYPE_CONNECTION,
+                "name": "battery_soc_below_undercharge:charge",
+                "source": "network",
+                "target": "battery_soc_below_undercharge",
+                "segments": {
+                    "efficiency": {"segment_type": "efficiency", "efficiency": [0.95]},
+                    "power_limit": {"segment_type": "power_limit", "max_power": [5.0]},
+                },
+            },
+        ],
+    },
+    {
         "description": "Battery with SOC pricing thresholds",
         "data": BatteryConfigData(
             element_type=ElementType.BATTERY,
@@ -249,6 +314,94 @@ CREATE_CASES: Sequence[CreateCase] = [
 
 OUTPUTS_CASES: Sequence[OutputsCase] = [
     {
+        "description": "Battery outputs use min charge as SOC floor when undercharge exceeds min charge",
+        "name": "battery_undercharge_exceeds_min",
+        "data": BatteryConfigData(
+            element_type=ElementType.BATTERY,
+            name="battery_undercharge_exceeds_min",
+            connection=as_connection_target("network"),
+            storage={
+                "capacity": np.array([10.0, 10.0]),
+                "initial_charge_percentage": 0.15,
+            },
+            limits={
+                "min_charge_percentage": np.array([0.0, 0.0]),
+                "max_charge_percentage": np.array([1.0, 1.0]),
+            },
+            power_limits={
+                "max_power_source_target": np.array([5.0]),
+                "max_power_target_source": np.array([5.0]),
+            },
+            pricing={"salvage_value": 0.0},
+            efficiency={
+                "efficiency_source_target": np.array([0.95]),
+                "efficiency_target_source": np.array([0.95]),
+            },
+            partitioning={},
+            undercharge={
+                "percentage": np.array([0.20, 0.20]),
+                "cost": np.array([0.05]),
+            },
+            overcharge={},
+        ),
+        "model_outputs": {
+            "battery_undercharge_exceeds_min": {
+                battery_model.BATTERY_POWER_CHARGE: OutputData(
+                    type=OutputType.POWER, unit="kW", values=(0.0,), direction="-"
+                ),
+                battery_model.BATTERY_POWER_DISCHARGE: OutputData(
+                    type=OutputType.POWER, unit="kW", values=(0.0,), direction="+"
+                ),
+                battery_model.BATTERY_ENERGY_STORED: OutputData(
+                    type=OutputType.ENERGY, unit="kWh", values=(1.5, 1.5)
+                ),
+                battery_model.BATTERY_POWER_BALANCE: OutputData(
+                    type=OutputType.SHADOW_PRICE, unit="$/kWh", values=(0.0,)
+                ),
+                battery_model.BATTERY_ENERGY_IN_FLOW: OutputData(
+                    type=OutputType.SHADOW_PRICE, unit="$/kWh", values=(0.0,)
+                ),
+                battery_model.BATTERY_ENERGY_OUT_FLOW: OutputData(
+                    type=OutputType.SHADOW_PRICE, unit="$/kWh", values=(0.0,)
+                ),
+                battery_model.BATTERY_SOC_MAX: OutputData(
+                    type=OutputType.SHADOW_PRICE, unit="$/kWh", values=(0.0,)
+                ),
+                battery_model.BATTERY_SOC_MIN: OutputData(
+                    type=OutputType.SHADOW_PRICE, unit="$/kWh", values=(0.0,)
+                ),
+            },
+            "battery_undercharge_exceeds_min:discharge": {
+                connection.CONNECTION_POWER: OutputData(
+                    type=OutputType.POWER_FLOW, unit="kW", values=(0.0,), direction="+"
+                ),
+            },
+            "battery_undercharge_exceeds_min:charge": {
+                connection.CONNECTION_POWER: OutputData(
+                    type=OutputType.POWER_FLOW, unit="kW", values=(0.0,), direction="-"
+                ),
+            },
+        },
+        "outputs": {
+            BATTERY_DEVICE_BATTERY: {
+                BATTERY_POWER_CHARGE: OutputData(type=OutputType.POWER, unit="kW", values=(0.0,), direction="-"),
+                BATTERY_POWER_DISCHARGE: OutputData(type=OutputType.POWER, unit="kW", values=(0.0,), direction="+"),
+                BATTERY_POWER_ACTIVE: OutputData(type=OutputType.POWER, unit="kW", values=(0.0,), direction=None),
+                BATTERY_ENERGY_STORED: OutputData(type=OutputType.ENERGY, unit="kWh", values=(1.5, 1.5)),
+                BATTERY_STATE_OF_CHARGE: OutputData(type=OutputType.STATE_OF_CHARGE, unit="%", values=(0.15, 0.15)),
+                BATTERY_POWER_BALANCE: OutputData(type=OutputType.SHADOW_PRICE, unit="$/kWh", values=(0.0,)),
+                BATTERY_ENERGY_IN_FLOW: OutputData(
+                    type=OutputType.SHADOW_PRICE, unit="$/kWh", values=(0.0,), advanced=True
+                ),
+                BATTERY_ENERGY_OUT_FLOW: OutputData(
+                    type=OutputType.SHADOW_PRICE, unit="$/kWh", values=(0.0,), advanced=True
+                ),
+                BATTERY_SOC_MAX: OutputData(type=OutputType.SHADOW_PRICE, unit="$/kWh", values=(0.0,), advanced=True),
+                BATTERY_SOC_MIN: OutputData(type=OutputType.SHADOW_PRICE, unit="$/kWh", values=(0.0,), advanced=True),
+            },
+        },
+    },
+    {
         "description": "Battery normal range outputs",
         "name": "battery_no_balance",
         "data": BatteryConfigData(
@@ -433,3 +586,45 @@ def test_outputs_mapping(case: OutputsCase) -> None:
     entry = ELEMENT_TYPES[ElementType.BATTERY]
     result = entry.outputs(case["name"], case["model_outputs"], config=case["data"])
     assert result == case["outputs"]
+
+
+@pytest.mark.xfail(
+    reason=(
+        "The battery model's initial constraints require energy_in[0] >= 0, which prevents the "
+        "adapter from passing a negative initial_charge when the actual SOC falls below the "
+        "undercharge hard floor (undercharge_pct < min_pct configuration).  The battery model's "
+        "initial constraints need to be updated to distribute a negative initial_charge into "
+        "energy_out[0] rather than energy_in[0] to support this case."
+    ),
+    strict=True,
+)
+def test_initial_charge_preserved_when_soc_below_hard_floor() -> None:
+    """Adapter preserves actual SOC as a negative initial_charge when below the undercharge floor."""
+    data = BatteryConfigData(
+        element_type=ElementType.BATTERY,
+        name="battery_soc_below_hard_floor",
+        connection=as_connection_target("network"),
+        storage={
+            "capacity": np.array([10.0, 10.0]),
+            "initial_charge_percentage": 0.03,  # 3% — below the 5% undercharge hard floor
+        },
+        limits={
+            "min_charge_percentage": np.array([0.1, 0.1]),
+            "max_charge_percentage": np.array([0.9, 0.9]),
+        },
+        power_limits={
+            "max_power_source_target": np.array([5.0]),
+            "max_power_target_source": np.array([5.0]),
+        },
+        pricing={"salvage_value": 0.0},
+        efficiency={
+            "efficiency_source_target": np.array([0.95]),
+            "efficiency_target_source": np.array([0.95]),
+        },
+        partitioning={},
+        undercharge={"percentage": np.array([0.05, 0.05]), "cost": np.array([0.03])},
+        overcharge={"percentage": np.array([0.95, 0.95]), "cost": np.array([0.04])},
+    )
+    entry = ELEMENT_TYPES[ElementType.BATTERY]
+    result = normalize_for_compare(entry.model_elements(data))
+    assert result[0]["initial_charge"] == pytest.approx(-0.2)


### PR DESCRIPTION
## Summary

When `undercharge_percentage` exceeds `min_charge_percentage` (e.g. undercharge=20%, min=0%), the adapter anchored the LP coordinate origin at the undercharge boundary rather than the hardware minimum. This caused two related failures:

- **SOC pinned at partition level**: initial SOC values below the undercharge boundary were mapped to a negative `initial_charge`, clamped to zero by the LP model, and all forecasts showed SOC pinned at the partition level rather than the actual battery state.
- **Partition cost never fires**: `discharge_energy_threshold` was computed as `(min - undercharge) * capacity`, which is always ≤ 0 in this configuration. The soc_pricing slack variable was perpetually zero, so the undercharge penalty had no effect — the boundary acted as a hard floor regardless of the configured cost.

Both issues share the same root cause: the LP origin was in the wrong place.

## Changes

- **`battery.py` (adapter)**: anchor `lower_ratio` at `min(undercharge_percentage, min_charge_percentage)` so the LP origin always sits at the true hardware minimum. Compute `discharge_energy_threshold` as the distance from that origin to `max(undercharge, min_charge_percentage)`, which is always positive and activates the penalty at the correct SOC level. Apply the same minimum in `_calculate_total_energy` so displayed SOC is consistent with the model.
- **`test_battery_model.py`**: add parametrized cases covering the corrected `initial_charge` and SOC reconstruction when initial SOC falls inside the undercharge penalty zone. An `xfail` test documents the remaining edge case where initial SOC falls below the undercharge floor in an inverted configuration (`undercharge < min`), which requires model-layer changes to accept a negative `initial_charge`.

Configurations where `undercharge_percentage < min_charge_percentage` are unaffected: `min()` and `max()` return the same values as before, so all existing tests pass unchanged.