### PR TITLE
ci: accept PEP 440 .post/.dev release tags, gate fork-only deploy jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -337,6 +337,9 @@ jobs:
   hacs:
     name: HACS
     runs-on: ubuntu-latest
+    # HACS publish requirements (issues enabled, repo topics, etc.) only apply
+    # to the canonical integration repo. Skip on forks so they don't show red.
+    if: github.repository == 'hass-energy/haeo'
     steps:
       - name: Run HACS validation
         uses: hacs/action@d556e736723344f83838d08488c983a15381059a # 22.5.0
@@ -390,6 +393,7 @@ jobs:
     steps:
       - name: Check all jobs passed
         run: |
+          # 'skipped' is allowed (e.g., hacs is gated to the upstream repo).
           if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" ]]; then
             echo "::error::One or more required jobs failed"
             exit 1

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -66,6 +66,9 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
+    # Only deploy from the canonical repo. Forks still run the build job above
+    # to catch documentation breakage, but they don't have Pages enabled.
+    if: github.repository == 'hass-energy/haeo'
     steps:
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,8 +25,10 @@ jobs:
           echo "Tag: $TAG"
           echo "Version: $VERSION"
 
-          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(rc[0-9]+)?$ ]]; then
-            echo "::error::Release tag '$TAG' does not match expected format (vX.Y.Z or vX.Y.ZrcN)"
+          # PEP 440-compatible: vX.Y.Z, optional pre-release (rcN/aN/bN),
+          # optional post-release (.postN), optional dev-release (.devN).
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+((rc|a|b)[0-9]+)?(\.post[0-9]+)?(\.dev[0-9]+)?$ ]]; then
+            echo "::error::Release tag '$TAG' does not match expected format (vX.Y.Z[rcN|aN|bN][.postN][.devN])"
             exit 1
           fi
 


### PR DESCRIPTION
Three small fixes to the release-flow and fork-only deploy checks that were showing red on the purcell-lab fork without affecting any real CI signal on hass-energy/haeo.

1. **release.yml — Validate release version**

   The tag-format regex only accepted `vX.Y.Z` or `vX.Y.ZrcN`, so every `.postN` rebuild (post5, post6, post7, post8) failed with:

       Release tag 'v0.4.0rc5.post8' does not match expected format
       (vX.Y.Z or vX.Y.ZrcN)

   Broaden to a full PEP 440-compatible pattern that accepts optional pre-release (rcN/aN/bN), post-release (.postN), and dev-release (.devN) suffixes. Validated against both passing tags (v0.4.0, v0.4.0rc5, v0.4.0rc5.post8, v1.0.0a1, v1.2.3rc4.post5, v1.2.3.dev1) and rejection tags (v1.2.3-bad, v1.2, v1.2.3rcfoo).

2. **ci.yml — HACS job**

   `hacs/action` enforces publish requirements (issues enabled, valid repo topics, brand images) that only matter for the canonical integration repo. Forks don't need to be HACS-publishable and were showing 2/7 checks failed on every push. Gate the job with `if: github.repository == 'hass-energy/haeo'` so it skips on forks.

   Also note in the ci-passed aggregator that `skipped` results are acceptable (it already only fails on `failure`/`cancelled`, but the comment makes the intent explicit).

3. **docs.yml — Deploy to GitHub Pages**

   The `deploy` job runs `actions/deploy-pages` which 404s on forks that don't have Pages enabled. The `build` job is left ungated so forks still catch documentation-build breakage; only the actual deployment is restricted to the canonical repo.

### Dropped from earlier revision per @TrentHouliston review

- **Codecov coverage-upload gate**: no longer needed — tokenless uploads are now working on forks (fix applied upstream), so the third Codecov step succeeds without a canonical-repo gate.
- **`power-policies.md` walkthrough fix**: superseded upstream — the `validate_policies` expectation list was already updated on `main` to include both auto-surfaced `Battery charge cost` and `Battery discharge cost` rules. Conflict resolved to upstream verbatim during rebase.

Net effect: the post-release-tag reds and the HACS/Pages fork reds disappear on purcell-lab/haeo; behaviour on hass-energy/haeo is unchanged. No code paths were touched.

Single commit: `909ca34e`.