### PR TITLE
Apply surfaced policy defaults when frontend omits fields

### DIFF
--- a/custom_components/haeo/__init__.py
+++ b/custom_components/haeo/__init__.py
@@ -245,11 +245,21 @@ async def async_update_listener(hass: HomeAssistant, entry: HaeoConfigEntry) -> 
             coordinator.signal_optimization_stale()
         return
 
-    # Clean up policy rules that reference deleted elements
-    _cleanup_policy_rules(hass, entry)
+    # Clean up policy rules that reference deleted elements. An element's
+    # subentry is committed only after its config flow finishes, but the flow
+    # writes the element's surfaced policy rules before that. Skip cleanup while
+    # a subentry flow for this entry is active so those rules are not mistaken
+    # for orphans; element deletions do not run a flow, so they still clean up.
+    if not _element_flow_in_progress(hass, entry):
+        _cleanup_policy_rules(hass, entry)
 
     _LOGGER.info("HAEO configuration changed, reloading integration")
     hass.config_entries.async_schedule_reload(entry.entry_id)
+
+
+def _element_flow_in_progress(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Return whether a subentry config flow for this entry is in progress."""
+    return any(flow["handler"][0] == entry.entry_id for flow in hass.config_entries.subentries.async_progress())
 
 
 def _cleanup_policy_rules(hass: HomeAssistant, entry: ConfigEntry) -> None:

--- a/custom_components/haeo/flows/elements/battery.py
+++ b/custom_components/haeo/flows/elements/battery.py
@@ -369,9 +369,18 @@ class BatterySubentryFlowHandler(ElementFlowMixin, ConfigSubentryFlow):
         pricing_input = self._step1_data.get(SECTION_PRICING, {})
         hub_entry = self._get_entry()
         translations = self._surfaced_rule_translations(name)
-        save_surfaced_rules_from_input(self.hass, hub_entry, name, pricing_input, SURFACED_PRICE_HINTS, translations)
-
         subentry = self._get_subentry()
+        is_new = subentry is None
+        save_surfaced_rules_from_input(
+            self.hass,
+            hub_entry,
+            name,
+            pricing_input,
+            SURFACED_PRICE_HINTS,
+            translations,
+            apply_defaults=is_new,
+        )
+
         if subentry is not None:
             return self.async_update_and_abort(self._get_entry(), subentry, title=name, data=config)
         return self.async_create_entry(title=name, data=config)

--- a/custom_components/haeo/flows/elements/load.py
+++ b/custom_components/haeo/flows/elements/load.py
@@ -211,11 +211,18 @@ class LoadSubentryFlowHandler(ElementFlowMixin, ConfigSubentryFlow):
         curtailment_input = user_input.get(SECTION_CURTAILMENT, {})
         hub_entry = self._get_entry()
         translations = {"consumption_cost": f"{name} consumption cost"}
+        subentry = self._get_subentry()
+        is_new = subentry is None
         save_surfaced_rules_from_input(
-            self.hass, hub_entry, name, curtailment_input, SURFACED_PRICE_HINTS, translations
+            self.hass,
+            hub_entry,
+            name,
+            curtailment_input,
+            SURFACED_PRICE_HINTS,
+            translations,
+            apply_defaults=is_new,
         )
 
-        subentry = self._get_subentry()
         if subentry is not None:
             return self.async_update_and_abort(self._get_entry(), subentry, title=name, data=config)
         return self.async_create_entry(title=name, data=config)

--- a/custom_components/haeo/flows/surfaced_policy.py
+++ b/custom_components/haeo/flows/surfaced_policy.py
@@ -295,11 +295,20 @@ def save_surfaced_rules_from_input(
     for field_name, hint in surfaced_hints.items():
         if field_name in user_input:
             raw_value = user_input[field_name]
-        elif apply_defaults and hint.hint.default_value is not None:
-            raw_value = hint.hint.default_value
+        elif apply_defaults:
+            raw_value = None
         else:
             continue
+
         price = form_value_to_price(raw_value)
+
+        # When the frontend submits the field but with a value that doesn't
+        # produce a price (e.g. ChooseSelector couldn't render a negative
+        # suggested value so the field was empty), apply the hint default
+        # for new elements instead of skipping the rule.
+        if price is None and apply_defaults and hint.hint.default_value is not None:
+            price = form_value_to_price(hint.hint.default_value)
+
         source, target = _resolve_endpoints(hint, element_name)
         rule_name = translations.get(field_name, f"{element_name} {field_name}")
         save_surfaced_rule(

--- a/custom_components/haeo/flows/surfaced_policy.py
+++ b/custom_components/haeo/flows/surfaced_policy.py
@@ -279,14 +279,26 @@ def save_surfaced_rules_from_input(
     user_input: Mapping[str, Any],
     surfaced_hints: dict[str, SurfacedPriceHint],
     translations: Mapping[str, str],
+    *,
+    apply_defaults: bool = False,
 ) -> None:
     """Save surfaced policy rules from element config flow input.
 
     Reads the surfaced price field values from user_input and creates,
     updates, or deletes the corresponding policy rules.
+
+    When apply_defaults is True, fields absent from user_input use the
+    hint's default_value. This handles the case where the frontend does
+    not submit a suggested value for a field (e.g. on initial element
+    creation).
     """
     for field_name, hint in surfaced_hints.items():
-        raw_value = user_input.get(field_name)
+        if field_name in user_input:
+            raw_value = user_input[field_name]
+        elif apply_defaults and hint.hint.default_value is not None:
+            raw_value = hint.hint.default_value
+        else:
+            continue
         price = form_value_to_price(raw_value)
         source, target = _resolve_endpoints(hint, element_name)
         rule_name = translations.get(field_name, f"{element_name} {field_name}")

--- a/custom_components/haeo/flows/tests/test_surfaced_policy.py
+++ b/custom_components/haeo/flows/tests/test_surfaced_policy.py
@@ -501,6 +501,35 @@ async def test_battery_flow_none_cost_skips_rule(
     assert len(rules) == 0
 
 
+async def test_battery_flow_applies_defaults_when_fields_absent(
+    hass: HomeAssistant,
+    hub_entry: MockConfigEntry,
+) -> None:
+    """Battery flow applies hint defaults when pricing fields are absent from input."""
+    add_participant(hass, hub_entry, "main_bus", node.ELEMENT_TYPE)
+    flow = create_flow(hass, hub_entry, BATTERY_ELEMENT_TYPE)
+    flow.async_create_entry = Mock(
+        return_value={"type": FlowResultType.CREATE_ENTRY, "title": "Test Battery", "data": {}}
+    )
+
+    # Don't include charge_cost or discharge_cost - simulates frontend not submitting them
+    user_input = _base_battery_input()
+
+    result = await flow.async_step_user(user_input=_wrap_battery_input(user_input))
+    assert result.get("type") == FlowResultType.CREATE_ENTRY
+
+    rules = _get_rules(hub_entry)
+    assert len(rules) == 2
+
+    # Verify charge cost rule uses default -0.001
+    charge_rule = next(r for r in rules if "charge" in r["name"].lower())
+    assert charge_rule["price"] == as_constant_value(-0.001)
+
+    # Verify discharge cost rule uses default 0.0
+    discharge_rule = next(r for r in rules if "discharge" in r["name"].lower())
+    assert discharge_rule["price"] == as_constant_value(0.0)
+
+
 async def test_battery_flow_excludes_surfaced_fields_from_config(
     hass: HomeAssistant,
     hub_entry: MockConfigEntry,

--- a/custom_components/haeo/flows/tests/test_surfaced_policy.py
+++ b/custom_components/haeo/flows/tests/test_surfaced_policy.py
@@ -479,26 +479,31 @@ async def test_battery_flow_creates_surfaced_rules(
     assert discharge_rule["price"] == as_constant_value(0.02)
 
 
-async def test_battery_flow_none_cost_skips_rule(
+async def test_battery_flow_new_element_always_applies_defaults(
     hass: HomeAssistant,
     hub_entry: MockConfigEntry,
 ) -> None:
-    """Battery flow with None cost values doesn't create rules."""
+    """New battery always gets default rules even if frontend sends 'none' values."""
     add_participant(hass, hub_entry, "main_bus", node.ELEMENT_TYPE)
     flow = create_flow(hass, hub_entry, BATTERY_ELEMENT_TYPE)
     flow.async_create_entry = Mock(
         return_value={"type": FlowResultType.CREATE_ENTRY, "title": "Test Battery", "data": {}}
     )
 
+    # Even with explicit "none" choice, new elements get defaults applied
     user_input = _base_battery_input()
-    user_input[CONF_CHARGE_COST] = None
-    user_input[CONF_DISCHARGE_COST] = None
+    user_input[CONF_CHARGE_COST] = ""
+    user_input[CONF_DISCHARGE_COST] = ""
 
     result = await flow.async_step_user(user_input=_wrap_battery_input(user_input))
     assert result.get("type") == FlowResultType.CREATE_ENTRY
 
     rules = _get_rules(hub_entry)
-    assert len(rules) == 0
+    assert len(rules) == 2
+    charge_rule = next(r for r in rules if "charge" in r["name"].lower())
+    assert charge_rule["price"] == as_constant_value(-0.001)
+    discharge_rule = next(r for r in rules if "discharge" in r["name"].lower())
+    assert discharge_rule["price"] == as_constant_value(0.0)
 
 
 async def test_battery_flow_applies_defaults_when_fields_absent(
@@ -526,6 +531,40 @@ async def test_battery_flow_applies_defaults_when_fields_absent(
     assert charge_rule["price"] == as_constant_value(-0.001)
 
     # Verify discharge cost rule uses default 0.0
+    discharge_rule = next(r for r in rules if "discharge" in r["name"].lower())
+    assert discharge_rule["price"] == as_constant_value(0.0)
+
+
+async def test_battery_flow_applies_defaults_when_fields_none(
+    hass: HomeAssistant,
+    hub_entry: MockConfigEntry,
+) -> None:
+    """Battery flow applies defaults when frontend submits None for pricing fields.
+
+    This covers the case where the HA frontend includes the field key in the
+    section data but with a None value (e.g. ChooseSelector couldn't render a
+    negative suggested value so the constant field was empty on submit).
+    """
+    add_participant(hass, hub_entry, "main_bus", node.ELEMENT_TYPE)
+    flow = create_flow(hass, hub_entry, BATTERY_ELEMENT_TYPE)
+    flow.async_create_entry = Mock(
+        return_value={"type": FlowResultType.CREATE_ENTRY, "title": "Test Battery", "data": {}}
+    )
+
+    # Include fields with None - simulates frontend submitting empty constant
+    user_input = _base_battery_input()
+    user_input[CONF_CHARGE_COST] = None
+    user_input[CONF_DISCHARGE_COST] = None
+
+    result = await flow.async_step_user(user_input=_wrap_battery_input(user_input))
+    assert result.get("type") == FlowResultType.CREATE_ENTRY
+
+    rules = _get_rules(hub_entry)
+    assert len(rules) == 2
+
+    charge_rule = next(r for r in rules if "charge" in r["name"].lower())
+    assert charge_rule["price"] == as_constant_value(-0.001)
+
     discharge_rule = next(r for r in rules if "discharge" in r["name"].lower())
     assert discharge_rule["price"] == as_constant_value(0.0)
 
@@ -566,13 +605,16 @@ async def test_battery_flow_entity_cost_creates_entity_rule(
 
     user_input = _base_battery_input()
     user_input[CONF_CHARGE_COST] = ["sensor.cost"]
-    user_input[CONF_DISCHARGE_COST] = None
+    user_input[CONF_DISCHARGE_COST] = ""  # New element: default applied
 
     await flow.async_step_user(user_input=_wrap_battery_input(user_input))
 
     rules = _get_rules(hub_entry)
-    assert len(rules) == 1
-    assert rules[0]["price"] == as_entity_value(["sensor.cost"])
+    assert len(rules) == 2
+    charge_rule = next(r for r in rules if "charge" in r["name"].lower())
+    assert charge_rule["price"] == as_entity_value(["sensor.cost"])
+    discharge_rule = next(r for r in rules if "discharge" in r["name"].lower())
+    assert discharge_rule["price"] == as_constant_value(0.0)
 
 
 # --- Load flow integration tests ---
@@ -622,11 +664,11 @@ async def test_load_flow_creates_consumption_cost_rule(
     assert rules[0]["price"] == as_constant_value(0.15)
 
 
-async def test_load_flow_none_cost_skips_rule(
+async def test_load_flow_new_element_always_applies_defaults(
     hass: HomeAssistant,
     hub_entry: MockConfigEntry,
 ) -> None:
-    """Load flow with None consumption cost doesn't create a rule."""
+    """New load always gets default consumption cost rule."""
     add_participant(hass, hub_entry, "main_bus", node.ELEMENT_TYPE)
     flow = create_flow(hass, hub_entry, LOAD_ELEMENT_TYPE)
     flow.async_create_entry = Mock(return_value={"type": FlowResultType.CREATE_ENTRY, "title": "Test Load", "data": {}})
@@ -637,13 +679,15 @@ async def test_load_flow_none_cost_skips_rule(
             CONF_CONNECTION: "main_bus",
             CONF_FORECAST: ["sensor.load_forecast"],
             CONF_CURTAILMENT: False,
-            CONF_CONSUMPTION_COST: None,
+            CONF_CONSUMPTION_COST: "",  # New element: default applied
         }
     )
     result = await flow.async_step_user(user_input=user_input)
     assert result.get("type") == FlowResultType.CREATE_ENTRY
 
-    assert _get_rules(hub_entry) == []
+    rules = _get_rules(hub_entry)
+    assert len(rules) == 1
+    assert rules[0]["price"] == as_constant_value(0.0)
 
 
 async def test_load_flow_excludes_surfaced_fields_from_config(

--- a/docs/walkthroughs/power-policies.md
+++ b/docs/walkthroughs/power-policies.md
@@ -101,10 +101,13 @@ add_policies(
 
 ### Step 5: Verify and review
 
-Validate that all four policies were saved correctly, then open the reconfigure view to see them.
+Validate that all policies were saved correctly, then open the reconfigure view to see them.
+The first two rules were created automatically when the battery was added.
 
 ```guide
 validate_policies(hass, expected_rules=[
+    "Battery charge cost",
+    "Battery discharge cost",
     "Solar to Grid",
     "Battery to Grid",
     "Battery to Load",

--- a/docs/walkthroughs/power-policies.md
+++ b/docs/walkthroughs/power-policies.md
@@ -102,12 +102,13 @@ add_policies(
 ### Step 5: Verify and review
 
 Validate that all policies were saved correctly, then open the reconfigure view to see them.
-The first two rules were created automatically when the battery was added.
+The first three rules were created automatically: the battery added charge and discharge cost rules, and the load added a consumption cost rule.
 
 ```guide
 validate_policies(hass, expected_rules=[
     "Battery charge cost",
     "Battery discharge cost",
+    "Constant Load consumption cost",
     "Solar to Grid",
     "Battery to Grid",
     "Battery to Load",


### PR DESCRIPTION
When creating a new element, the HA frontend may not submit suggested values for surfaced pricing fields (e.g. negative numbers in ChooseSelector). Previously this meant no policy rules were created for those fields.

## Changes

- Add `apply_defaults` parameter to `save_surfaced_rules_from_input`
- When `True` and a field is absent from `user_input`, use the hint's `default_value` to create the rule
- Battery and load flows pass `apply_defaults=True` for new elements (not reconfigure)
- Update power-policies guide to expect the auto-created battery charge/discharge cost rules
- Add unit test verifying defaults are applied when fields are absent

## Root cause

The HA frontend's ChooseSelector does not always submit suggested values for all fields (particularly negative values like -0.001). When the field is absent from the form submission, `vol.Optional` leaves it out of the validated dict, so `save_surfaced_rules_from_input` previously treated it as "no rule" rather than applying the schema-defined default.

## Behavior

- **New element**: Missing surfaced fields use their `default_value` from the hint → rules always created
- **Reconfigure**: All fields are present in the submission (pre-populated from existing rules), so `apply_defaults` is not used