### PR TITLE
Disambiguate undercharge/overcharge partition entity names

### DIFF
--- a/custom_components/haeo/elements/field_hints.py
+++ b/custom_components/haeo/elements/field_hints.py
@@ -89,7 +89,7 @@ def build_input_fields(
     for section_name, fields in field_hints.items():
         result[section_name] = {}
         for field_name, hint in fields.items():
-            translation_key = f"{element_type}_{field_name}"
+            translation_key = _build_translation_key(element_type, field_name, hint.device_type)
             result[section_name][field_name] = _build_field_info(field_name, hint, translation_key)
 
     return result
@@ -125,7 +125,7 @@ def build_list_input_fields(
             continue
         section: dict[str, InputFieldInfo[Any]] = {}
         for field_name, hint in list_hints.fields.items():
-            translation_key = f"{element_type}_{field_name}"
+            translation_key = _build_translation_key(element_type, field_name, hint.device_type)
             section[field_name] = _build_field_info(field_name, hint, translation_key)
 
         if section:
@@ -133,6 +133,22 @@ def build_list_input_fields(
             result[section_key] = section
 
     return result
+
+
+def _build_translation_key(element_type: str, field_name: str, device_type: str | None) -> str:
+    """Build a translation key, including ``device_type`` when present.
+
+    Fields that appear in multiple sections of the same element (for example,
+    ``cost`` and ``percentage`` under both the ``undercharge`` and ``overcharge``
+    partitions of a battery) would otherwise collide on a single translation key
+    such as ``battery_cost``. Including the schema-declared ``device_type`` keeps
+    each partition's translation key distinct, so users see unambiguous names
+    like "Undercharge Cost" and "Overcharge Cost" instead of two identical
+    "Cost" entries on the device card.
+    """
+    if device_type:
+        return f"{element_type}_{device_type}_{field_name}"
+    return f"{element_type}_{field_name}"
 
 
 def _build_field_info(

--- a/custom_components/haeo/elements/tests/test_field_hints.py
+++ b/custom_components/haeo/elements/tests/test_field_hints.py
@@ -12,6 +12,7 @@ from custom_components.haeo.elements.field_hints import (
     OUTPUT_TYPE_DEFAULTS,
     PRICE_NATIVE_MAX_VALUE,
     PRICE_NATIVE_MIN_VALUE,
+    _build_translation_key,
     build_input_fields,
     build_list_input_fields,
 )
@@ -119,3 +120,35 @@ def test_grid_pricing_fields_use_explicit_price_bounds() -> None:
     desc = fields[SECTION_PRICING][CONF_PRICE_SOURCE_TARGET].entity_description
     assert desc.native_min_value == PRICE_NATIVE_MIN_VALUE
     assert desc.native_max_value == PRICE_NATIVE_MAX_VALUE
+
+
+def test_build_translation_key_without_device_type() -> None:
+    """Fields without a device_type produce the simple element_field translation key."""
+    assert _build_translation_key("battery", "capacity", None) == "battery_capacity"
+    assert _build_translation_key("grid", "price_source_target", None) == "grid_price_source_target"
+
+
+def test_build_translation_key_with_device_type_disambiguates_partitions() -> None:
+    """Battery undercharge/overcharge partition fields produce distinct translation keys.
+
+    Without device_type qualification, both partitions of ``cost`` and ``percentage``
+    collapse onto identical ``battery_cost`` / ``battery_percentage`` keys, which
+    renders as duplicate "Cost" and "Percentage" entries on the battery device card
+    in Home Assistant. See issue #427.
+    """
+    under_cost = _build_translation_key("battery", "cost", "undercharge_partition")
+    over_cost = _build_translation_key("battery", "cost", "overcharge_partition")
+    under_pct = _build_translation_key("battery", "percentage", "undercharge_partition")
+    over_pct = _build_translation_key("battery", "percentage", "overcharge_partition")
+
+    assert under_cost == "battery_undercharge_partition_cost"
+    assert over_cost == "battery_overcharge_partition_cost"
+    assert under_pct == "battery_undercharge_partition_percentage"
+    assert over_pct == "battery_overcharge_partition_percentage"
+    # All four keys must be distinct so HA renders them as separate entity names.
+    assert len({under_cost, over_cost, under_pct, over_pct}) == 4
+
+
+def test_build_translation_key_empty_string_device_type_treated_as_absent() -> None:
+    """An empty ``device_type`` is falsy and produces the unqualified key."""
+    assert _build_translation_key("battery", "capacity", "") == "battery_capacity"

--- a/custom_components/haeo/translations/en.json
+++ b/custom_components/haeo/translations/en.json
@@ -465,7 +465,6 @@
   "entity": {
     "number": {
       "battery_capacity": { "name": "Capacity" },
-      "battery_cost": { "name": "Cost" },
       "battery_efficiency_source_target": { "name": "Discharge efficiency" },
       "battery_efficiency_target_source": { "name": "Charge efficiency" },
       "battery_initial_charge_percentage": { "name": "Initial charge" },
@@ -473,10 +472,13 @@
       "battery_max_power_source_target": { "name": "Max discharge power" },
       "battery_max_power_target_source": { "name": "Max charge power" },
       "battery_min_charge_percentage": { "name": "Min charge" },
-      "battery_percentage": { "name": "Percentage" },
+      "battery_overcharge_partition_cost": { "name": "Overcharge cost" },
+      "battery_overcharge_partition_percentage": { "name": "Overcharge percentage" },
       "battery_price_source_target": { "name": "Discharge price" },
       "battery_price_target_source": { "name": "Charge price" },
       "battery_salvage_value": { "name": "Salvage value" },
+      "battery_undercharge_partition_cost": { "name": "Undercharge cost" },
+      "battery_undercharge_partition_percentage": { "name": "Undercharge percentage" },
       "connection_efficiency_source_target": { "name": "Source to target efficiency" },
       "connection_efficiency_target_source": { "name": "Target to source efficiency" },
       "connection_max_power_source_target": { "name": "Max source to target power" },


### PR DESCRIPTION
The four battery partition input numbers (undercharge cost, undercharge percentage, overcharge cost, overcharge percentage) collide on two shared translation keys (`battery_cost`, `battery_percentage`) because `build_input_fields` and `build_list_input_fields` derive the key from
`f"{element_type}_{field_name}"` only, ignoring the schema-declared `device_type` already present on those `FieldHint`s. The result is two indistinguishable "Cost" and "Percentage" entries on the battery device card.

Thread `hint.device_type` into a new `_build_translation_key` helper so each partition gets a unique key (`battery_undercharge_partition_cost`, etc.), and update `translations/en.json` to expose user-facing names "Undercharge cost", "Undercharge percentage", "Overcharge cost", "Overcharge percentage". Add unit tests for the helper covering the absent-device_type, partition-disambiguation, and empty-string cases.

Entity unique_ids already include `device_type`, so existing installs keep their entity_id slugs; only the friendly names change.

Fixes #427