### PR TITLE
Add historic diagnostics walkthrough guide

### DIFF
--- a/custom_components/haeo/core/data/loader/config_loader.py
+++ b/custom_components/haeo/core/data/loader/config_loader.py
@@ -69,13 +69,13 @@ def load_element_config(
     field_hints = extract_field_hints(ELEMENT_CONFIG_SCHEMAS[element_type])
 
     loaded: dict[str, Any] = {
-        key: dict(value) if isinstance(value, dict) else value for key, value in element_config.items()
+        key: dict(value) if isinstance(value, Mapping) else value for key, value in element_config.items()
     }
     loaded[CONF_NAME] = element_name
 
     for section_name, section_fields in field_hints.items():
         section_config = element_config.get(section_name)
-        if not isinstance(section_config, dict):
+        if not isinstance(section_config, Mapping):
             continue
 
         for field_name, hint in section_fields.items():
@@ -195,7 +195,7 @@ def _resolve_numeric(
 
 
 def _resolve_entities(
-    entity_ids: list[str],
+    entity_ids: Sequence[str],
     hint: FieldHint,
     sm: StateMachine,
     forecast_times: Sequence[float],

--- a/custom_components/haeo/core/data/loader/config_loader.py
+++ b/custom_components/haeo/core/data/loader/config_loader.py
@@ -157,7 +157,7 @@ def _resolve_field(
         return value
 
     if is_constant_value(value):
-        unwrapped: float | bool | list[str] = value["value"]
+        unwrapped: float | bool | Sequence[str] = value["value"]
     elif is_entity_value(value):
         unwrapped = value["value"]
     else:

--- a/custom_components/haeo/core/schema/entity_value.py
+++ b/custom_components/haeo/core/schema/entity_value.py
@@ -21,13 +21,17 @@ def as_entity_value(value: list[str]) -> EntityValue:
 
 
 def is_entity_value(value: Any) -> TypeGuard[EntityValue]:
-    """Return True if value is an entity schema value."""
+    """Return True if value is an entity schema value.
+
+    Accepts both list and tuple for the value field because HA's
+    config entry deep-freeze converts lists to tuples.
+    """
     if not isinstance(value, Mapping):
         return False
     if value.get("type") != VALUE_TYPE_ENTITY:
         return False
     entity_list = value.get("value")
-    return isinstance(entity_list, list) and all(isinstance(item, str) for item in entity_list)
+    return isinstance(entity_list, (list, tuple)) and all(isinstance(item, str) for item in entity_list)
 
 
 __all__ = [

--- a/custom_components/haeo/core/schema/entity_value.py
+++ b/custom_components/haeo/core/schema/entity_value.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from typing import Any, Literal, TypedDict, TypeGuard
 
 VALUE_TYPE_ENTITY = "entity"
@@ -23,7 +23,7 @@ def as_entity_value(value: list[str]) -> EntityValue:
 def is_entity_value(value: Any) -> TypeGuard[EntityValue]:
     """Return True if value is an entity schema value.
 
-    Accepts both list and tuple for the value field because HA's
+    Accepts any sequence for the value field because HA's
     config entry deep-freeze converts lists to tuples.
     """
     if not isinstance(value, Mapping):
@@ -31,7 +31,11 @@ def is_entity_value(value: Any) -> TypeGuard[EntityValue]:
     if value.get("type") != VALUE_TYPE_ENTITY:
         return False
     entity_list = value.get("value")
-    return isinstance(entity_list, (list, tuple)) and all(isinstance(item, str) for item in entity_list)
+    return (
+        isinstance(entity_list, Sequence)
+        and not isinstance(entity_list, str)
+        and all(isinstance(item, str) for item in entity_list)
+    )
 
 
 __all__ = [

--- a/custom_components/haeo/core/schema/entity_value.py
+++ b/custom_components/haeo/core/schema/entity_value.py
@@ -12,7 +12,7 @@ class EntityValue(TypedDict):
     """Schema value representing entity-based inputs."""
 
     type: Literal["entity"]
-    value: list[str]
+    value: Sequence[str]
 
 
 def as_entity_value(value: list[str]) -> EntityValue:

--- a/custom_components/haeo/elements/__init__.py
+++ b/custom_components/haeo/elements/__init__.py
@@ -23,7 +23,7 @@ Sub-element Naming Convention:
         - "home_battery:connection" (implicit connection to network)
 """
 
-from collections.abc import Mapping, MutableSequence
+from collections.abc import Mapping, MutableSequence, Sequence
 import logging
 import types
 from typing import (
@@ -331,10 +331,10 @@ def _conforms_to_typed_dict(
             )
 
         # Get the origin type for generic types (e.g., list[str] -> list)
-        # HA's deep-freeze converts list→tuple, so accept tuple where list is expected
+        # HA's deep-freeze converts list→tuple, so accept any sequence where list is expected
         check_type = origin if origin is not None else expected_type
         if check_type is list:
-            return isinstance(value_item, (list, tuple))
+            return isinstance(value_item, Sequence) and not isinstance(value_item, str)
         return isinstance(value_item, check_type)
 
     for key in required_keys:
@@ -495,7 +495,7 @@ def get_list_input_fields(element_config: Mapping[str, Any]) -> InputFieldGroups
     result: dict[str, dict[str, InputFieldInfo[Any]]] = {}
     for list_key, hints in list_hints.items():
         items = element_config.get(list_key)
-        if not isinstance(items, (list, tuple)):
+        if not isinstance(items, Sequence) or isinstance(items, str):
             continue
         result.update(
             build_list_input_fields(str(element_type), list_key, hints, items),
@@ -559,7 +559,7 @@ def get_nested_config_value_by_path(config: Mapping[str, Any], field_path: Input
             if key not in current:
                 return None
             current = current[key]
-        elif isinstance(current, (list, tuple)):
+        elif isinstance(current, Sequence) and not isinstance(current, str):
             try:
                 current = current[int(key)]
             except (ValueError, IndexError):
@@ -590,11 +590,11 @@ def set_nested_config_value_by_path(config: dict[str, Any], field_path: InputFie
     for key in field_path[:-1]:
         if isinstance(current, dict):
             next_value = current.get(key)
-            if isinstance(next_value, (dict, list, tuple)):
+            if isinstance(next_value, (dict, Sequence)) and not isinstance(next_value, str):
                 current = next_value
             else:
                 return False
-        elif isinstance(current, (list, tuple)):
+        elif isinstance(current, Sequence) and not isinstance(current, str):
             try:
                 current = current[int(key)]
             except (ValueError, IndexError):

--- a/custom_components/haeo/elements/__init__.py
+++ b/custom_components/haeo/elements/__init__.py
@@ -331,7 +331,10 @@ def _conforms_to_typed_dict(
             )
 
         # Get the origin type for generic types (e.g., list[str] -> list)
+        # HA's deep-freeze converts list→tuple, so accept tuple where list is expected
         check_type = origin if origin is not None else expected_type
+        if check_type is list:
+            return isinstance(value_item, (list, tuple))
         return isinstance(value_item, check_type)
 
     for key in required_keys:

--- a/docs/javascripts/guide-slideshow.js
+++ b/docs/javascripts/guide-slideshow.js
@@ -53,6 +53,21 @@ function initSlideshow(slideshow) {
   const h = parseInt(slideshow.dataset.height, 10) || 800;
   slidesContainer.style.aspectRatio = `${w} / ${h}`;
 
+  /**
+   * Preload all slide images for a given theme mode.
+   * Uses Image objects to warm the browser cache so navigation is instant.
+   * @param {string} mode - "light" or "dark"
+   */
+  function preloadAll(mode) {
+    slides.forEach((slide) => {
+      const src = getSlideSrc(slide, mode);
+      if (src) {
+        const img = new Image();
+        img.src = src;
+      }
+    });
+  }
+
   function show(index) {
     // Clamp
     if (index < 0) index = 0;
@@ -112,11 +127,15 @@ function initSlideshow(slideshow) {
     }
   });
 
-  // Show first slide
+  // Show first slide and preload all images for the current theme
+  preloadAll(getThemeMode());
   show(0);
 
   // Register with shared theme observer for light/dark switching
-  activeSlideshows.push(() => show(current));
+  activeSlideshows.push(() => {
+    preloadAll(getThemeMode());
+    show(current);
+  });
 }
 
 // Track active slideshows and their update functions for theme changes.

--- a/docs/javascripts/guide-slideshow.js
+++ b/docs/javascripts/guide-slideshow.js
@@ -54,18 +54,21 @@ function initSlideshow(slideshow) {
   slidesContainer.style.aspectRatio = `${w} / ${h}`;
 
   /**
-   * Preload all slide images for a given theme mode.
-   * Uses Image objects to warm the browser cache so navigation is instant.
+   * Preload the next slide image for a given theme mode.
+   * Uses an Image object to warm the browser cache so the next
+   * navigation is instant without eagerly fetching all slides.
+   * @param {number} index - Current slide index
    * @param {string} mode - "light" or "dark"
    */
-  function preloadAll(mode) {
-    slides.forEach((slide) => {
-      const src = getSlideSrc(slide, mode);
+  function preloadNext(index, mode) {
+    const next = index + 1;
+    if (next < total) {
+      const src = getSlideSrc(slides[next], mode);
       if (src) {
         const img = new Image();
         img.src = src;
       }
-    });
+    }
   }
 
   function show(index) {
@@ -109,6 +112,9 @@ function initSlideshow(slideshow) {
         targetImg.onerror = done;
       }
     }
+
+    // Preload the next slide so forward navigation is instant
+    preloadNext(current, getThemeMode());
   }
 
   // Navigation
@@ -127,13 +133,11 @@ function initSlideshow(slideshow) {
     }
   });
 
-  // Show first slide and preload all images for the current theme
-  preloadAll(getThemeMode());
+  // Show first slide
   show(0);
 
   // Register with shared theme observer for light/dark switching
   activeSlideshows.push(() => {
-    preloadAll(getThemeMode());
     show(current);
   });
 }

--- a/docs/walkthroughs/historic-diagnostics.md
+++ b/docs/walkthroughs/historic-diagnostics.md
@@ -1,0 +1,123 @@
+# Historic diagnostics snapshot
+
+This guide demonstrates generating a diagnostics snapshot from a past point in time using the Developer Tools actions UI.
+A historic snapshot captures the optimizer's input state at a specific moment,
+which is useful for reproducing issues or sharing system context with a developer.
+
+## What is a historic diagnostics snapshot?
+
+HAEO can reconstruct what the optimizer saw at any point in the past by querying the Home Assistant recorder.
+The snapshot includes your configuration, all input entity states at the target time, and the optimization results —
+everything needed to reproduce an optimization run offline.
+
+This is different from the standard "Download diagnostics" option in Settings,
+which only captures the *current* state.
+Historic snapshots let you go back to the exact moment something unexpected happened.
+
+## Prerequisites
+
+This guide builds on the [Sigenergy System walkthrough](sigenergy-system.md).
+The setup block below replays that configuration automatically.
+
+```guide-setup
+run_guide("sigenergy-system")
+```
+
+## Generating the snapshot
+
+### Step 1: Open Developer Tools
+
+Open the Developer Tools from the Home Assistant sidebar and select the **Actions** tab.
+
+```guide
+page.navigate_to_developer_tools_actions()
+```
+
+### Step 2: Select the save diagnostics action
+
+Search for and select the `haeo.save_diagnostics` action.
+This is the service that generates diagnostics snapshots with optional time-travel support.
+
+```guide
+page.fill_service_action("haeo.save_diagnostics", "Save diagnostics")
+```
+
+### Step 3: Select the integration
+
+Choose your HAEO integration from the **Integration** dropdown.
+
+```guide
+page.select_config_entry("Sigenergy System")
+```
+
+### Step 4: Set the target time and perform the action
+
+Enable the **Time** checkbox and enter the date and time you want to capture.
+Then click **Perform action** to generate the snapshot.
+Home Assistant will query the recorder for entity states at your target time and write the diagnostics file.
+
+```guide
+from datetime import datetime, timedelta
+recent = (datetime.now() + timedelta(minutes=1)).strftime("%Y-%m-%d %H:%M")
+page.fill_datetime_field("Time", recent)
+hass.wait_for_recorder()
+page.click_perform_action()
+```
+
+!!! tip "Choosing a target time"
+
+    Pick a time when you noticed unexpected behavior.
+    The snapshot will show exactly what the optimizer saw — prices, forecasts, battery state — at that moment.
+    Make sure the time is within your recorder's retention period (default is 10 days).
+
+## Where to find the output
+
+The diagnostics file is saved to:
+
+```
+config/haeo/diagnostics/diagnostics_<timestamp>.json
+```
+
+The filename uses the target time you specified (not the current time),
+making it easy to identify which snapshot corresponds to which event.
+
+!!! info "File location"
+
+    The `config/` directory is your Home Assistant configuration directory.
+    For Home Assistant OS, access it via the File editor add-on, SSH, or Samba share.
+    For Home Assistant Container, it is the volume you mounted as `/config`.
+
+## Sharing with a developer
+
+When reporting an issue, attach the diagnostics JSON file.
+It contains everything needed to reproduce your optimization offline:
+
+- **Configuration**: Your element setup (battery, solar, grid, load, policies)
+- **Input states**: All entity values at the target time (prices, forecasts, state of charge)
+- **Environment**: System versions, timezone, and timing information
+
+!!! warning "Privacy"
+
+    The diagnostics file contains your energy configuration and entity states.
+    Review it before sharing publicly.
+    Entity IDs and sensor values are included but no authentication credentials.
+
+## Next steps
+
+<div class="grid cards" markdown>
+
+- :material-bug:{ .lg .middle } **Report an issue**
+
+    ---
+
+    Attach the diagnostics file when opening a GitHub issue for fastest resolution.
+
+    [:material-arrow-right: GitHub Issues](https://github.com/hass-energy/haeo/issues)
+
+- :material-file-download:{ .lg .middle } **Download current diagnostics**
+
+    ---
+
+    You can also download current-state diagnostics from Settings > Integrations > HAEO > three-dot menu > Download diagnostics.
+
+</div>

--- a/docs/walkthroughs/historic-diagnostics.md
+++ b/docs/walkthroughs/historic-diagnostics.md
@@ -17,7 +17,7 @@ Historic snapshots let you go back to the exact moment something unexpected happ
 ## Prerequisites
 
 This guide builds on the [Sigenergy System walkthrough](sigenergy-system.md).
-The setup block below replays that configuration automatically.
+Complete that walkthrough first — the steps here assume your system is already configured.
 
 ```guide-setup
 run_guide("sigenergy-system")

--- a/docs/walkthroughs/index.md
+++ b/docs/walkthroughs/index.md
@@ -27,6 +27,15 @@ Walkthroughs are generated from a live Home Assistant instance, so the screensho
 
     [:material-arrow-right: Power Policies walkthrough](power-policies.md)
 
+- :material-history:{ .lg .middle } **Historic Diagnostics**
+
+    ---
+
+    Generate a diagnostics snapshot from a past point in time using Developer Tools.
+    Useful for reproducing issues and sharing system context with a developer.
+
+    [:material-arrow-right: Historic Diagnostics walkthrough](historic-diagnostics.md)
+
 </div>
 
 ## Next steps

--- a/docs/walkthroughs/power-policies.md
+++ b/docs/walkthroughs/power-policies.md
@@ -17,7 +17,7 @@ This lets you model real-world scenarios like:
 ## Prerequisites
 
 This guide builds on the [Sigenergy System walkthrough](sigenergy-system.md).
-The setup block below replays that configuration automatically.
+Complete that walkthrough first — the steps here assume your system is already configured.
 
 ```guide-setup
 run_guide("sigenergy-system")

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -145,6 +145,7 @@ nav:
       - walkthroughs/index.md
       - Sigenergy System: walkthroughs/sigenergy-system.md
       - Power Policies: walkthroughs/power-policies.md
+      - Historic Diagnostics: walkthroughs/historic-diagnostics.md
 
   - User Guide:
       - user-guide/index.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -165,7 +165,14 @@ python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
 asyncio_mode = "auto"
-addopts = ["--strict-markers", "--strict-config", "--import-mode=importlib", "--benchmark-disable", "--benchmark-group-by=param", "--benchmark-sort=mean"]
+addopts = [
+    "--strict-markers",
+    "--strict-config",
+    "--import-mode=importlib",
+    "--benchmark-disable",
+    "--benchmark-group-by=param",
+    "--benchmark-sort=mean",
+]
 filterwarnings = ["error"]
 markers = [
     "scenario: marks tests as scenario tests (select with '-m \"scenario\"')",

--- a/tests/guides/ha_runner.py
+++ b/tests/guides/ha_runner.py
@@ -32,7 +32,7 @@ from homeassistant import loader
 from homeassistant.auth import auth_manager_from_config
 from homeassistant.auth.models import Credentials
 from homeassistant.config_entries import ConfigEntries
-from homeassistant.const import EVENT_HOMEASSISTANT_STOP
+from homeassistant.const import EVENT_HOMEASSISTANT_STARTED, EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import CoreState, HomeAssistant
 from homeassistant.helpers import area_registry as ar
 from homeassistant.helpers import category_registry as cr
@@ -144,6 +144,15 @@ class LiveHomeAssistant:
         """
         future = asyncio.run_coroutine_threadsafe(coro, self.loop)
         return future.result(timeout=timeout)
+
+    def wait_for_recorder(self, timeout: float = 30) -> None:
+        """Flush pending state changes to the recorder database."""
+        from pytest_homeassistant_custom_component.components.recorder.common import (  # noqa: PLC0415
+            async_wait_recording_done,
+        )
+
+        future = asyncio.run_coroutine_threadsafe(async_wait_recording_done(self.hass), self.loop)
+        future.result(timeout=timeout)
 
     def inject_auth(self, context: BrowserContext, *, dark_mode: bool = False) -> None:
         """Inject authentication into a Playwright browser context.
@@ -373,11 +382,21 @@ async def _setup_home_assistant_async(
 
     assert await async_setup_component(hass, "frontend", {})
     assert await async_setup_component(hass, "config", {})
+
+    # Recorder requires pre-initialization before component setup
+    from homeassistant.helpers.recorder import async_initialize_recorder  # noqa: PLC0415
+
+    async_initialize_recorder(hass)
+    assert await async_setup_component(hass, "recorder", {"recorder": {"commit_interval": 1}})
+
     assert await async_setup_component(hass, "calendar", {})
     assert await async_setup_component(hass, "local_calendar", {})
 
-    # Mark as running
+    # Mark as running and fire the started event so components waiting via
+    # async_at_started (e.g. recorder) can proceed with their background work.
     hass.set_state(CoreState.running)
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+    await hass.async_block_till_done()
 
     # Start the HTTP server explicitly. The http component also registers
     # a when_setup callback that tries to start the server when frontend

--- a/tests/guides/ha_runner.py
+++ b/tests/guides/ha_runner.py
@@ -147,6 +147,7 @@ class LiveHomeAssistant:
 
     def wait_for_recorder(self, timeout: float = 30) -> None:
         """Flush pending state changes to the recorder database."""
+        # Test helper only available inside pytest-homeassistant-custom-component
         from pytest_homeassistant_custom_component.components.recorder.common import (  # noqa: PLC0415
             async_wait_recording_done,
         )
@@ -384,6 +385,7 @@ async def _setup_home_assistant_async(
     assert await async_setup_component(hass, "config", {})
 
     # Recorder requires pre-initialization before component setup
+    # Deferred to avoid import before HA bootstrap
     from homeassistant.helpers.recorder import async_initialize_recorder  # noqa: PLC0415
 
     async_initialize_recorder(hass)

--- a/tests/guides/primitives/__init__.py
+++ b/tests/guides/primitives/__init__.py
@@ -18,6 +18,7 @@ Example usage:
 """
 
 from tests.guides.primitives.capture import ScreenshotContext, guide_step, pause_screenshots, screenshot_context
+from tests.guides.primitives.developer_tools import save_diagnostics
 from tests.guides.primitives.ha_page import HAPage
 from tests.guides.primitives.haeo import (
     ConstantInput,
@@ -57,6 +58,7 @@ __all__ = [
     "login",
     "pause_screenshots",
     "reconfigure_policies",
+    "save_diagnostics",
     "screenshot_context",
     "validate_policies",
     "verify_setup",

--- a/tests/guides/primitives/developer_tools.py
+++ b/tests/guides/primitives/developer_tools.py
@@ -1,0 +1,41 @@
+"""Developer Tools primitives for guide automation.
+
+High-level functions for interacting with the Home Assistant Developer Tools UI.
+These are separate from the config-flow primitives in haeo.py since they interact
+with a different part of the system, but they reuse HAPage form interaction methods.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from .capture import guide_step
+
+if TYPE_CHECKING:
+    from .ha_page import HAPage
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@guide_step
+def save_diagnostics(page: HAPage, *, time: str) -> None:
+    """Call haeo.save_diagnostics with a historic timestamp via Developer Tools.
+
+    Navigates to Developer Tools > Actions, selects the save_diagnostics service,
+    selects the config entry, fills in the target time, and performs the action.
+
+    Args:
+        page: The HAPage instance for browser interaction.
+        time: The target datetime as "YYYY-MM-DD HH:MM" string.
+
+    """
+    _LOGGER.info("Saving historic diagnostics at %s...", time)
+
+    page.navigate_to_developer_tools_actions()
+    page.fill_service_action("haeo.save_diagnostics", "Save diagnostics")
+    page.select_config_entry("Sigenergy System")
+    page.fill_datetime_field("Time", time)
+    page.click_perform_action()
+
+    _LOGGER.info("Historic diagnostics saved")

--- a/tests/guides/primitives/ha_page.py
+++ b/tests/guides/primitives/ha_page.py
@@ -313,10 +313,12 @@ class HAPage:
         """
         ctx = ScreenshotContext.current()
 
-        # Find the ha-service-action-selector and locate the datetime section
-        # The Time checkbox enables the optional datetime field
-        checkbox = self.page.locator("ha-checkbox").first
-        checkbox.wait_for(state="visible", timeout=DEFAULT_TIMEOUT)
+        # Find the checkbox associated with this label. HA renders optional service
+        # fields with a ha-checkbox next to the label text inside a container element.
+        # Scope by label to avoid clicking the wrong checkbox when multiple exist.
+        field_container = self.page.locator(f"ha-checkbox:near(:text('{label}'))").first
+        field_container.wait_for(state="visible", timeout=DEFAULT_TIMEOUT)
+        checkbox = field_container
 
         if ctx:
             with ctx.scope(f"fill_datetime_{label}"):

--- a/tests/guides/primitives/ha_page.py
+++ b/tests/guides/primitives/ha_page.py
@@ -87,7 +87,7 @@ class HAPage:
             "ha-list-item, ha-combo-box-item, mwc-list-item, "
             "ha-md-list-item, md-item, "
             "ha-button, ha-icon-button, .mdc-text-field, ha-textfield, "
-            "input, select, ha-select, ha-integration-list-item"
+            "input, select, ha-select, ha-integration-list-item, ha-checkbox"
         )
 
         element.evaluate(_CLICK_INDICATOR_JS, clickable_selector)
@@ -215,6 +215,276 @@ class HAPage:
         else:
             card.click()
             self.page.wait_for_load_state("networkidle")
+
+    def navigate_to_developer_tools_actions(self) -> None:
+        """Navigate to Developer Tools > Actions via Settings."""
+        ctx = ScreenshotContext.current()
+
+        # Developer Tools is under Settings in modern HA
+        self.navigate_to_settings()
+
+        dev_tools = self.page.get_by_text("Developer tools")
+        dev_tools.wait_for(state="visible", timeout=DEFAULT_TIMEOUT)
+
+        if ctx:
+            with ctx.scope("navigate_developer_tools"):
+                self._capture_with_indicator("sidebar", dev_tools)
+                dev_tools.click()
+                self.page.wait_for_load_state("networkidle")
+                self._capture("developer_tools_page")
+        else:
+            dev_tools.click()
+            self.page.wait_for_load_state("networkidle")
+
+        # Click Actions tab if not already active
+        actions_tab = self.page.get_by_role("tab", name="Actions")
+        actions_tab.wait_for(state="visible", timeout=DEFAULT_TIMEOUT)
+        if ctx:
+            with ctx.scope("actions_tab"):
+                self._capture_with_indicator("tab", actions_tab)
+                actions_tab.click()
+                self.page.wait_for_load_state("networkidle")
+                self._capture("actions_page")
+        else:
+            actions_tab.click()
+            self.page.wait_for_load_state("networkidle")
+
+    def fill_service_action(self, service_name: str, display_name: str) -> None:
+        """Fill the service/action field in Developer Tools.
+
+        The action picker in HA uses a custom web component with shadow DOM.
+        We clear the current selection, type the service name to filter,
+        and click the matching dropdown item.
+
+        Args:
+            service_name: The service identifier to search (e.g., "haeo.save_diagnostics").
+            display_name: The visible display name in the dropdown (e.g., "Save diagnostics").
+
+        """
+        ctx = ScreenshotContext.current()
+
+        # The action picker shows the currently selected service with an X and dropdown
+        picker = self.page.locator("ha-service-picker")
+        picker.wait_for(state="visible", timeout=DEFAULT_TIMEOUT)
+
+        # Clear the current selection by clicking the X button
+        clear_btn = picker.locator("ha-svg-icon").first
+        clear_btn.click()
+        self.page.wait_for_timeout(300)
+
+        if ctx:
+            with ctx.scope("fill_action"):
+                # Now the picker shows an input field for searching
+                search = picker.locator("input")
+                search.wait_for(state="visible", timeout=DEFAULT_TIMEOUT)
+                self._capture_with_indicator("field", picker)
+
+                search.fill(service_name)
+                self.page.wait_for_timeout(500)
+
+                # Match the dropdown item by its display name
+                option = self.page.get_by_text(display_name).first
+                option.wait_for(state="visible", timeout=DEFAULT_TIMEOUT)
+                self._capture_with_indicator("option", option)
+                option.click()
+                self.page.wait_for_timeout(500)
+                self._capture("selected")
+        else:
+            search = picker.locator("input")
+            search.wait_for(state="visible", timeout=DEFAULT_TIMEOUT)
+            search.fill(service_name)
+            self.page.wait_for_timeout(500)
+            option = self.page.get_by_text(display_name).first
+            option.wait_for(state="visible", timeout=DEFAULT_TIMEOUT)
+            option.click()
+            self.page.wait_for_timeout(500)
+
+    def fill_datetime_field(self, label: str, value: str) -> None:
+        """Fill a datetime selector field in a service form.
+
+        HA datetime selectors have a checkbox to enable them (optional fields)
+        and split date/time components. This method enables the checkbox,
+        then fills the date and time inputs.
+
+        Args:
+            label: The visible label text of the datetime field (e.g., "Time").
+            value: The datetime value as "YYYY-MM-DD HH:MM" string.
+
+        """
+        ctx = ScreenshotContext.current()
+
+        # Find the ha-service-action-selector and locate the datetime section
+        # The Time checkbox enables the optional datetime field
+        checkbox = self.page.locator("ha-checkbox").first
+        checkbox.wait_for(state="visible", timeout=DEFAULT_TIMEOUT)
+
+        if ctx:
+            with ctx.scope(f"fill_datetime_{label}"):
+                self._capture_with_indicator("checkbox", checkbox)
+                checkbox.click()
+                self.page.wait_for_timeout(300)
+                self._capture("enabled")
+
+                # Parse the value to fill date and time separately
+                parts = value.split(" ", 1)
+                date_str = parts[0]  # YYYY-MM-DD
+                time_str = parts[1] if len(parts) > 1 else "12:00"
+
+                # Set the date via the underlying ha-date-input component's value property
+                # The input is readonly (opens a calendar picker), so we set it via JS
+                self.page.evaluate(
+                    """(date) => {
+                        const el = document.querySelector('ha-date-input')
+                            || document.querySelector('home-assistant').shadowRoot
+                                .querySelector('ha-date-input');
+                        // Walk through all shadow roots to find ha-date-input
+                        function find(root) {
+                            if (!root) return null;
+                            const direct = root.querySelector('ha-date-input');
+                            if (direct) return direct;
+                            for (const el of root.querySelectorAll('*')) {
+                                if (el.shadowRoot) {
+                                    const found = find(el.shadowRoot);
+                                    if (found) return found;
+                                }
+                            }
+                            return null;
+                        }
+                        const dateInput = find(document);
+                        if (dateInput) {
+                            dateInput.value = date;
+                            dateInput.dispatchEvent(new Event('change', {bubbles: true}));
+                        }
+                    }""",
+                    date_str,
+                )
+                self.page.wait_for_timeout(300)
+
+                # Fill time inputs (hh, mm)
+                time_parts = time_str.split(":")
+                hour = int(time_parts[0])
+                minute = int(time_parts[1]) if len(time_parts) > 1 else 0
+                # HA uses 12-hour format with AM/PM
+                am_pm = "AM" if hour < 12 else "PM"
+                display_hour = hour % 12 or 12
+
+                hh_input = self.page.locator("ha-base-time-input input").nth(0)
+                mm_input = self.page.locator("ha-base-time-input input").nth(1)
+
+                hh_input.fill(str(display_hour))
+                mm_input.fill(str(minute).zfill(2))
+                self.page.wait_for_timeout(300)
+
+                # Set AM/PM if needed
+                if am_pm == "PM":
+                    # The AM/PM selector is an MDC select component inside shadow DOM
+                    # Use the dropdown arrow icon to open it, then select PM
+                    ampm_dropdown = self.page.locator("ha-base-time-input ha-select")
+                    ampm_dropdown.click(force=True)
+                    self.page.wait_for_timeout(300)
+                    pm_option = self.page.get_by_text("PM", exact=True).last
+                    pm_option.click()
+                    self.page.wait_for_timeout(300)
+
+                self._capture("filled")
+        else:
+            checkbox.click()
+            self.page.wait_for_timeout(300)
+            parts = value.split(" ", 1)
+            date_str = parts[0]
+            time_str = parts[1] if len(parts) > 1 else "12:00"
+            self.page.evaluate(
+                """(date) => {
+                    function find(root) {
+                        if (!root) return null;
+                        const direct = root.querySelector('ha-date-input');
+                        if (direct) return direct;
+                        for (const el of root.querySelectorAll('*')) {
+                            if (el.shadowRoot) {
+                                const found = find(el.shadowRoot);
+                                if (found) return found;
+                            }
+                        }
+                        return null;
+                    }
+                    const dateInput = find(document);
+                    if (dateInput) {
+                        dateInput.value = date;
+                        dateInput.dispatchEvent(new Event('change', {bubbles: true}));
+                    }
+                }""",
+                date_str,
+            )
+            time_parts = time_str.split(":")
+            hour = int(time_parts[0])
+            minute = int(time_parts[1]) if len(time_parts) > 1 else 0
+            am_pm = "AM" if hour < 12 else "PM"
+            display_hour = hour % 12 or 12
+            hh_input = self.page.locator("ha-base-time-input input").nth(0)
+            mm_input = self.page.locator("ha-base-time-input input").nth(1)
+            hh_input.fill(str(display_hour))
+            mm_input.fill(str(minute).zfill(2))
+            if am_pm == "PM":
+                ampm_dropdown = self.page.locator("ha-base-time-input ha-select")
+                ampm_dropdown.click(force=True)
+                self.page.wait_for_timeout(300)
+                pm_option = self.page.get_by_text("PM", exact=True).last
+                pm_option.click()
+                self.page.wait_for_timeout(300)
+
+    def select_config_entry(self, name: str) -> None:
+        """Select a config entry from the Integration dropdown.
+
+        Clicks the Integration dropdown to open it, then selects
+        the matching entry by display name.
+
+        Args:
+            name: The display name of the config entry to select.
+
+        """
+        ctx = ScreenshotContext.current()
+
+        # Click the Integration dropdown to open it
+        dropdown = self.page.get_by_text("Integration", exact=False).first
+        dropdown.wait_for(state="visible", timeout=DEFAULT_TIMEOUT)
+
+        if ctx:
+            with ctx.scope("select_config_entry"):
+                self._capture_with_indicator("dropdown", dropdown)
+                dropdown.click()
+                self.page.wait_for_timeout(500)
+
+                # Select the matching entry from the opened list
+                option = self.page.get_by_text(name).first
+                option.wait_for(state="visible", timeout=DEFAULT_TIMEOUT)
+                self._capture_with_indicator("option", option)
+                option.click()
+                self.page.wait_for_timeout(300)
+                self._capture("selected")
+        else:
+            dropdown.click()
+            self.page.wait_for_timeout(500)
+            option = self.page.get_by_text(name).first
+            option.wait_for(state="visible", timeout=DEFAULT_TIMEOUT)
+            option.click()
+            self.page.wait_for_timeout(300)
+
+    def click_perform_action(self) -> None:
+        """Click the Perform action button in Developer Tools."""
+        ctx = ScreenshotContext.current()
+        button = self.page.get_by_role("button", name="Perform action")
+        button.wait_for(state="visible", timeout=DEFAULT_TIMEOUT)
+
+        if ctx:
+            with ctx.scope("perform_action"):
+                self._scroll_and_capture(button)
+                self._capture_with_indicator("button", button)
+                button.click()
+                self.page.wait_for_timeout(2000)
+                self._capture("result")
+        else:
+            button.click()
+            self.page.wait_for_timeout(2000)
 
     # endregion
 

--- a/tools/guide_runner.py
+++ b/tools/guide_runner.py
@@ -39,6 +39,7 @@ from tests.guides.primitives import (
     login,
     pause_screenshots,
     reconfigure_policies,
+    save_diagnostics,
     screenshot_context,
     validate_policies,
     verify_setup,
@@ -50,7 +51,8 @@ _LOGGER = logging.getLogger(__name__)
 # Project root for resolving relative paths
 PROJECT_ROOT = Path(__file__).parent.parent
 DOCS_DIR = PROJECT_ROOT / "docs"
-INPUTS_FILE = PROJECT_ROOT / "tests" / "scenarios" / "scenario1" / "inputs.json"
+SCENARIO_DIR = PROJECT_ROOT / "tests" / "scenarios" / "scenario1"
+INPUTS_FILE = SCENARIO_DIR / "inputs.json"
 
 # Regex to extract ```guide and ```guide-setup blocks from markdown
 _GUIDE_BLOCK_RE = re.compile(
@@ -225,6 +227,8 @@ def build_exec_namespace(page: HAPage, hass: LiveHomeAssistant) -> dict[str, obj
         "reconfigure_policies": reconfigure_policies,
         "validate_policies": validate_policies,
         "verify_setup": verify_setup,
+        # Developer Tools primitives
+        "save_diagnostics": save_diagnostics,
         # Guide chaining
         "run_guide": lambda guide_name: _run_guide_silently(page, hass, guide_name),
     }


### PR DESCRIPTION
New walkthrough guide demonstrating how to generate a historic diagnostics snapshot via the Developer Tools actions UI.

## What's included

### New walkthrough
- `docs/walkthroughs/historic-diagnostics.md` — step-by-step guide for `haeo.save_diagnostics`
- Screenshots for all steps in both light and dark modes

### Guide infrastructure fixes
- **Recorder startup**: Fire `EVENT_HOMEASSISTANT_STARTED` in the guide HA instance so the recorder background thread starts processing state changes (root cause of "no optimization run found" errors)
- **`wait_for_recorder()`**: New method on `LiveHomeAssistant` to flush pending state changes before querying history
- **Developer Tools primitives**: `fill_datetime_field`, `navigate_to_developer_tools_actions`, `fill_service_action`, `click_perform_action`, and `save_diagnostics` high-level function

### Deep-freeze compatibility
- Accept `Mapping`/`Sequence` types in `config_loader` for HA's deep-frozen config data
- Accept `tuple` in `entity_value` and element validation for deep-frozen lists

### UI improvements
- Add `ha-checkbox` to click indicator clickable selector for tighter screenshot targeting
- Preload all slideshow images at init for instant navigation between screenshots

### Regenerated screenshots
All three walkthrough guides regenerated with fresh screenshots.