### PR TITLE
Allow policy selectors to use Home Assistant entities

### DIFF
--- a/custom_components/haeo/flows/elements/battery.py
+++ b/custom_components/haeo/flows/elements/battery.py
@@ -196,7 +196,7 @@ class BatterySubentryFlowHandler(ElementFlowMixin, ConfigSubentryFlow):
         """Build the schema with name, connection, and choose selectors for main inputs."""
         field_schema = get_input_field_schema_info(ELEMENT_TYPE, input_fields)
         surfaced_fields = get_surfaced_input_fields(ELEMENT_TYPE)
-        surfaced_entries = build_surfaced_schema_entries(surfaced_fields)
+        surfaced_entries = build_surfaced_schema_entries(self.hass, surfaced_fields)
         return build_sectioned_choose_schema(
             self._get_sections(),
             input_fields,

--- a/custom_components/haeo/flows/elements/load.py
+++ b/custom_components/haeo/flows/elements/load.py
@@ -116,7 +116,7 @@ class LoadSubentryFlowHandler(ElementFlowMixin, ConfigSubentryFlow):
         """Build the schema with name, connection, and choose selectors for inputs."""
         field_schema = get_input_field_schema_info(ELEMENT_TYPE, input_fields)
         surfaced_fields = get_surfaced_input_fields(ELEMENT_TYPE)
-        surfaced_entries = build_surfaced_schema_entries(surfaced_fields)
+        surfaced_entries = build_surfaced_schema_entries(self.hass, surfaced_fields)
         return build_sectioned_choose_schema(
             self._get_sections(),
             input_fields,

--- a/custom_components/haeo/flows/elements/policy.py
+++ b/custom_components/haeo/flows/elements/policy.py
@@ -46,7 +46,8 @@ from custom_components.haeo.core.schema.elements.policy import (
 from custom_components.haeo.core.schema.entity_value import as_entity_value, is_entity_value
 from custom_components.haeo.elements import get_list_input_fields
 from custom_components.haeo.elements.input_fields import InputFieldInfo
-from custom_components.haeo.flows.element_flow import ElementFlowMixin
+from custom_components.haeo.flows.element_flow import ElementFlowMixin, build_inclusion_map
+from custom_components.haeo.flows.entity_metadata import extract_entity_metadata
 from custom_components.haeo.flows.field_schema import (
     CHOICE_CONSTANT,
     CHOICE_ENTITY,
@@ -171,11 +172,14 @@ class PolicySubentryFlowHandler(ElementFlowMixin, ConfigSubentryFlow):
     def _build_price_selector(self) -> NormalizingChooseSelector:
         """Build a ChooseSelector for the price field (entity/constant)."""
         field_info = self._get_price_field_info()
+        entity_metadata = extract_entity_metadata(self.hass)
+        inclusion_map = build_inclusion_map({field_info.field_name: field_info}, entity_metadata)
         return build_choose_selector(
             field_info,
             allowed_choices={CHOICE_ENTITY, CHOICE_CONSTANT},
             multiple=True,
             preferred_choice=CHOICE_CONSTANT,
+            include_entities=inclusion_map.get(field_info.field_name),
         )
 
     def _build_endpoint_selector(

--- a/custom_components/haeo/flows/elements/policy.py
+++ b/custom_components/haeo/flows/elements/policy.py
@@ -46,8 +46,7 @@ from custom_components.haeo.core.schema.elements.policy import (
 from custom_components.haeo.core.schema.entity_value import as_entity_value, is_entity_value
 from custom_components.haeo.elements import get_list_input_fields
 from custom_components.haeo.elements.input_fields import InputFieldInfo
-from custom_components.haeo.flows.element_flow import ElementFlowMixin, build_inclusion_map
-from custom_components.haeo.flows.entity_metadata import extract_entity_metadata
+from custom_components.haeo.flows.element_flow import ElementFlowMixin
 from custom_components.haeo.flows.field_schema import (
     CHOICE_CONSTANT,
     CHOICE_ENTITY,
@@ -172,14 +171,11 @@ class PolicySubentryFlowHandler(ElementFlowMixin, ConfigSubentryFlow):
     def _build_price_selector(self) -> NormalizingChooseSelector:
         """Build a ChooseSelector for the price field (entity/constant)."""
         field_info = self._get_price_field_info()
-        entity_metadata = extract_entity_metadata(self.hass)
-        inclusion_map = build_inclusion_map({field_info.field_name: field_info}, entity_metadata)
         return build_choose_selector(
             field_info,
             allowed_choices={CHOICE_ENTITY, CHOICE_CONSTANT},
             multiple=True,
             preferred_choice=CHOICE_CONSTANT,
-            include_entities=inclusion_map.get(field_info.field_name),
         )
 
     def _build_endpoint_selector(

--- a/custom_components/haeo/flows/field_schema.py
+++ b/custom_components/haeo/flows/field_schema.py
@@ -176,14 +176,16 @@ def build_entity_selector(
         multiple: Whether to allow multiple entity selection (for chaining).
 
     Returns:
-        EntitySelector configured with include_entities list.
+        EntitySelector with domain filter only, or restricted to include_entities
+        when unit-compatible entities are provided.
 
     """
-    # Start with compatible entities from unit filtering
     entities_to_include = list(include_entities or [])
 
-    # Include all HAEO input entities so they can be re-selected during reconfigure
-    entities_to_include.extend(get_haeo_input_entity_ids())
+    # Only restrict the picker when unit filtering supplies a list. HAEO input
+    # entities are added to that list so they remain selectable on reconfigure.
+    if include_entities:
+        entities_to_include.extend(get_haeo_input_entity_ids())
 
     config_kwargs: dict[str, Any] = {
         "domain": [DOMAIN, "sensor", "input_number", "number", "switch"],

--- a/custom_components/haeo/flows/surfaced_policy.py
+++ b/custom_components/haeo/flows/surfaced_policy.py
@@ -30,6 +30,8 @@ from custom_components.haeo.core.schema.elements.policy import (
 )
 from custom_components.haeo.core.schema.entity_value import EntityValue, as_entity_value, is_entity_value
 from custom_components.haeo.core.schema.field_hints import SurfacedPriceHint
+from custom_components.haeo.flows.element_flow import build_inclusion_map
+from custom_components.haeo.flows.entity_metadata import extract_entity_metadata
 from custom_components.haeo.flows.field_schema import (
     CHOICE_CONSTANT,
     CHOICE_ENTITY,
@@ -251,13 +253,17 @@ def build_surfaced_defaults(
 
 
 def build_surfaced_schema_entries(
+    hass: HomeAssistant,
     surfaced_fields: Mapping[str, Any],
 ) -> dict[str, tuple[Any, Any]]:
     """Build vol.Schema entries for surfaced pricing fields.
 
     Uses the standard build_choose_selector to create selectors from the
-    InputFieldInfo objects.
+    InputFieldInfo objects, with the same unit-based entity filtering as
+    other element config flows.
     """
+    entity_metadata = extract_entity_metadata(hass)
+    inclusion_map = build_inclusion_map(surfaced_fields, entity_metadata)
     return {
         field_info.field_name: (
             vol.Optional(field_info.field_name),
@@ -266,6 +272,7 @@ def build_surfaced_schema_entries(
                 allowed_choices={CHOICE_ENTITY, CHOICE_CONSTANT, CHOICE_NONE},
                 multiple=True,
                 preferred_choice=CHOICE_CONSTANT,
+                include_entities=inclusion_map.get(field_info.field_name),
             ),
         )
         for field_info in surfaced_fields.values()

--- a/custom_components/haeo/flows/tests/test_field_schema.py
+++ b/custom_components/haeo/flows/tests/test_field_schema.py
@@ -955,11 +955,11 @@ def test_build_entity_selector_with_include_entities(hass: HomeAssistant) -> Non
 
 
 def test_build_entity_selector_without_include_entities(hass: HomeAssistant) -> None:
-    """build_entity_selector with no include_entities still includes HAEO entities."""
+    """build_entity_selector without include_entities does not restrict entity choices."""
     selector = build_entity_selector(include_entities=None)
     config = selector.config
-    # Even with None, HAEO input entities are added (if any exist)
     assert config["domain"] == [DOMAIN, "sensor", "input_number", "number", "switch"]
+    assert "include_entities" not in config
 
 
 # --- Tests for preprocess_choose_selector_input ---

--- a/custom_components/haeo/flows/tests/test_field_schema.py
+++ b/custom_components/haeo/flows/tests/test_field_schema.py
@@ -962,6 +962,13 @@ def test_build_entity_selector_without_include_entities(hass: HomeAssistant) -> 
     assert "include_entities" not in config
 
 
+def test_build_entity_selector_with_empty_include_entities(hass: HomeAssistant) -> None:
+    """Empty unit-filtered list does not fall back to a HAEO-only whitelist."""
+    selector = build_entity_selector(include_entities=[])
+    config = selector.config
+    assert "include_entities" not in config
+
+
 # --- Tests for preprocess_choose_selector_input ---
 
 

--- a/custom_components/haeo/flows/tests/test_policy_flows.py
+++ b/custom_components/haeo/flows/tests/test_policy_flows.py
@@ -142,11 +142,11 @@ async def test_user_step_shows_form(
     assert result.get("step_id") == "user"
 
 
-async def test_price_selector_uses_price_unit_filtering_not_haeo_only(
+async def test_price_selector_allows_entities_without_include_filter(
     hass: HomeAssistant,
     hub_entry: MockConfigEntry,
 ) -> None:
-    """Policy price entity picker uses unit filtering like other config flows."""
+    """Policy price entity picker allows broad Home Assistant entity selection."""
     hass.states.async_set("sensor.import_price", "0.25", {"unit_of_measurement": "$/kWh"})
     hass.states.async_set("sensor.grid_power", "1.5", {"unit_of_measurement": "kW"})
 
@@ -154,10 +154,9 @@ async def test_price_selector_uses_price_unit_filtering_not_haeo_only(
     price_selector = flow._build_price_selector()
     entity_choice = price_selector.config["choices"][CHOICE_ENTITY]
     entity_selector_config = entity_choice["selector"]["entity"]
-    include_entities = entity_selector_config["include_entities"]
 
-    assert "sensor.import_price" in include_entities
-    assert "sensor.grid_power" not in include_entities
+    assert entity_selector_config["domain"] == [DOMAIN, "sensor", "input_number", "number", "switch"]
+    assert "include_entities" not in entity_selector_config
 
 
 async def test_user_step_creates_entry_when_none_exists(

--- a/custom_components/haeo/flows/tests/test_policy_flows.py
+++ b/custom_components/haeo/flows/tests/test_policy_flows.py
@@ -41,7 +41,7 @@ from custom_components.haeo.flows.elements.policy import (
     POLICIES_TITLE,
     PolicySubentryFlowHandler,
 )
-from custom_components.haeo.flows.field_schema import CHOICE_NONE
+from custom_components.haeo.flows.field_schema import CHOICE_ENTITY, CHOICE_NONE
 
 
 @pytest.fixture
@@ -140,6 +140,18 @@ async def test_user_step_shows_form(
 
     assert result.get("type") == FlowResultType.FORM
     assert result.get("step_id") == "user"
+
+
+def test_price_selector_allows_all_home_assistant_entities(
+    hass: HomeAssistant,
+    hub_entry: MockConfigEntry,
+) -> None:
+    """Policy price entity picker is not restricted to HAEO entities only."""
+    flow = _create_flow(hass, hub_entry)
+    price_selector = flow._build_price_selector()
+    entity_choice = price_selector.config["choices"][CHOICE_ENTITY]
+    entity_selector_config = entity_choice["selector"]["entity"]
+    assert "include_entities" not in entity_selector_config
 
 
 async def test_user_step_creates_entry_when_none_exists(

--- a/custom_components/haeo/flows/tests/test_policy_flows.py
+++ b/custom_components/haeo/flows/tests/test_policy_flows.py
@@ -142,16 +142,22 @@ async def test_user_step_shows_form(
     assert result.get("step_id") == "user"
 
 
-def test_price_selector_allows_all_home_assistant_entities(
+async def test_price_selector_uses_price_unit_filtering_not_haeo_only(
     hass: HomeAssistant,
     hub_entry: MockConfigEntry,
 ) -> None:
-    """Policy price entity picker is not restricted to HAEO entities only."""
+    """Policy price entity picker uses unit filtering like other config flows."""
+    hass.states.async_set("sensor.import_price", "0.25", {"unit_of_measurement": "$/kWh"})
+    hass.states.async_set("sensor.grid_power", "1.5", {"unit_of_measurement": "kW"})
+
     flow = _create_flow(hass, hub_entry)
     price_selector = flow._build_price_selector()
     entity_choice = price_selector.config["choices"][CHOICE_ENTITY]
     entity_selector_config = entity_choice["selector"]["entity"]
-    assert "include_entities" not in entity_selector_config
+    include_entities = entity_selector_config["include_entities"]
+
+    assert "sensor.import_price" in include_entities
+    assert "sensor.grid_power" not in include_entities
 
 
 async def test_user_step_creates_entry_when_none_exists(

--- a/custom_components/haeo/flows/tests/test_surfaced_policy.py
+++ b/custom_components/haeo/flows/tests/test_surfaced_policy.py
@@ -57,9 +57,11 @@ from custom_components.haeo.core.schema.elements.policy import ELEMENT_TYPE as P
 from custom_components.haeo.core.schema.sections import CONF_CONNECTION
 from custom_components.haeo.elements import get_surfaced_input_fields
 from custom_components.haeo.flows.conftest import create_flow
+from custom_components.haeo.flows.field_schema import CHOICE_ENTITY
 from custom_components.haeo.flows.surfaced_policy import (
     POLICIES_TITLE,
     build_surfaced_defaults,
+    build_surfaced_schema_entries,
     find_policy_subentry,
     find_surfaced_rule,
     form_value_to_price,
@@ -346,6 +348,24 @@ def test_save_with_none_price_no_match_is_noop(
     )
     rules = _get_rules(hub_entry)
     assert len(rules) == 1
+
+
+# --- build_surfaced_schema_entries tests ---
+
+
+async def test_surfaced_schema_entries_use_price_unit_filtering(hass: HomeAssistant) -> None:
+    """Surfaced pricing fields use the same unit-based entity filtering as element flows."""
+    hass.states.async_set("sensor.import_price", "0.25", {"unit_of_measurement": "$/kWh"})
+    hass.states.async_set("sensor.grid_power", "1.5", {"unit_of_measurement": "kW"})
+
+    surfaced_fields = get_surfaced_input_fields(BATTERY_ELEMENT_TYPE)
+    entries = build_surfaced_schema_entries(hass, surfaced_fields)
+    _, charge_selector = entries[CONF_CHARGE_COST]
+    entity_selector_config = charge_selector.config["choices"][CHOICE_ENTITY]["selector"]["entity"]
+    include_entities = entity_selector_config["include_entities"]
+
+    assert "sensor.import_price" in include_entities
+    assert "sensor.grid_power" not in include_entities
 
 
 # --- build_surfaced_defaults tests ---


### PR DESCRIPTION

<img width="536" height="676" alt="image" src="https://github.com/user-attachments/assets/2c86d9cb-e415-4b70-9a11-a7ecc129ebe1" />

## Summary
- Allow standalone policy price selectors to use the normal Home Assistant entity picker instead of an exact `include_entities` whitelist.
- Keep unit-based entity filtering for surfaced policy pricing fields and shared selector behavior.
- Add regression coverage for unrestricted policy prices and surfaced price unit filtering.

## Test plan
- `uv run pytest custom_components/haeo/flows/tests/test_policy_flows.py`
- IDE lint diagnostics on edited files