### PR TITLE
Filter config flow entity pickers by unit compatibility

### DIFF
--- a/custom_components/haeo/core/data/loader/extractors/utils/tests/test_entity_metadata.py
+++ b/custom_components/haeo/core/data/loader/extractors/utils/tests/test_entity_metadata.py
@@ -3,9 +3,18 @@
 from homeassistant.const import UnitOfEnergy, UnitOfPower
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 
+from custom_components.haeo.const import DOMAIN
 from custom_components.haeo.core.data.loader.extractors import EntityMetadata
 from custom_components.haeo.flows.entity_metadata import extract_entity_metadata
+
+
+def _hub_entry(hass: HomeAssistant) -> MockConfigEntry:
+    """Create and register a hub config entry for metadata extraction."""
+    entry = MockConfigEntry(domain=DOMAIN, title="Test Hub")
+    entry.add_to_hass(hass)
+    return entry
 
 
 def test_entity_metadata_is_compatible_with_none_unit() -> None:
@@ -90,7 +99,7 @@ async def test_extract_entity_metadata_filters_domain(
     hass.states.async_set("sensor.power", "100", {"unit_of_measurement": "kW"})
     hass.states.async_set("input_number.value", "50", {"unit_of_measurement": "%"})
 
-    result = extract_entity_metadata(hass)
+    result = extract_entity_metadata(hass, _hub_entry(hass))
 
     # Should only include sensor and input_number, not light
     assert len(result) == 2
@@ -123,7 +132,7 @@ async def test_extract_entity_metadata_skips_none_state(
     hass.states.async_set("sensor.power", "100", {"unit_of_measurement": "kW"})
     # sensor.missing will have None state
 
-    result = extract_entity_metadata(hass)
+    result = extract_entity_metadata(hass, _hub_entry(hass))
 
     # Should only include entities with valid state
     assert len(result) == 1
@@ -153,7 +162,7 @@ async def test_extract_entity_metadata_includes_none_unit(
     hass.states.async_set("sensor.power", "100", {"unit_of_measurement": "kW"})
     hass.states.async_set("sensor.no_unit", "on", {})  # No unit_of_measurement
 
-    result = extract_entity_metadata(hass)
+    result = extract_entity_metadata(hass, _hub_entry(hass))
 
     # Should include both entities (with and without units) for exclusion mask
     assert len(result) == 2
@@ -185,9 +194,57 @@ async def test_extract_entity_metadata_uses_get_extracted_units(
         },
     )
 
-    result = extract_entity_metadata(hass)
+    result = extract_entity_metadata(hass, _hub_entry(hass))
 
     # Should extract unit using get_extracted_units
     assert len(result) == 1
     assert result[0].entity_id == "sensor.forecast"
     assert result[0].unit_of_measurement == "kW"
+
+
+async def test_extract_entity_metadata_excludes_own_hub_entities(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Entities created by this hub are excluded to prevent self-referential loops."""
+    hub_entry = _hub_entry(hass)
+
+    own_entity = entity_registry.async_get_or_create(
+        domain="number",
+        platform=DOMAIN,
+        unique_id="hub_price_input",
+        suggested_object_id="hub_price",
+        config_entry=hub_entry,
+    )
+    hass.states.async_set(own_entity.entity_id, "0.25", {"unit_of_measurement": "$/kWh"})
+    hass.states.async_set("sensor.external_price", "0.30", {"unit_of_measurement": "$/kWh"})
+
+    result = extract_entity_metadata(hass, hub_entry)
+
+    entity_ids = {meta.entity_id for meta in result}
+    assert own_entity.entity_id not in entity_ids
+    assert "sensor.external_price" in entity_ids
+
+
+async def test_extract_entity_metadata_includes_other_hub_entities(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Entities from a different hub remain selectable."""
+    hub_entry = _hub_entry(hass)
+    other_hub = MockConfigEntry(domain=DOMAIN, title="Other Hub")
+    other_hub.add_to_hass(hass)
+
+    other_entity = entity_registry.async_get_or_create(
+        domain="number",
+        platform=DOMAIN,
+        unique_id="other_price_input",
+        suggested_object_id="other_price",
+        config_entry=other_hub,
+    )
+    hass.states.async_set(other_entity.entity_id, "0.25", {"unit_of_measurement": "$/kWh"})
+
+    result = extract_entity_metadata(hass, hub_entry)
+
+    entity_ids = {meta.entity_id for meta in result}
+    assert other_entity.entity_id in entity_ids

--- a/custom_components/haeo/flows/elements/battery.py
+++ b/custom_components/haeo/flows/elements/battery.py
@@ -142,7 +142,7 @@ class BatterySubentryFlowHandler(ElementFlowMixin, ConfigSubentryFlow):
             config = self._build_config(user_input, {})
             return self._finalize(config)
 
-        entity_metadata = extract_entity_metadata(self.hass)
+        entity_metadata = extract_entity_metadata(self.hass, self._get_entry())
         section_inclusion_map = build_sectioned_inclusion_map(input_fields, entity_metadata)
         schema = self._build_schema(
             participants,
@@ -176,7 +176,7 @@ class BatterySubentryFlowHandler(ElementFlowMixin, ConfigSubentryFlow):
             return self._finalize(config)
 
         input_fields = get_input_fields(ELEMENT_TYPE)
-        entity_metadata = extract_entity_metadata(self.hass)
+        entity_metadata = extract_entity_metadata(self.hass, self._get_entry())
         section_inclusion_map = build_sectioned_inclusion_map(input_fields, entity_metadata)
 
         schema = self._build_partition_schema(input_fields, section_inclusion_map, subentry_data)
@@ -196,7 +196,7 @@ class BatterySubentryFlowHandler(ElementFlowMixin, ConfigSubentryFlow):
         """Build the schema with name, connection, and choose selectors for main inputs."""
         field_schema = get_input_field_schema_info(ELEMENT_TYPE, input_fields)
         surfaced_fields = get_surfaced_input_fields(ELEMENT_TYPE)
-        surfaced_entries = build_surfaced_schema_entries(surfaced_fields)
+        surfaced_entries = build_surfaced_schema_entries(self.hass, self._get_entry(), surfaced_fields)
         return build_sectioned_choose_schema(
             self._get_sections(),
             input_fields,

--- a/custom_components/haeo/flows/elements/battery_section.py
+++ b/custom_components/haeo/flows/elements/battery_section.py
@@ -57,7 +57,7 @@ class BatterySectionSubentryFlowHandler(ElementFlowMixin, ConfigSubentryFlow):
             config = self._build_config(user_input)
             return self._finalize(config, user_input)
 
-        entity_metadata = extract_entity_metadata(self.hass)
+        entity_metadata = extract_entity_metadata(self.hass, self._get_entry())
         section_inclusion_map = build_sectioned_inclusion_map(input_fields, entity_metadata)
 
         schema = self._build_schema(

--- a/custom_components/haeo/flows/elements/connection.py
+++ b/custom_components/haeo/flows/elements/connection.py
@@ -128,7 +128,7 @@ class ConnectionSubentryFlowHandler(ElementFlowMixin, ConfigSubentryFlow):
             config = self._build_config(user_input)
             return self._finalize(config, user_input)
 
-        entity_metadata = extract_entity_metadata(self.hass)
+        entity_metadata = extract_entity_metadata(self.hass, self._get_entry())
         section_inclusion_map = build_sectioned_inclusion_map(input_fields, entity_metadata)
         schema = self._build_schema(
             participants,

--- a/custom_components/haeo/flows/elements/grid.py
+++ b/custom_components/haeo/flows/elements/grid.py
@@ -70,7 +70,7 @@ class GridSubentryFlowHandler(ElementFlowMixin, ConfigSubentryFlow):
             config = self._build_config(user_input)
             return self._finalize(config, user_input)
 
-        entity_metadata = extract_entity_metadata(self.hass)
+        entity_metadata = extract_entity_metadata(self.hass, self._get_entry())
         section_inclusion_map = build_sectioned_inclusion_map(input_fields, entity_metadata)
         schema = self._build_schema(
             participants,

--- a/custom_components/haeo/flows/elements/inverter.py
+++ b/custom_components/haeo/flows/elements/inverter.py
@@ -73,7 +73,7 @@ class InverterSubentryFlowHandler(ElementFlowMixin, ConfigSubentryFlow):
             config = self._build_config(user_input)
             return self._finalize(config, user_input)
 
-        entity_metadata = extract_entity_metadata(self.hass)
+        entity_metadata = extract_entity_metadata(self.hass, self._get_entry())
         section_inclusion_map = build_sectioned_inclusion_map(input_fields, entity_metadata)
 
         schema = self._build_schema(

--- a/custom_components/haeo/flows/elements/load.py
+++ b/custom_components/haeo/flows/elements/load.py
@@ -77,7 +77,7 @@ class LoadSubentryFlowHandler(ElementFlowMixin, ConfigSubentryFlow):
             config = self._build_config(user_input)
             return self._finalize(config, user_input)
 
-        entity_metadata = extract_entity_metadata(self.hass)
+        entity_metadata = extract_entity_metadata(self.hass, self._get_entry())
         section_inclusion_map = build_sectioned_inclusion_map(input_fields, entity_metadata)
         schema = self._build_schema(
             participants,
@@ -116,7 +116,7 @@ class LoadSubentryFlowHandler(ElementFlowMixin, ConfigSubentryFlow):
         """Build the schema with name, connection, and choose selectors for inputs."""
         field_schema = get_input_field_schema_info(ELEMENT_TYPE, input_fields)
         surfaced_fields = get_surfaced_input_fields(ELEMENT_TYPE)
-        surfaced_entries = build_surfaced_schema_entries(surfaced_fields)
+        surfaced_entries = build_surfaced_schema_entries(self.hass, self._get_entry(), surfaced_fields)
         return build_sectioned_choose_schema(
             self._get_sections(),
             input_fields,

--- a/custom_components/haeo/flows/elements/policy.py
+++ b/custom_components/haeo/flows/elements/policy.py
@@ -46,7 +46,8 @@ from custom_components.haeo.core.schema.elements.policy import (
 from custom_components.haeo.core.schema.entity_value import as_entity_value, is_entity_value
 from custom_components.haeo.elements import get_list_input_fields
 from custom_components.haeo.elements.input_fields import InputFieldInfo
-from custom_components.haeo.flows.element_flow import ElementFlowMixin
+from custom_components.haeo.flows.element_flow import ElementFlowMixin, build_inclusion_map
+from custom_components.haeo.flows.entity_metadata import extract_entity_metadata
 from custom_components.haeo.flows.field_schema import (
     CHOICE_CONSTANT,
     CHOICE_ENTITY,
@@ -171,9 +172,12 @@ class PolicySubentryFlowHandler(ElementFlowMixin, ConfigSubentryFlow):
     def _build_price_selector(self) -> NormalizingChooseSelector:
         """Build a ChooseSelector for the price field (entity/constant)."""
         field_info = self._get_price_field_info()
+        entity_metadata = extract_entity_metadata(self.hass, self._get_entry())
+        inclusion_map = build_inclusion_map({CONF_PRICE: field_info}, entity_metadata)
         return build_choose_selector(
             field_info,
             allowed_choices={CHOICE_ENTITY, CHOICE_CONSTANT},
+            include_entities=inclusion_map.get(CONF_PRICE),
             multiple=True,
             preferred_choice=CHOICE_CONSTANT,
         )

--- a/custom_components/haeo/flows/elements/solar.py
+++ b/custom_components/haeo/flows/elements/solar.py
@@ -61,7 +61,7 @@ class SolarSubentryFlowHandler(ElementFlowMixin, ConfigSubentryFlow):
             config = self._build_config(user_input)
             return self._finalize(config, user_input)
 
-        entity_metadata = extract_entity_metadata(self.hass)
+        entity_metadata = extract_entity_metadata(self.hass, self._get_entry())
         section_inclusion_map = build_sectioned_inclusion_map(input_fields, entity_metadata)
         schema = self._build_schema(
             participants,

--- a/custom_components/haeo/flows/entity_metadata.py
+++ b/custom_components/haeo/flows/entity_metadata.py
@@ -19,9 +19,7 @@ def extract_entity_metadata(hass: HomeAssistant, hub_entry: ConfigEntry) -> list
     repeated entity registry and state lookups.
     """
     registry = er.async_get(hass)
-    own_entity_ids = {
-        entry.entity_id for entry in er.async_entries_for_config_entry(registry, hub_entry.entry_id)
-    }
+    own_entity_ids = {entry.entity_id for entry in er.async_entries_for_config_entry(registry, hub_entry.entry_id)}
 
     entities: list[EntityMetadata] = []
     for state in hass.states.async_all():

--- a/custom_components/haeo/flows/entity_metadata.py
+++ b/custom_components/haeo/flows/entity_metadata.py
@@ -1,19 +1,32 @@
 """Home Assistant entity metadata extraction."""
 
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import entity_registry as er
 
 from custom_components.haeo.core.data.loader.extractors import EntityMetadata, extract
 
 
-def extract_entity_metadata(hass: HomeAssistant) -> list[EntityMetadata]:
-    """Extract metadata for all sensor and input_number entities.
+def extract_entity_metadata(hass: HomeAssistant, hub_entry: ConfigEntry) -> list[EntityMetadata]:
+    """Extract metadata for selectable entities, excluding this hub's own entities.
+
+    Entities created by this hub's config entry (e.g. HAEO input number/switch
+    entities) are excluded so an element cannot reference a value produced by the
+    same hub, which would create a confusing feedback loop.
 
     This should be called once and the result passed to schema_for_type to avoid
     repeated entity registry and state lookups.
     """
+    registry = er.async_get(hass)
+    own_entity_ids = {
+        entry.entity_id for entry in er.async_entries_for_config_entry(registry, hub_entry.entry_id)
+    }
+
     entities: list[EntityMetadata] = []
     for state in hass.states.async_all():
+        if state.entity_id in own_entity_ids:
+            continue
         try:
             unit = extract(state).unit
         except (ValueError, KeyError, HomeAssistantError):

--- a/custom_components/haeo/flows/field_schema.py
+++ b/custom_components/haeo/flows/field_schema.py
@@ -11,9 +11,7 @@ from numbers import Real
 from typing import Any
 
 from homeassistant.components.number import NumberEntityDescription
-from homeassistant.core import async_get_hass
 from homeassistant.data_entry_flow import section
-from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.selector import (
     BooleanSelector,
     BooleanSelectorConfig,
@@ -118,58 +116,12 @@ def boolean_selector_from_field() -> BooleanSelector:  # type: ignore[type-arg]
     return BooleanSelector(BooleanSelectorConfig())
 
 
-def get_haeo_input_entity_ids() -> list[str]:
-    """Get all HAEO-created input entity IDs.
-
-    Returns all entity IDs for HAEO input entities (number/switch) that were
-    created for configurable fields. These should always be included in entity
-    pickers so they can be re-selected during reconfiguration.
-
-    Returns:
-        List of entity IDs for HAEO input entities.
-
-    """
-    hass = async_get_hass()
-    registry = er.async_get(hass)
-    return [
-        entry.entity_id
-        for entry in registry.entities.values()
-        if entry.platform == DOMAIN and entry.domain in ("number", "switch")
-    ]
-
-
-def resolve_haeo_input_entity_id(
-    entry_id: str,
-    subentry_id: str,
-    field_name: str,
-) -> str | None:
-    """Resolve the HAEO-created entity for a configured field.
-
-    When a user configures a field with a constant value, HAEO creates an
-    input entity (e.g., number.grid_export_limit). This function looks up
-    that resolved entity.
-
-    Args:
-        entry_id: The config entry ID.
-        subentry_id: The subentry ID for the element.
-        field_name: The field name (e.g., 'export_limit').
-
-    Returns:
-        The entity_id (e.g., 'number.grid_export_limit') or None if not found.
-
-    """
-    hass = async_get_hass()
-    registry = er.async_get(hass)
-    unique_id = f"{entry_id}_{subentry_id}_{field_name}"
-    return registry.async_get_entity_id("number", DOMAIN, unique_id)
-
-
 def build_entity_selector(
     *,
     include_entities: list[str] | None = None,
     multiple: bool = True,
 ) -> EntitySelector:  # type: ignore[type-arg]
-    """Build an EntitySelector for compatible entities.
+    """Build an EntitySelector restricted to unit-compatible entities.
 
     Args:
         include_entities: Entity IDs to include (compatible entities from unit filtering).
@@ -179,11 +131,7 @@ def build_entity_selector(
         EntitySelector configured with include_entities list.
 
     """
-    # Start with compatible entities from unit filtering
     entities_to_include = list(include_entities or [])
-
-    # Include all HAEO input entities so they can be re-selected during reconfigure
-    entities_to_include.extend(get_haeo_input_entity_ids())
 
     config_kwargs: dict[str, Any] = {
         "domain": [DOMAIN, "sensor", "input_number", "number", "switch"],
@@ -870,13 +818,11 @@ __all__ = [
     "convert_choose_data_to_config",
     "convert_sectioned_choose_data_to_config",
     "get_choose_default",
-    "get_haeo_input_entity_ids",
     "get_preferred_choice",
     "is_valid_choose_value",
     "number_selector_from_field",
     "preprocess_choose_selector_input",
     "preprocess_sectioned_choose_input",
-    "resolve_haeo_input_entity_id",
     "validate_choose_fields",
     "validate_sectioned_choose_fields",
 ]

--- a/custom_components/haeo/flows/surfaced_policy.py
+++ b/custom_components/haeo/flows/surfaced_policy.py
@@ -30,6 +30,8 @@ from custom_components.haeo.core.schema.elements.policy import (
 )
 from custom_components.haeo.core.schema.entity_value import EntityValue, as_entity_value, is_entity_value
 from custom_components.haeo.core.schema.field_hints import SurfacedPriceHint
+from custom_components.haeo.flows.element_flow import build_inclusion_map
+from custom_components.haeo.flows.entity_metadata import extract_entity_metadata
 from custom_components.haeo.flows.field_schema import (
     CHOICE_CONSTANT,
     CHOICE_ENTITY,
@@ -251,6 +253,8 @@ def build_surfaced_defaults(
 
 
 def build_surfaced_schema_entries(
+    hass: HomeAssistant,
+    hub_entry: ConfigEntry,
     surfaced_fields: Mapping[str, Any],
 ) -> dict[str, tuple[Any, Any]]:
     """Build vol.Schema entries for surfaced pricing fields.
@@ -258,12 +262,15 @@ def build_surfaced_schema_entries(
     Uses the standard build_choose_selector to create selectors from the
     InputFieldInfo objects.
     """
+    entity_metadata = extract_entity_metadata(hass, hub_entry)
+    inclusion_map = build_inclusion_map(dict(surfaced_fields), entity_metadata)
     return {
         field_info.field_name: (
             vol.Optional(field_info.field_name),
             build_choose_selector(
                 field_info,
                 allowed_choices={CHOICE_ENTITY, CHOICE_CONSTANT, CHOICE_NONE},
+                include_entities=inclusion_map.get(field_info.field_name),
                 multiple=True,
                 preferred_choice=CHOICE_CONSTANT,
             ),

--- a/custom_components/haeo/flows/tests/test_element_flow_inclusion.py
+++ b/custom_components/haeo/flows/tests/test_element_flow_inclusion.py
@@ -1,0 +1,76 @@
+"""Tests for config flow entity inclusion map unit filtering."""
+
+from homeassistant.components.number import NumberEntityDescription
+import pytest
+
+from custom_components.haeo.core.data.loader.extractors import EntityMetadata
+from custom_components.haeo.core.model.const import OutputType
+from custom_components.haeo.elements.input_fields import InputFieldInfo
+from custom_components.haeo.flows.element_flow import build_inclusion_map
+
+
+def _field(field_name: str, output_type: OutputType) -> InputFieldInfo[NumberEntityDescription]:
+    return InputFieldInfo(
+        field_name=field_name,
+        entity_description=NumberEntityDescription(key=field_name, name=field_name),
+        output_type=output_type,
+    )
+
+
+@pytest.mark.parametrize(
+    ("entity_id", "unit"),
+    [
+        ("sensor.power_w", "W"),
+        ("sensor.power_kw", "kW"),
+        ("sensor.power_mw", "MW"),
+    ],
+)
+def test_build_inclusion_map_includes_compatible_power_units(entity_id: str, unit: str) -> None:
+    """Power fields accept any Home Assistant power unit."""
+    entity_metadata = [
+        EntityMetadata(entity_id=entity_id, unit_of_measurement=unit),
+        EntityMetadata(entity_id="sensor.energy", unit_of_measurement="kWh"),
+    ]
+    inclusion_map = build_inclusion_map({"max_power": _field("max_power", OutputType.POWER_LIMIT)}, entity_metadata)
+
+    assert inclusion_map["max_power"] == [entity_id]
+
+
+@pytest.mark.parametrize(
+    ("entity_id", "unit"),
+    [
+        ("sensor.energy_wh", "Wh"),
+        ("sensor.energy_kwh", "kWh"),
+        ("sensor.energy_mwh", "MWh"),
+        ("sensor.energy_gwh", "GWh"),
+    ],
+)
+def test_build_inclusion_map_includes_compatible_energy_units(entity_id: str, unit: str) -> None:
+    """Energy fields accept any Home Assistant energy unit."""
+    entity_metadata = [
+        EntityMetadata(entity_id=entity_id, unit_of_measurement=unit),
+        EntityMetadata(entity_id="sensor.power", unit_of_measurement="kW"),
+    ]
+    inclusion_map = build_inclusion_map({"capacity": _field("capacity", OutputType.ENERGY)}, entity_metadata)
+
+    assert inclusion_map["capacity"] == [entity_id]
+
+
+@pytest.mark.parametrize(
+    ("entity_id", "unit"),
+    [
+        ("sensor.price_kwh", "$/kWh"),
+        ("sensor.price_mwh", "€/MWh"),
+        ("sensor.price_wh", "AUD/Wh"),
+        ("sensor.price_gwh", "£/GWh"),
+    ],
+)
+def test_build_inclusion_map_includes_compatible_price_units(entity_id: str, unit: str) -> None:
+    """Price fields accept any currency paired with a supported energy denominator."""
+    entity_metadata = [
+        EntityMetadata(entity_id=entity_id, unit_of_measurement=unit),
+        EntityMetadata(entity_id="sensor.power", unit_of_measurement="kW"),
+    ]
+    inclusion_map = build_inclusion_map({"price": _field("price", OutputType.PRICE)}, entity_metadata)
+
+    assert inclusion_map["price"] == [entity_id]

--- a/custom_components/haeo/flows/tests/test_field_schema.py
+++ b/custom_components/haeo/flows/tests/test_field_schema.py
@@ -37,13 +37,11 @@ from custom_components.haeo.flows.field_schema import (
     convert_choose_data_to_config,
     convert_sectioned_choose_data_to_config,
     get_choose_default,
-    get_haeo_input_entity_ids,
     get_preferred_choice,
     is_valid_choose_value,
     number_selector_from_field,
     preprocess_choose_selector_input,
     preprocess_sectioned_choose_input,
-    resolve_haeo_input_entity_id,
     validate_choose_fields,
     validate_sectioned_choose_fields,
 )
@@ -305,68 +303,6 @@ def test_get_preferred_choice_uses_current_data_boolean_constant() -> None:
     current_data = {"enabled": as_constant_value(value=True)}
     result = get_preferred_choice(field, current_data, allowed_choices=ALLOWED_CHOICES_REQUIRED)
     assert result == CHOICE_CONSTANT
-
-
-# --- Tests for get_haeo_input_entity_ids ---
-
-
-def test_get_haeo_input_entity_ids_returns_empty_for_no_haeo_entities(hass: HomeAssistant) -> None:
-    """get_haeo_input_entity_ids returns empty list when no HAEO input entities exist."""
-    registry = er.async_get(hass)
-    # Create non-HAEO entities only
-    registry.async_get_or_create(
-        domain="number",
-        platform="other_integration",
-        unique_id="external_number",
-        suggested_object_id="external",
-    )
-    result = get_haeo_input_entity_ids()
-    # Result should not include non-HAEO entities
-    assert "number.external" not in result
-
-
-def test_get_haeo_input_entity_ids_includes_haeo_number_and_switch(hass: HomeAssistant) -> None:
-    """get_haeo_input_entity_ids includes HAEO number and switch entities."""
-    registry = er.async_get(hass)
-    # Create HAEO number entity
-    number_entity = registry.async_get_or_create(
-        domain="number",
-        platform=DOMAIN,
-        unique_id="test_number",
-        suggested_object_id="haeo_number",
-    )
-    # Create HAEO switch entity
-    switch_entity = registry.async_get_or_create(
-        domain="switch",
-        platform=DOMAIN,
-        unique_id="test_switch",
-        suggested_object_id="haeo_switch",
-    )
-    # Create non-HAEO entity
-    registry.async_get_or_create(
-        domain="number",
-        platform="other_integration",
-        unique_id="external",
-        suggested_object_id="external_number",
-    )
-    result = get_haeo_input_entity_ids()
-    assert number_entity.entity_id in result
-    assert switch_entity.entity_id in result
-    assert "number.external_number" not in result
-
-
-def test_get_haeo_input_entity_ids_excludes_haeo_sensors(hass: HomeAssistant) -> None:
-    """get_haeo_input_entity_ids excludes HAEO sensor entities."""
-    registry = er.async_get(hass)
-    # Create HAEO sensor (not an input entity)
-    sensor_entity = registry.async_get_or_create(
-        domain="sensor",
-        platform=DOMAIN,
-        unique_id="test_sensor",
-        suggested_object_id="haeo_sensor",
-    )
-    result = get_haeo_input_entity_ids()
-    assert sensor_entity.entity_id not in result
 
 
 # --- Tests for get_choose_default ---
@@ -933,15 +869,6 @@ def test_get_preferred_choice_returns_none_when_no_choices() -> None:
     assert result == CHOICE_NONE
 
 
-# --- Tests for resolve_haeo_input_entity_id ---
-
-
-def test_resolve_haeo_input_entity_id_returns_none_when_not_found(hass: HomeAssistant) -> None:
-    """resolve_haeo_input_entity_id returns None when entity doesn't exist."""
-    result = resolve_haeo_input_entity_id("entry123", "subentry456", "test_field")
-    assert result is None
-
-
 # --- Tests for build_entity_selector ---
 
 
@@ -955,11 +882,29 @@ def test_build_entity_selector_with_include_entities(hass: HomeAssistant) -> Non
 
 
 def test_build_entity_selector_without_include_entities(hass: HomeAssistant) -> None:
-    """build_entity_selector with no include_entities still includes HAEO entities."""
+    """build_entity_selector with no include_entities does not restrict to a subset."""
     selector = build_entity_selector(include_entities=None)
     config = selector.config
-    # Even with None, HAEO input entities are added (if any exist)
     assert config["domain"] == [DOMAIN, "sensor", "input_number", "number", "switch"]
+    assert "include_entities" not in config
+
+
+def test_build_entity_selector_does_not_add_incompatible_haeo_entities(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """build_entity_selector only includes unit-compatible entities from include_entities."""
+    entity_registry.async_get_or_create(
+        domain="number",
+        platform=DOMAIN,
+        unique_id="grid_export_limit",
+        suggested_object_id="grid_export_limit",
+    )
+    selector = build_entity_selector(include_entities=["sensor.import_price"])
+    include_entities = selector.config.get("include_entities")
+
+    assert include_entities == ["sensor.import_price"]
+    assert "number.grid_export_limit" not in include_entities
 
 
 # --- Tests for preprocess_choose_selector_input ---

--- a/custom_components/haeo/flows/tests/test_policy_flows.py
+++ b/custom_components/haeo/flows/tests/test_policy_flows.py
@@ -140,14 +140,17 @@ async def test_build_price_selector_includes_compatible_price_entities(
     hub_entry: MockConfigEntry,
     entity_registry: er.EntityRegistry,
 ) -> None:
-    """Price entity picker includes price-compatible sensors, not only HAEO entities."""
+    """Price entity picker includes price-compatible sensors across energy scales."""
     haeo_number = entity_registry.async_get_or_create(
         domain="number",
         platform=DOMAIN,
         unique_id="policy_price_constant",
         suggested_object_id="policy_price",
+        config_entry=hub_entry,
     )
     hass.states.async_set("sensor.import_price", "0.25", {"unit_of_measurement": "$/kWh"})
+    hass.states.async_set("sensor.export_price", "0.05", {"unit_of_measurement": "€/MWh"})
+    hass.states.async_set("sensor.wholesale_price", "0.001", {"unit_of_measurement": "AUD/Wh"})
     hass.states.async_set("sensor.power_only", "5", {"unit_of_measurement": "kW"})
 
     flow = _create_flow(hass, hub_entry)
@@ -155,6 +158,8 @@ async def test_build_price_selector_includes_compatible_price_entities(
 
     assert include_entities is not None
     assert "sensor.import_price" in include_entities
+    assert "sensor.export_price" in include_entities
+    assert "sensor.wholesale_price" in include_entities
     assert "sensor.power_only" not in include_entities
     assert haeo_number.entity_id not in include_entities
 

--- a/custom_components/haeo/flows/tests/test_policy_flows.py
+++ b/custom_components/haeo/flows/tests/test_policy_flows.py
@@ -7,6 +7,7 @@ from unittest.mock import Mock
 from homeassistant.config_entries import ConfigSubentry
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers import entity_registry as er
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 import voluptuous as vol
@@ -41,7 +42,7 @@ from custom_components.haeo.flows.elements.policy import (
     POLICIES_TITLE,
     PolicySubentryFlowHandler,
 )
-from custom_components.haeo.flows.field_schema import CHOICE_NONE
+from custom_components.haeo.flows.field_schema import CHOICE_ENTITY, CHOICE_NONE
 
 
 @pytest.fixture
@@ -124,6 +125,38 @@ def _get_selector(result: Any, field_name: str) -> Any:
         if getattr(key, "schema", None) == field_name:
             return selector
     return None
+
+
+def _get_entity_include_entities(selector: Any) -> list[str] | None:
+    """Extract include_entities from the entity branch of a choose selector."""
+    entity_choice = selector.config["choices"][CHOICE_ENTITY]
+    entity_config = entity_choice["selector"]["entity"]
+    included = entity_config.get("include_entities")
+    return list(included) if included is not None else None
+
+
+async def test_build_price_selector_includes_compatible_price_entities(
+    hass: HomeAssistant,
+    hub_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Price entity picker includes price-compatible sensors, not only HAEO entities."""
+    haeo_number = entity_registry.async_get_or_create(
+        domain="number",
+        platform=DOMAIN,
+        unique_id="policy_price_constant",
+        suggested_object_id="policy_price",
+    )
+    hass.states.async_set("sensor.import_price", "0.25", {"unit_of_measurement": "$/kWh"})
+    hass.states.async_set("sensor.power_only", "5", {"unit_of_measurement": "kW"})
+
+    flow = _create_flow(hass, hub_entry)
+    include_entities = _get_entity_include_entities(flow._build_price_selector())
+
+    assert include_entities is not None
+    assert "sensor.import_price" in include_entities
+    assert "sensor.power_only" not in include_entities
+    assert haeo_number.entity_id not in include_entities
 
 
 # --- User step (adding a policy rule) ---

--- a/custom_components/haeo/flows/tests/test_surfaced_policy.py
+++ b/custom_components/haeo/flows/tests/test_surfaced_policy.py
@@ -7,11 +7,13 @@ from unittest.mock import Mock
 from homeassistant.config_entries import ConfigSubentry
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers import entity_registry as er
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from conftest import add_participant
 from custom_components.haeo import _cleanup_policy_rules
+from custom_components.haeo.const import DOMAIN
 from custom_components.haeo.core.const import CONF_ELEMENT_TYPE, CONF_NAME
 from custom_components.haeo.core.schema import as_constant_value, as_entity_value
 from custom_components.haeo.core.schema.elements import node
@@ -57,9 +59,11 @@ from custom_components.haeo.core.schema.elements.policy import ELEMENT_TYPE as P
 from custom_components.haeo.core.schema.sections import CONF_CONNECTION
 from custom_components.haeo.elements import get_surfaced_input_fields
 from custom_components.haeo.flows.conftest import create_flow
+from custom_components.haeo.flows.field_schema import CHOICE_ENTITY
 from custom_components.haeo.flows.surfaced_policy import (
     POLICIES_TITLE,
     build_surfaced_defaults,
+    build_surfaced_schema_entries,
     find_policy_subentry,
     find_surfaced_rule,
     form_value_to_price,
@@ -877,3 +881,31 @@ def test_cleanup_deduplicates_rules_after_stripping(
     rules = _get_rules(hub_entry)
     assert len(rules) == 1
     assert rules[0]["name"] == "first"
+
+
+def test_build_surfaced_schema_entries_includes_compatible_price_entities(
+    hass: HomeAssistant,
+    hub_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Surfaced price pickers include price-compatible sensors, not this hub's own entities."""
+    haeo_number = entity_registry.async_get_or_create(
+        domain="number",
+        platform=DOMAIN,
+        unique_id="surfaced_price_constant",
+        suggested_object_id="surfaced_price",
+        config_entry=hub_entry,
+    )
+    hass.states.async_set("sensor.import_price", "0.25", {"unit_of_measurement": "$/kWh"})
+    hass.states.async_set("sensor.power_only", "5", {"unit_of_measurement": "kW"})
+
+    surfaced_fields = get_surfaced_input_fields(LOAD_ELEMENT_TYPE)
+    _, selector = build_surfaced_schema_entries(hass, hub_entry, surfaced_fields)[CONF_CONSUMPTION_COST]
+
+    entity_choice = selector.config["choices"][CHOICE_ENTITY]
+    include_entities = entity_choice["selector"]["entity"].get("include_entities")
+
+    assert include_entities is not None
+    assert "sensor.import_price" in include_entities
+    assert "sensor.power_only" not in include_entities
+    assert haeo_number.entity_id not in include_entities

--- a/custom_components/haeo/flows/tests/test_surfaced_policy.py
+++ b/custom_components/haeo/flows/tests/test_surfaced_policy.py
@@ -897,6 +897,8 @@ def test_build_surfaced_schema_entries_includes_compatible_price_entities(
         config_entry=hub_entry,
     )
     hass.states.async_set("sensor.import_price", "0.25", {"unit_of_measurement": "$/kWh"})
+    hass.states.async_set("sensor.export_price", "0.05", {"unit_of_measurement": "€/MWh"})
+    hass.states.async_set("sensor.wholesale_price", "0.001", {"unit_of_measurement": "AUD/Wh"})
     hass.states.async_set("sensor.power_only", "5", {"unit_of_measurement": "kW"})
 
     surfaced_fields = get_surfaced_input_fields(LOAD_ELEMENT_TYPE)
@@ -907,5 +909,7 @@ def test_build_surfaced_schema_entries_includes_compatible_price_entities(
 
     assert include_entities is not None
     assert "sensor.import_price" in include_entities
+    assert "sensor.export_price" in include_entities
+    assert "sensor.wholesale_price" in include_entities
     assert "sensor.power_only" not in include_entities
     assert haeo_number.entity_id not in include_entities


### PR DESCRIPTION
## Summary

- Remove legacy pre-choose-selector helpers that unconditionally merged HAEO input entities into every entity picker
- Restrict entity pickers to unit-compatible entities via the existing inclusion map (e.g. `*/kWh` for price fields)
- Exclude entities owned by the current hub config entry to prevent self-referential configuration loops
- Wire unit filtering into policy price fields and surfaced policy pricing fields that were missing inclusion maps

## Test plan

- [x] `uv run pytest custom_components/haeo/flows/ custom_components/haeo/core/data/loader/extractors/utils/tests/test_entity_metadata.py`
- [ ] Verify policy rule price picker shows external price sensors with compatible units
- [ ] Verify load/battery surfaced price pickers do not show this hub's own number entities


Made with [Cursor](https://cursor.com)