### PR TITLE
Add Volcast solar forecast extractor

### DIFF
--- a/custom_components/haeo/core/data/loader/extractors/__init__.py
+++ b/custom_components/haeo/core/data/loader/extractors/__init__.py
@@ -17,6 +17,7 @@ from . import (
     nordpool,
     open_meteo_solar_forecast,
     solcast_solar,
+    volcast_solar,
 )
 from .utils import EntityMetadata, separate_duplicate_timestamps
 
@@ -31,6 +32,7 @@ ExtractorFormat = (
     | nordpool.Format
     | open_meteo_solar_forecast.Format
     | solcast_solar.Format
+    | volcast_solar.Format
 )
 
 # Union of all Extractor class types
@@ -44,6 +46,7 @@ DataExtractor = (
     | type[nordpool.Parser]
     | type[open_meteo_solar_forecast.Parser]
     | type[solcast_solar.Parser]
+    | type[volcast_solar.Parser]
 )
 
 
@@ -58,6 +61,7 @@ FORMATS: dict[ExtractorFormat, DataExtractor] = {
     nordpool.DOMAIN: nordpool.Parser,
     open_meteo_solar_forecast.DOMAIN: open_meteo_solar_forecast.Parser,
     solcast_solar.DOMAIN: solcast_solar.Parser,
+    volcast_solar.DOMAIN: volcast_solar.Parser,
 }
 
 
@@ -96,6 +100,8 @@ def extract(state: EntityState) -> ExtractedData:
         data, unit, device_class = open_meteo_solar_forecast.Parser.extract(state)
     elif solcast_solar.Parser.detect(state):
         data, unit, device_class = solcast_solar.Parser.extract(state)
+    elif volcast_solar.Parser.detect(state):
+        data, unit, device_class = volcast_solar.Parser.extract(state)
     else:
         # If no extractor matched read the state as a single float value
         data = float(state.state)

--- a/custom_components/haeo/core/data/loader/extractors/__init__.py
+++ b/custom_components/haeo/core/data/loader/extractors/__init__.py
@@ -17,7 +17,7 @@ from . import (
     nordpool,
     open_meteo_solar_forecast,
     solcast_solar,
-    volcast_solar,
+    volcast,
 )
 from .utils import EntityMetadata, separate_duplicate_timestamps
 
@@ -32,7 +32,7 @@ ExtractorFormat = (
     | nordpool.Format
     | open_meteo_solar_forecast.Format
     | solcast_solar.Format
-    | volcast_solar.Format
+    | volcast.Format
 )
 
 # Union of all Extractor class types
@@ -46,7 +46,7 @@ DataExtractor = (
     | type[nordpool.Parser]
     | type[open_meteo_solar_forecast.Parser]
     | type[solcast_solar.Parser]
-    | type[volcast_solar.Parser]
+    | type[volcast.Parser]
 )
 
 
@@ -61,7 +61,7 @@ FORMATS: dict[ExtractorFormat, DataExtractor] = {
     nordpool.DOMAIN: nordpool.Parser,
     open_meteo_solar_forecast.DOMAIN: open_meteo_solar_forecast.Parser,
     solcast_solar.DOMAIN: solcast_solar.Parser,
-    volcast_solar.DOMAIN: volcast_solar.Parser,
+    volcast.DOMAIN: volcast.Parser,
 }
 
 
@@ -100,8 +100,8 @@ def extract(state: EntityState) -> ExtractedData:
         data, unit, device_class = open_meteo_solar_forecast.Parser.extract(state)
     elif solcast_solar.Parser.detect(state):
         data, unit, device_class = solcast_solar.Parser.extract(state)
-    elif volcast_solar.Parser.detect(state):
-        data, unit, device_class = volcast_solar.Parser.extract(state)
+    elif volcast.Parser.detect(state):
+        data, unit, device_class = volcast.Parser.extract(state)
     else:
         # If no extractor matched read the state as a single float value
         data = float(state.state)

--- a/custom_components/haeo/core/data/loader/extractors/tests/test_data/sensors/__init__.py
+++ b/custom_components/haeo/core/data/loader/extractors/tests/test_data/sensors/__init__.py
@@ -19,7 +19,7 @@ VALID_SENSORS_BY_PARSER: dict[str, list[dict[str, Any]]] = {
     "nordpool": nordpool.VALID,
     "solcast_solar": solcast.VALID,
     "open_meteo_solar_forecast": open_meteo.VALID,
-    "volcast_solar": volcast.VALID,
+    "volcast": volcast.VALID,
 }
 
 # Aggregate all invalid sensor configs by parser type
@@ -33,7 +33,7 @@ INVALID_SENSORS_BY_PARSER: dict[str, list[dict[str, Any]]] = {
     "nordpool": nordpool.INVALID,
     "solcast_solar": solcast.INVALID,
     "open_meteo_solar_forecast": open_meteo.INVALID,
-    "volcast_solar": volcast.INVALID,
+    "volcast": volcast.INVALID,
 }
 
 # Flatten all valid sensors into a single list for easy iteration

--- a/custom_components/haeo/core/data/loader/extractors/tests/test_data/sensors/__init__.py
+++ b/custom_components/haeo/core/data/loader/extractors/tests/test_data/sensors/__init__.py
@@ -6,7 +6,7 @@ by parser type for easy access in parameterized tests.
 
 from typing import Any
 
-from . import aemo, amber2mqtt, amberelectric, emhass, flow_power, haeo, nordpool, open_meteo, solcast
+from . import aemo, amber2mqtt, amberelectric, emhass, flow_power, haeo, nordpool, open_meteo, solcast, volcast
 
 # Aggregate all valid sensor configs by parser type
 VALID_SENSORS_BY_PARSER: dict[str, list[dict[str, Any]]] = {
@@ -19,6 +19,7 @@ VALID_SENSORS_BY_PARSER: dict[str, list[dict[str, Any]]] = {
     "nordpool": nordpool.VALID,
     "solcast_solar": solcast.VALID,
     "open_meteo_solar_forecast": open_meteo.VALID,
+    "volcast_solar": volcast.VALID,
 }
 
 # Aggregate all invalid sensor configs by parser type
@@ -32,6 +33,7 @@ INVALID_SENSORS_BY_PARSER: dict[str, list[dict[str, Any]]] = {
     "nordpool": nordpool.INVALID,
     "solcast_solar": solcast.INVALID,
     "open_meteo_solar_forecast": open_meteo.INVALID,
+    "volcast_solar": volcast.INVALID,
 }
 
 # Flatten all valid sensors into a single list for easy iteration

--- a/custom_components/haeo/core/data/loader/extractors/tests/test_data/sensors/volcast.py
+++ b/custom_components/haeo/core/data/loader/extractors/tests/test_data/sensors/volcast.py
@@ -1,0 +1,125 @@
+"""Test data for Volcast solar forecast sensors."""
+
+from datetime import UTC, datetime
+from typing import Any
+
+VALID: list[dict[str, Any]] = [
+    {
+        "entity_id": "sensor.volcast_forecast",
+        "state": "0",
+        "attributes": {"detailedForecast": [{"period_start": "2026-05-29T00:00:00+10:00", "power_w": 0}]},
+        "expected_format": "volcast_solar",
+        "expected_unit": "kW",
+        "expected_data": [(1779976800.0, 0.0)],
+        "description": "Single Volcast forecast entry",
+    },
+    {
+        "entity_id": "sensor.volcast_multi_forecast",
+        "state": "0",
+        "attributes": {
+            "detailedForecast": [
+                {"period_start": "2026-05-29T00:00:00+10:00", "power_w": 0},
+                {"period_start": "2026-05-29T00:05:00+10:00", "power_w": 3500},
+            ]
+        },
+        "expected_format": "volcast_solar",
+        "expected_unit": "kW",
+        "expected_data": [(1779976800.0, 0.0), (1779977100.0, 3.5)],
+        "description": "Multiple Volcast forecast entries",
+    },
+    {
+        "entity_id": "sensor.volcast_datetime_objects",
+        "state": "0",
+        "attributes": {
+            "detailedForecast": [
+                {"period_start": datetime(2026, 5, 29, 0, 0, 0, tzinfo=UTC), "power_w": 2000},
+                {"period_start": datetime(2026, 5, 29, 0, 5, 0, tzinfo=UTC), "power_w": 7500},
+            ]
+        },
+        "expected_format": "volcast_solar",
+        "expected_unit": "kW",
+        "expected_data": [(1780012800.0, 2.0), (1780013100.0, 7.5)],
+        "description": "Volcast forecast with datetime objects instead of strings",
+    },
+    {
+        "entity_id": "sensor.volcast_mixed_datetime_types",
+        "state": "0",
+        "attributes": {
+            "detailedForecast": [
+                {"period_start": "2026-05-29T00:00:00+10:00", "power_w": 1000},
+                {"period_start": datetime(2026, 5, 29, 1, 0, 0, tzinfo=UTC), "power_w": 4000},
+            ]
+        },
+        "expected_format": "volcast_solar",
+        "expected_unit": "kW",
+        "expected_data": [(1779976800.0, 1.0), (1780016400.0, 4.0)],
+        "description": "Volcast forecast with mixed string and datetime object timestamps",
+    },
+]
+
+INVALID: list[dict[str, Any]] = [
+    {
+        "entity_id": "sensor.volcast_no_forecast",
+        "state": "0",
+        "attributes": {},
+        "expected_format": None,
+        "description": "Volcast sensor missing detailedForecast attribute",
+    },
+    {
+        "entity_id": "sensor.volcast_bad_forecast",
+        "state": "0",
+        "attributes": {"detailedForecast": "not a list"},
+        "expected_format": None,
+        "description": "Volcast sensor with detailedForecast not being a list",
+    },
+    {
+        "entity_id": "sensor.volcast_empty_forecast",
+        "state": "0",
+        "attributes": {"detailedForecast": []},
+        "expected_format": None,
+        "description": "Volcast sensor with empty detailedForecast list",
+    },
+    {
+        "entity_id": "sensor.volcast_bad_timestamp",
+        "state": "0",
+        "attributes": {"detailedForecast": [{"period_start": "not a timestamp", "power_w": 100}]},
+        "expected_format": None,
+        "description": "Volcast sensor with invalid timestamp",
+    },
+    {
+        "entity_id": "sensor.volcast_missing_power_w",
+        "state": "0",
+        "attributes": {
+            "detailedForecast": [
+                {"period_start": "2026-05-29T00:00:00+10:00"},
+                {"period_start": "2026-05-29T00:05:00+10:00"},
+            ]
+        },
+        "expected_format": None,
+        "description": "Volcast sensor missing power_w field",
+    },
+    {
+        "entity_id": "sensor.volcast_non_mapping_entry",
+        "state": "0",
+        "attributes": {
+            "detailedForecast": [
+                {"period_start": "2026-05-29T00:00:00+10:00", "power_w": 500},
+                "not-a-dict",
+            ]
+        },
+        "expected_format": None,
+        "description": "Volcast forecast containing a non-mapping item",
+    },
+    {
+        "entity_id": "sensor.volcast_mixed_valid_invalid",
+        "state": "0",
+        "attributes": {
+            "detailedForecast": [
+                {"period_start": "2026-05-29T00:00:00+10:00", "power_w": 500},
+                {"period_start": "bad", "power_w": 1000},
+            ]
+        },
+        "expected_format": None,
+        "description": "Volcast forecast containing both valid and invalid rows",
+    },
+]

--- a/custom_components/haeo/core/data/loader/extractors/tests/test_data/sensors/volcast.py
+++ b/custom_components/haeo/core/data/loader/extractors/tests/test_data/sensors/volcast.py
@@ -8,7 +8,7 @@ VALID: list[dict[str, Any]] = [
         "entity_id": "sensor.volcast_forecast",
         "state": "0",
         "attributes": {"detailedForecast": [{"period_start": "2026-05-29T00:00:00+10:00", "power_w": 0}]},
-        "expected_format": "volcast_solar",
+        "expected_format": "volcast",
         "expected_unit": "kW",
         "expected_data": [(1779976800.0, 0.0)],
         "description": "Single Volcast forecast entry",
@@ -22,7 +22,7 @@ VALID: list[dict[str, Any]] = [
                 {"period_start": "2026-05-29T00:05:00+10:00", "power_w": 3500},
             ]
         },
-        "expected_format": "volcast_solar",
+        "expected_format": "volcast",
         "expected_unit": "kW",
         "expected_data": [(1779976800.0, 0.0), (1779977100.0, 3.5)],
         "description": "Multiple Volcast forecast entries",
@@ -36,7 +36,7 @@ VALID: list[dict[str, Any]] = [
                 {"period_start": datetime(2026, 5, 29, 0, 5, 0, tzinfo=UTC), "power_w": 7500},
             ]
         },
-        "expected_format": "volcast_solar",
+        "expected_format": "volcast",
         "expected_unit": "kW",
         "expected_data": [(1780012800.0, 2.0), (1780013100.0, 7.5)],
         "description": "Volcast forecast with datetime objects instead of strings",
@@ -50,7 +50,7 @@ VALID: list[dict[str, Any]] = [
                 {"period_start": datetime(2026, 5, 29, 1, 0, 0, tzinfo=UTC), "power_w": 4000},
             ]
         },
-        "expected_format": "volcast_solar",
+        "expected_format": "volcast",
         "expected_unit": "kW",
         "expected_data": [(1779976800.0, 1.0), (1780016400.0, 4.0)],
         "description": "Volcast forecast with mixed string and datetime object timestamps",

--- a/custom_components/haeo/core/data/loader/extractors/volcast.py
+++ b/custom_components/haeo/core/data/loader/extractors/volcast.py
@@ -12,8 +12,8 @@ from .utils import is_parsable_to_datetime, parse_datetime_to_timestamp
 
 _LOGGER = logging.getLogger(__name__)
 
-Format = Literal["volcast_solar"]
-DOMAIN: Format = "volcast_solar"
+Format = Literal["volcast"]
+DOMAIN: Format = "volcast"
 
 
 class VolcastForecastEntry(TypedDict):
@@ -23,16 +23,16 @@ class VolcastForecastEntry(TypedDict):
     power_w: int | float
 
 
-class VolcastSolarAttributes(TypedDict):
-    """Type definition for Volcast solar forecast state attributes."""
+class VolcastAttributes(TypedDict):
+    """Type definition for Volcast state attributes."""
 
     detailedForecast: Sequence[VolcastForecastEntry]
 
 
-class VolcastSolarState(Protocol):
-    """Protocol for a State object with validated Volcast solar forecast data."""
+class VolcastState(Protocol):
+    """Protocol for a State object with validated Volcast forecast data."""
 
-    attributes: VolcastSolarAttributes
+    attributes: VolcastAttributes
 
 
 class Parser:
@@ -43,7 +43,7 @@ class Parser:
     DEVICE_CLASS: DeviceClass = DeviceClass.POWER
 
     @staticmethod
-    def detect(state: EntityState) -> TypeGuard[VolcastSolarState]:
+    def detect(state: EntityState) -> TypeGuard[VolcastState]:
         """Check if data matches Volcast solar forecast format and narrow type."""
 
         if "detailedForecast" not in state.attributes:
@@ -66,8 +66,8 @@ class Parser:
         )
 
     @staticmethod
-    def extract(state: VolcastSolarState) -> tuple[Sequence[tuple[int, float]], UnitOfMeasurement, DeviceClass]:
-        """Extract forecast data from Volcast solar forecast format.
+    def extract(state: VolcastState) -> tuple[Sequence[tuple[int, float]], UnitOfMeasurement, DeviceClass]:
+        """Extract forecast data from Volcast format.
 
         State has been validated by detect(), so all entries are guaranteed to be valid.
         """

--- a/custom_components/haeo/core/data/loader/extractors/volcast_solar.py
+++ b/custom_components/haeo/core/data/loader/extractors/volcast_solar.py
@@ -1,0 +1,79 @@
+"""Volcast solar forecast parser."""
+
+from collections.abc import Mapping, Sequence
+from datetime import datetime
+import logging
+from typing import Literal, Protocol, TypedDict, TypeGuard
+
+from custom_components.haeo.core.state import EntityState
+from custom_components.haeo.core.units import DeviceClass, UnitOfMeasurement
+
+from .utils import is_parsable_to_datetime, parse_datetime_to_timestamp
+
+_LOGGER = logging.getLogger(__name__)
+
+Format = Literal["volcast_solar"]
+DOMAIN: Format = "volcast_solar"
+
+
+class VolcastForecastEntry(TypedDict):
+    """Type definition for a Volcast forecast entry."""
+
+    period_start: str | datetime
+    power_w: int | float
+
+
+class VolcastSolarAttributes(TypedDict):
+    """Type definition for Volcast solar forecast state attributes."""
+
+    detailedForecast: Sequence[VolcastForecastEntry]
+
+
+class VolcastSolarState(Protocol):
+    """Protocol for a State object with validated Volcast solar forecast data."""
+
+    attributes: VolcastSolarAttributes
+
+
+class Parser:
+    """Parser for Volcast solar forecast data."""
+
+    DOMAIN: Format = DOMAIN
+    UNIT: UnitOfMeasurement = UnitOfMeasurement.WATT  # Volcast detailedForecast returns W
+    DEVICE_CLASS: DeviceClass = DeviceClass.POWER
+
+    @staticmethod
+    def detect(state: EntityState) -> TypeGuard[VolcastSolarState]:
+        """Check if data matches Volcast solar forecast format and narrow type."""
+
+        if "detailedForecast" not in state.attributes:
+            return False
+
+        detailed_forecast = state.attributes["detailedForecast"]
+        if (
+            not (isinstance(detailed_forecast, Sequence) and not isinstance(detailed_forecast, (str, bytes)))
+            or not detailed_forecast
+        ):
+            return False
+
+        return all(
+            isinstance(item, Mapping)
+            and "period_start" in item
+            and "power_w" in item
+            and isinstance(item["power_w"], (int, float))
+            and is_parsable_to_datetime(item["period_start"])
+            for item in detailed_forecast
+        )
+
+    @staticmethod
+    def extract(state: VolcastSolarState) -> tuple[Sequence[tuple[int, float]], UnitOfMeasurement, DeviceClass]:
+        """Extract forecast data from Volcast solar forecast format.
+
+        State has been validated by detect(), so all entries are guaranteed to be valid.
+        """
+        parsed: list[tuple[int, float]] = [
+            (parse_datetime_to_timestamp(item["period_start"]), item["power_w"])
+            for item in state.attributes["detailedForecast"]
+        ]
+        parsed.sort(key=lambda x: x[0])
+        return parsed, Parser.UNIT, Parser.DEVICE_CLASS

--- a/docs/developer-guide/data-loading.md
+++ b/docs/developer-guide/data-loading.md
@@ -165,7 +165,7 @@ The extractor system ([`extractors/`](https://github.com/hass-energy/haeo/tree/m
 | HAEO                      | Chaining HAEO sensor outputs | [`haeo.py`](https://github.com/hass-energy/haeo/blob/main/custom_components/haeo/core/data/loader/extractors/haeo.py)                                           |
 | Nordpool                  | Electricity pricing          | [`nordpool.py`](https://github.com/hass-energy/haeo/blob/main/custom_components/haeo/core/data/loader/extractors/nordpool.py)                                   |
 | Solcast Solar             | Solar forecasting            | [`solcast_solar.py`](https://github.com/hass-energy/haeo/blob/main/custom_components/haeo/core/data/loader/extractors/solcast_solar.py)                         |
-| Volcast Solar             | Solar forecasting            | [`volcast_solar.py`](https://github.com/hass-energy/haeo/blob/main/custom_components/haeo/core/data/loader/extractors/volcast_solar.py)                         |
+| Volcast                   | Solar forecasting            | [`volcast.py`](https://github.com/hass-energy/haeo/blob/main/custom_components/haeo/core/data/loader/extractors/volcast.py)                                     |
 | Open-Meteo Solar Forecast | Solar forecasting            | [`open_meteo_solar_forecast.py`](https://github.com/hass-energy/haeo/blob/main/custom_components/haeo/core/data/loader/extractors/open_meteo_solar_forecast.py) |
 
 ### Parser Design

--- a/docs/developer-guide/data-loading.md
+++ b/docs/developer-guide/data-loading.md
@@ -165,6 +165,7 @@ The extractor system ([`extractors/`](https://github.com/hass-energy/haeo/tree/m
 | HAEO                      | Chaining HAEO sensor outputs | [`haeo.py`](https://github.com/hass-energy/haeo/blob/main/custom_components/haeo/core/data/loader/extractors/haeo.py)                                           |
 | Nordpool                  | Electricity pricing          | [`nordpool.py`](https://github.com/hass-energy/haeo/blob/main/custom_components/haeo/core/data/loader/extractors/nordpool.py)                                   |
 | Solcast Solar             | Solar forecasting            | [`solcast_solar.py`](https://github.com/hass-energy/haeo/blob/main/custom_components/haeo/core/data/loader/extractors/solcast_solar.py)                         |
+| Volcast Solar             | Solar forecasting            | [`volcast_solar.py`](https://github.com/hass-energy/haeo/blob/main/custom_components/haeo/core/data/loader/extractors/volcast_solar.py)                         |
 | Open-Meteo Solar Forecast | Solar forecasting            | [`open_meteo_solar_forecast.py`](https://github.com/hass-energy/haeo/blob/main/custom_components/haeo/core/data/loader/extractors/open_meteo_solar_forecast.py) |
 
 ### Parser Design

--- a/docs/user-guide/forecasts-and-sensors.md
+++ b/docs/user-guide/forecasts-and-sensors.md
@@ -57,6 +57,7 @@ Custom template sensors that match these formats will also work.
 - [EMHASS](https://github.com/davidusb-geern/emhass) (energy management forecasts)
 - [Nordpool](https://github.com/custom-components/nordpool) (electricity pricing)
 - [Solcast Solar](https://github.com/BJReplay/ha-solcast-solar) (solar generation)
+- [Volcast Solar](https://github.com/volter-labs/volcast-ha-integration) (solar generation)
 - [Open-Meteo Solar Forecast](https://github.com/rany2/ha-open-meteo-solar-forecast) (solar generation)
 - HAEO sensors (chain HAEO outputs as inputs to other elements)
 
@@ -289,6 +290,7 @@ HAEO automatically detects and parses these forecast formats:
 | [Nordpool](https://github.com/custom-components/nordpool)                          | `nordpool`                  | Electricity pricing (Europe)    | Variable intervals  |
 | [HAFO](https://hafo.haeo.io)                                                       | `hafo`                      | Historical load forecasting     | Hourly intervals    |
 | [Solcast Solar](https://github.com/BJReplay/ha-solcast-solar)                      | `solcast_pv_forecast`       | Solar generation                | 30-minute intervals |
+| [Volcast Solar](https://github.com/volter-labs/volcast-ha-integration)             | `volcast`                   | Solar generation                | 5-minute intervals  |
 | [Open-Meteo Solar Forecast](https://github.com/rany2/ha-open-meteo-solar-forecast) | `open_meteo_solar_forecast` | Solar generation                | Hourly intervals    |
 
 Format detection is automatic—you don't need to specify the integration type.

--- a/docs/user-guide/forecasts-and-sensors.md
+++ b/docs/user-guide/forecasts-and-sensors.md
@@ -290,7 +290,7 @@ HAEO automatically detects and parses these forecast formats:
 | [Nordpool](https://github.com/custom-components/nordpool)                          | `nordpool`                  | Electricity pricing (Europe)    | Variable intervals  |
 | [HAFO](https://hafo.haeo.io)                                                       | `hafo`                      | Historical load forecasting     | Hourly intervals    |
 | [Solcast Solar](https://github.com/BJReplay/ha-solcast-solar)                      | `solcast_pv_forecast`       | Solar generation                | 30-minute intervals |
-| [Volcast](https://github.com/volter-labs/volcast-ha-integration)             | `volcast`                   | Solar generation                | 5-minute intervals  |
+| [Volcast](https://github.com/volter-labs/volcast-ha-integration)                   | `volcast`                   | Solar generation                | 5-minute intervals  |
 | [Open-Meteo Solar Forecast](https://github.com/rany2/ha-open-meteo-solar-forecast) | `open_meteo_solar_forecast` | Solar generation                | Hourly intervals    |
 
 Format detection is automatic—you don't need to specify the integration type.

--- a/docs/user-guide/forecasts-and-sensors.md
+++ b/docs/user-guide/forecasts-and-sensors.md
@@ -57,7 +57,7 @@ Custom template sensors that match these formats will also work.
 - [EMHASS](https://github.com/davidusb-geern/emhass) (energy management forecasts)
 - [Nordpool](https://github.com/custom-components/nordpool) (electricity pricing)
 - [Solcast Solar](https://github.com/BJReplay/ha-solcast-solar) (solar generation)
-- [Volcast Solar](https://github.com/volter-labs/volcast-ha-integration) (solar generation)
+- [Volcast](https://github.com/volter-labs/volcast-ha-integration) (solar generation)
 - [Open-Meteo Solar Forecast](https://github.com/rany2/ha-open-meteo-solar-forecast) (solar generation)
 - HAEO sensors (chain HAEO outputs as inputs to other elements)
 
@@ -290,7 +290,7 @@ HAEO automatically detects and parses these forecast formats:
 | [Nordpool](https://github.com/custom-components/nordpool)                          | `nordpool`                  | Electricity pricing (Europe)    | Variable intervals  |
 | [HAFO](https://hafo.haeo.io)                                                       | `hafo`                      | Historical load forecasting     | Hourly intervals    |
 | [Solcast Solar](https://github.com/BJReplay/ha-solcast-solar)                      | `solcast_pv_forecast`       | Solar generation                | 30-minute intervals |
-| [Volcast Solar](https://github.com/volter-labs/volcast-ha-integration)             | `volcast`                   | Solar generation                | 5-minute intervals  |
+| [Volcast](https://github.com/volter-labs/volcast-ha-integration)             | `volcast`                   | Solar generation                | 5-minute intervals  |
 | [Open-Meteo Solar Forecast](https://github.com/rany2/ha-open-meteo-solar-forecast) | `open_meteo_solar_forecast` | Solar generation                | Hourly intervals    |
 
 Format detection is automatic—you don't need to specify the integration type.


### PR DESCRIPTION
Adds a data extractor for the [Volcast solar forecast](https://github.com/volter-labs/volcast-ha-integration) Home Assistant integration.

## What changed

- **New `volcast` parser** — detects and extracts from the `detailedForecast` attribute, which provides 5-minute resolution data with ISO 8601 timestamps and `power_w` values in watts. Detection keys on the `power_w` field, distinguishing it from the Solcast parser which keys on `pv_estimate`.
- **Unit handling** — the parser declares `UNIT = WATT` and `DEVICE_CLASS = POWER`; the existing `convert_to_base_unit` dispatch normalizes W → kW automatically, which is what the optimizer expects.
- **Registration** — parser added to the `ExtractorFormat`/`DataExtractor` unions, `FORMATS` dict, and the `elif` dispatch chain in `extractors/__init__.py`.
- **Tests** — 4 VALID fixtures (single entry, multi-entry, datetime objects, mixed timestamp types) and 7 INVALID fixtures covering all detection failure paths. All 125 extractor tests pass.