### PR TITLE
Use trusted_networks auth for guide tests and sim

### DIFF
--- a/docs/developer-guide/local-sim.md
+++ b/docs/developer-guide/local-sim.md
@@ -61,7 +61,8 @@ uv run sim scenario1 --config-dir config --port 8123
 
 ## How it works
 
-1. **`tools/live_hass.py`** boots an in-process Home Assistant with HTTP, frontend, auth, and recorder (default: `config/` on port 8123). The sim binds HTTP to `127.0.0.1` and adds a `trusted_networks` provider with `allow_bypass_login`, so loopback requests log in automatically.
+1. **`tools/live_hass.py`** boots an in-process Home Assistant with HTTP, frontend, auth, and recorder (default: `config/` on port 8123).
+    The sim binds HTTP to `127.0.0.1` and adds a `trusted_networks` provider with `allow_bypass_login`, so loopback requests log in automatically.
 2. **`tools/time_shift.py`** applies a uniform timestamp delta to scenario input attributes.
 3. **`tools/sim.py`** runs a loop that recomputes the delta each tick, pushes shifted states via `hass.states.async_set()`, and optionally calls `setup_haeo_entry()` from the scenario config.
 

--- a/docs/developer-guide/local-sim.md
+++ b/docs/developer-guide/local-sim.md
@@ -11,10 +11,11 @@ This replaces the previous `config/packages/` command_line sensor workflow.
 uv run sim scenario1
 ```
 
-By default it uses the repo `config/` directory on port 8123, applies the scenario timezone, skips onboarding, and opens your browser to an auto-login page (same mechanism as guide tests, via frontend `localStorage` tokens).
+By default it uses the repo `config/` directory on port 8123, applies the scenario timezone, skips onboarding, and opens your browser to `http://127.0.0.1:8123/`.
 From there you can inspect entities, HAEO sensors, and the frontend while the simulator pushes updated input states on an interval.
 
-Use the `127.0.0.1` auto-login URL printed in the terminal — opening `localhost` directly will not match the stored auth client ID.
+Login is automatic: the instance registers a `trusted_networks` auth provider that logs in the single dev user for any request from loopback, so the frontend completes its OAuth flow without any token bootstrap.
+This is the same auth setup the guide tests use, so there is a single login mechanism across both runners.
 If auto-login does not take, `testuser` / `testpass` works as a fallback.
 
 ## Scenario data
@@ -55,12 +56,12 @@ uv run sim scenario1 --config-dir config --port 8123
 | `--no-config`  | off         | Skip automatic HAEO setup from `config.json`                            |
 | `--config-dir` | `config/`   | Home Assistant config directory                                         |
 | `--port`       | `8123`      | HTTP port                                                               |
-| `--no-open`    | off         | Do not open the browser to the auto-login page on startup               |
+| `--no-open`    | off         | Do not open the browser on startup                                      |
 | `--ephemeral`  | off         | Use a temporary config directory and ephemeral port                     |
 
 ## How it works
 
-1. **`tools/live_hass.py`** boots an in-process Home Assistant with HTTP, frontend, auth, and recorder (default: `config/` on port 8123).
+1. **`tools/live_hass.py`** boots an in-process Home Assistant with HTTP, frontend, auth, and recorder (default: `config/` on port 8123). The sim binds HTTP to `127.0.0.1` and adds a `trusted_networks` provider with `allow_bypass_login`, so loopback requests log in automatically.
 2. **`tools/time_shift.py`** applies a uniform timestamp delta to scenario input attributes.
 3. **`tools/sim.py`** runs a loop that recomputes the delta each tick, pushes shifted states via `hass.states.async_set()`, and optionally calls `setup_haeo_entry()` from the scenario config.
 

--- a/tests/guides/primitives/ha_page.py
+++ b/tests/guides/primitives/ha_page.py
@@ -158,8 +158,13 @@ class HAPage:
         should use click-based methods to demonstrate the real user flow.
         """
         full_url = f"{self.url}{path}" if path.startswith("/") else path
-        self.page.goto(full_url)
-        self.page.wait_for_load_state("networkidle")
+        # The initial load drives the trusted_networks auto-login redirect chain
+        # (/ -> /auth/authorize -> token exchange -> app), which takes longer than
+        # an in-app navigation, so allow a generous timeout. We keep networkidle
+        # here because callers inspect the URL immediately after this returns.
+        initial_load_timeout = 30000
+        self.page.goto(full_url, timeout=initial_load_timeout)
+        self.page.wait_for_load_state("networkidle", timeout=initial_load_timeout)
 
     def wait_for_load(self) -> None:
         """Wait for page to finish loading."""

--- a/tests/guides/primitives/ha_page.py
+++ b/tests/guides/primitives/ha_page.py
@@ -158,13 +158,17 @@ class HAPage:
         should use click-based methods to demonstrate the real user flow.
         """
         full_url = f"{self.url}{path}" if path.startswith("/") else path
-        # The initial load drives the trusted_networks auto-login redirect chain
-        # (/ -> /auth/authorize -> token exchange -> app), which takes longer than
-        # an in-app navigation, so allow a generous timeout. We keep networkidle
-        # here because callers inspect the URL immediately after this returns.
+        # Trusted-networks auto-login redirects through /auth/ before the app
+        # loads. Wait for that redirect chain, not networkidle — the frontend
+        # keeps a WebSocket open and OAuth pulls static assets whose aiohttp
+        # handlers must finish before the browser closes.
         initial_load_timeout = 30000
-        self.page.goto(full_url, timeout=initial_load_timeout)
-        self.page.wait_for_load_state("networkidle", timeout=initial_load_timeout)
+        self.page.goto(full_url, wait_until="domcontentloaded", timeout=initial_load_timeout)
+        if "/auth/" in self.page.url:
+            self.page.wait_for_url(
+                lambda url: "/auth/" not in url,
+                timeout=initial_load_timeout,
+            )
 
     def wait_for_load(self) -> None:
         """Wait for page to finish loading."""

--- a/tests/guides/primitives/ha_page.py
+++ b/tests/guides/primitives/ha_page.py
@@ -158,17 +158,13 @@ class HAPage:
         should use click-based methods to demonstrate the real user flow.
         """
         full_url = f"{self.url}{path}" if path.startswith("/") else path
-        # Trusted-networks auto-login redirects through /auth/ before the app
-        # loads. Wait for that redirect chain, not networkidle — the frontend
-        # keeps a WebSocket open and OAuth pulls static assets whose aiohttp
-        # handlers must finish before the browser closes.
+        # The initial load drives the trusted_networks auto-login redirect chain
+        # (/ -> /auth/authorize -> token exchange -> app), which takes longer than
+        # an in-app navigation, so allow a generous timeout. We keep networkidle
+        # here because callers inspect the URL immediately after this returns.
         initial_load_timeout = 30000
-        self.page.goto(full_url, wait_until="domcontentloaded", timeout=initial_load_timeout)
-        if "/auth/" in self.page.url:
-            self.page.wait_for_url(
-                lambda url: "/auth/" not in url,
-                timeout=initial_load_timeout,
-            )
+        self.page.goto(full_url, timeout=initial_load_timeout)
+        self.page.wait_for_load_state("networkidle", timeout=initial_load_timeout)
 
     def wait_for_load(self) -> None:
         """Wait for page to finish loading."""

--- a/tools/guide_runner.py
+++ b/tools/guide_runner.py
@@ -13,7 +13,6 @@ Usage:
 
 from __future__ import annotations
 
-import contextlib
 from dataclasses import dataclass, field
 import json
 import logging
@@ -319,10 +318,6 @@ def run_blocks_for_mode(
             raise
 
         finally:
-            # Drop any in-flight HA static requests before closing the browser so
-            # aiohttp file handlers are not left open when the HA loop shuts down.
-            with contextlib.suppress(Exception):
-                page_obj.goto("about:blank", wait_until="commit", timeout=5000)
             browser.close()
 
 

--- a/tools/guide_runner.py
+++ b/tools/guide_runner.py
@@ -278,7 +278,7 @@ def run_blocks_for_mode(
             viewport={"width": 1280, "height": 800},
             reduced_motion="reduce",
         )
-        hass.inject_auth(context, dark_mode=dark_mode)
+        hass.configure_context(context, dark_mode=dark_mode)
         page_obj = context.new_page()
         page_obj.set_default_timeout(5000)
 

--- a/tools/guide_runner.py
+++ b/tools/guide_runner.py
@@ -13,6 +13,7 @@ Usage:
 
 from __future__ import annotations
 
+import contextlib
 from dataclasses import dataclass, field
 import json
 import logging
@@ -318,6 +319,10 @@ def run_blocks_for_mode(
             raise
 
         finally:
+            # Drop any in-flight HA static requests before closing the browser so
+            # aiohttp file handlers are not left open when the HA loop shuts down.
+            with contextlib.suppress(Exception):
+                page_obj.goto("about:blank", wait_until="commit", timeout=5000)
             browser.close()
 
 

--- a/tools/live_hass.py
+++ b/tools/live_hass.py
@@ -9,7 +9,8 @@ The key insight is that we can:
 3. Load entity states directly via hass.states.async_set()
 4. Run the event loop in a background thread
 5. Access the HA instance from the main thread for Playwright automation
-6. Pre-create an owner user and auth token to bypass onboarding UI
+6. Pre-create the dev user and register a trusted_networks provider so loopback
+   browsers auto-login without minting tokens (shared with ``uv run sim``)
 
 This avoids needing config files, YAML, or packages - just load states from JSON.
 """
@@ -50,8 +51,65 @@ if TYPE_CHECKING:
 
 PROJECT_ROOT = Path(__file__).parent.parent
 
-# Client ID for refresh tokens (matches HA frontend)
-CLIENT_ID = "http://127.0.0.1/"
+# Loopback networks the trusted_networks auth provider auto-logs in from. Home
+# Assistant binds to all interfaces with a dual-stack socket, so IPv4 loopback
+# connections arrive as the IPv4-mapped form ``::ffff:127.0.0.1``.
+TRUSTED_LOOPBACK_NETWORKS = ["127.0.0.1/32", "::1/128", "::ffff:127.0.0.1/128"]
+
+
+def auth_provider_configs() -> list[dict[str, Any]]:
+    """Return the auth providers shared by the guide and sim runners.
+
+    The trusted_networks provider auto-logs in the single dev user for any
+    loopback request, so the frontend completes its OAuth flow without minting
+    tokens or injecting a bootstrap page. It must come first so the authorize
+    page starts its flow by default; homeassistant stays as a username/password
+    fallback.
+    """
+    return [
+        {
+            "type": "trusted_networks",
+            "trusted_networks": TRUSTED_LOOPBACK_NETWORKS,
+            "allow_bypass_login": True,
+        },
+        {"type": "homeassistant"},
+    ]
+
+
+async def ensure_dev_user(hass: HomeAssistant) -> None:
+    """Idempotently ensure a single ``Test User`` with testuser/testpass exists.
+
+    The trusted_networks provider only auto-logs in when exactly one non-system
+    user is available, so this is the sole user created for both runners.
+    """
+    provider = hass.auth.get_auth_provider("homeassistant", None)
+    if provider is None:
+        msg = "Home Assistant auth provider is not configured"
+        raise RuntimeError(msg)
+
+    users = await hass.auth.async_get_users()
+    for user in users:
+        for credential in user.credentials:
+            if credential.data.get("username") == "testuser":
+                return
+
+    await provider.async_add_auth("testuser", "testpass")  # pyright: ignore[reportAttributeAccessIssue]
+
+    owner = next(
+        (user for user in users if user.is_owner and not user.system_generated),
+        None,
+    )
+    if owner is None:
+        owner = await hass.auth.async_create_user(name="Test User", group_ids=["system-admin"])
+
+    credential = Credentials(
+        id="test-credential",
+        auth_provider_type="homeassistant",
+        auth_provider_id=None,
+        data={"username": "testuser"},
+        is_new=False,
+    )
+    await hass.auth.async_link_user(owner, credential)
 
 
 def _find_free_port() -> int:
@@ -73,6 +131,19 @@ async def _require_component(
         raise RuntimeError(msg)
 
 
+async def _ensure_http_started(hass: HomeAssistant) -> None:
+    """Start the HTTP server exactly once.
+
+    Setting up the frontend normally starts the server through Home Assistant's
+    ``async_when_setup_or_start`` lifecycle hook. That hook runs standalone but
+    not under pytest, so we start it ourselves when it has not already bound.
+    Guarding on the existing site avoids binding the socket twice, which would
+    orphan the already-listening server behind a failed second bind.
+    """
+    if hass.http.site is None:
+        await hass.http.start()
+
+
 @dataclass
 class LiveHomeAssistant:
     """A running Home Assistant instance with HTTP server.
@@ -85,8 +156,6 @@ class LiveHomeAssistant:
     url: str
     port: int
     loop: asyncio.AbstractEventLoop
-    access_token: str
-    refresh_token: str
     _stop_event: asyncio.Event
 
     def set_state(
@@ -138,40 +207,19 @@ class LiveHomeAssistant:
         future = asyncio.run_coroutine_threadsafe(async_wait_recording_done(self.hass), self.loop)
         future.result(timeout=timeout)
 
-    def inject_auth(self, context: BrowserContext, *, dark_mode: bool = False) -> None:
-        """Inject authentication into a Playwright browser context."""
-        from playwright.sync_api import Request, Route  # noqa: PLC0415
+    def configure_context(self, context: BrowserContext, *, dark_mode: bool = False) -> None:
+        """Apply browser preferences for a Playwright context.
 
-        def add_auth_header(route: Route, request: Request) -> None:
-            headers = {
-                **request.headers,
-                "Authorization": f"Bearer {self.access_token}",
-            }
-            route.continue_(headers=headers)
-
-        context.route("**/*", add_auth_header)
-
-        token_data = {
-            "hassUrl": self.url,
-            "clientId": CLIENT_ID,
-            "access_token": self.access_token,
-            "refresh_token": self.refresh_token,
-            "token_type": "Bearer",
-            "expires_in": 1800,
-        }
-
-        theme_js = ""
-        if dark_mode:
-            theme_data = {"theme": "default", "dark": True}
-            theme_js = f"""
-            localStorage.setItem('selectedTheme', JSON.stringify({json.dumps(theme_data)}));
-            """
-
-        init_script = f"""
-            localStorage.setItem('hassTokens', JSON.stringify({json.dumps(token_data)}));
-            {theme_js}
+        Authentication is automatic from loopback via the trusted_networks
+        provider, so this only seeds the dark mode theme when requested.
         """
-        context.add_init_script(init_script)
+        if not dark_mode:
+            return
+
+        theme_data = {"theme": "default", "dark": True}
+        context.add_init_script(
+            f"localStorage.setItem('selectedTheme', JSON.stringify({json.dumps(theme_data)}));",
+        )
 
     def call_service(
         self,
@@ -204,7 +252,7 @@ async def _setup_home_assistant_async(
     config_dir: str,
     *,
     timezone: str = "UTC",
-) -> tuple[HomeAssistant, str, str]:
+) -> HomeAssistant:
     """Set up a Home Assistant instance with HTTP server and pre-authenticated user."""
     storage_dir = Path(config_dir) / ".storage"
     storage_dir.mkdir(exist_ok=True)
@@ -246,38 +294,10 @@ async def _setup_home_assistant_async(
 
     hass.auth = await auth_manager_from_config(
         hass,
-        provider_configs=[{"type": "homeassistant"}],
+        provider_configs=auth_provider_configs(),
         module_configs=[],
     )
-
-    provider = hass.auth.auth_providers[0]
-    await provider.async_add_auth("testuser", "testpass")  # pyright: ignore[reportAttributeAccessIssue]
-
-    owner = await hass.auth.async_create_user(
-        name="Test User",
-        group_ids=["system-admin"],
-    )
-
-    credential = Credentials(
-        id="test-credential",
-        auth_provider_type="homeassistant",
-        auth_provider_id=None,
-        data={"username": "testuser"},
-        is_new=False,
-    )
-    await hass.auth.async_link_user(owner, credential)
-
-    refresh_token = await hass.auth.async_create_refresh_token(
-        owner,
-        CLIENT_ID,
-        credential=credential,
-    )
-    access_token = hass.auth.async_create_access_token(refresh_token)
-    refresh_token_value = refresh_token.token
-
-    http_config = {
-        "server_port": port,
-    }
+    await ensure_dev_user(hass)
 
     warnings.filterwarnings("ignore", category=DeprecationWarning, module="aiohttp")
     try:
@@ -287,7 +307,7 @@ async def _setup_home_assistant_async(
     except ImportError:
         pass
 
-    await _require_component(hass, "http", {"http": http_config})
+    await _require_component(hass, "http", {"http": {"server_port": port}})
     await _require_component(hass, "websocket_api", {})
     await _require_component(hass, "auth", {})
     await _require_component(hass, "onboarding", {})
@@ -298,6 +318,8 @@ async def _setup_home_assistant_async(
         msg = "Onboarding bypass failed - check storage file format and timing"
         raise RuntimeError(msg)
 
+    # Setting up frontend starts the HTTP server (it is wired via
+    # async_when_setup_or_start), so we must not start it again ourselves.
     await _require_component(hass, "frontend", {})
     await _require_component(hass, "config", {})
 
@@ -313,9 +335,9 @@ async def _setup_home_assistant_async(
     hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
     await hass.async_block_till_done()
 
-    await hass.http.start()
+    await _ensure_http_started(hass)
 
-    return hass, access_token, refresh_token_value
+    return hass
 
 
 def _run_hass_thread(
@@ -323,7 +345,6 @@ def _run_hass_thread(
     config_dir: str,
     timezone: str,
     hass_holder: list[HomeAssistant],
-    token_holder: list[tuple[str, str]],
     loop_holder: list[asyncio.AbstractEventLoop],
     ready_event: threading.Event,
     async_stop_event_holder: list[asyncio.Event],
@@ -339,13 +360,12 @@ def _run_hass_thread(
         async_stop_event_holder.append(async_stop_event)
 
         try:
-            hass, access_token, refresh_token_value = await _setup_home_assistant_async(
+            hass = await _setup_home_assistant_async(
                 port,
                 config_dir,
                 timezone=timezone,
             )
             hass_holder.append(hass)
-            token_holder.append((access_token, refresh_token_value))
             ready_event.set()
 
             await async_stop_event.wait()
@@ -382,7 +402,6 @@ def live_home_assistant(
 
         port = _find_free_port()
         hass_holder: list[HomeAssistant] = []
-        token_holder: list[tuple[str, str]] = []
         loop_holder: list[asyncio.AbstractEventLoop] = []
         error_holder: list[Exception] = []
         async_stop_event_holder: list[asyncio.Event] = []
@@ -395,7 +414,6 @@ def live_home_assistant(
                 config_dir,
                 timezone,
                 hass_holder,
-                token_holder,
                 loop_holder,
                 ready_event,
                 async_stop_event_holder,
@@ -419,7 +437,6 @@ def live_home_assistant(
             raise error_holder[0]
 
         hass = hass_holder[0]
-        access_token, refresh_token_value = token_holder[0]
         loop = loop_holder[0]
         async_stop_event = async_stop_event_holder[0]
 
@@ -428,8 +445,6 @@ def live_home_assistant(
             url=f"http://127.0.0.1:{port}",
             port=port,
             loop=loop,
-            access_token=access_token,
-            refresh_token=refresh_token_value,
             _stop_event=async_stop_event,
         )
 

--- a/tools/sim.py
+++ b/tools/sim.py
@@ -27,7 +27,7 @@ from zoneinfo import ZoneInfo
 from freezegun import freeze_time
 
 from tools.live_hass import LiveHomeAssistant
-from tools.sim_hass import live_sim_home_assistant, publish_browser_auth, remove_browser_auth, setup_haeo_entry
+from tools.sim_hass import live_sim_home_assistant, setup_haeo_entry, wait_for_sim_idle
 from tools.time_shift import parse_anchor_timestamp, shift_timestamps
 
 PROJECT_ROOT = Path(__file__).parent.parent
@@ -181,11 +181,15 @@ def run_sim(
                 live_hass.run_coro(setup_haeo_entry(live_hass.hass, scenario_data["config"]))
                 _LOGGER.info("HAEO configured from %s", scenario_data["path"].name)
 
-            auth_url = publish_browser_auth(live_hass)
+            # Let any in-flight setup/reload work finish before opening the browser.
+            live_hass.run_coro(wait_for_sim_idle(live_hass.hass))
 
-            print(f"Home Assistant: {live_hass.url}/")
-            print(f"Auto-login: {auth_url}")
-            print("Fallback login: testuser / testpass")
+            # The trusted_networks auth provider auto-logs in from loopback, so
+            # opening the root URL is enough; no token bootstrap is required.
+            home_url = f"{live_hass.url}/"
+
+            print(f"Home Assistant: {home_url}")
+            print("Login: automatic from loopback (fallback: testuser / testpass)")
             print(f"Scenario: {scenario_data['path'].name}")
             print(f"Timezone: {timezone}")
             print(f"Config dir: {config_dir if config_dir is not None else 'ephemeral'}")
@@ -193,20 +197,17 @@ def run_sim(
             print("Press Ctrl+C to stop.")
 
             if open_browser:
-                webbrowser.open(auth_url)
+                webbrowser.open(home_url)
 
-            try:
-                run_sim_loop(
-                    live_hass,
-                    inputs=scenario_data["inputs"],
-                    anchor=anchor,
-                    timezone=timezone,
-                    interval=interval,
-                    speed=speed,
-                    time_freezer=time_freezer,
-                )
-            finally:
-                remove_browser_auth(live_hass)
+            run_sim_loop(
+                live_hass,
+                inputs=scenario_data["inputs"],
+                anchor=anchor,
+                timezone=timezone,
+                interval=interval,
+                speed=speed,
+                time_freezer=time_freezer,
+            )
     finally:
         if time_freezer is not None:
             time_freezer.stop()

--- a/tools/sim_hass.py
+++ b/tools/sim_hass.py
@@ -1,8 +1,9 @@
 """Sim-specific extensions for the live Home Assistant runner.
 
 ``uv run sim`` uses persistent config directories, port-specific auth client IDs,
-optional HAEO setup from scenario config, and a browser auto-login bootstrap page.
-Guide tests continue to use ``tools.live_hass`` directly.
+optional HAEO setup from scenario config, and a trusted-networks auth provider so
+the browser is always logged in from loopback. Guide tests continue to use
+``tools.live_hass`` directly.
 """
 
 from __future__ import annotations
@@ -20,8 +21,7 @@ import warnings
 
 from homeassistant import loader
 from homeassistant.auth import auth_manager_from_config
-from homeassistant.auth.models import Credentials
-from homeassistant.config_entries import ConfigEntries, ConfigSubentry
+from homeassistant.config_entries import ConfigEntries, ConfigEntryState, ConfigSubentry
 from homeassistant.const import EVENT_HOMEASSISTANT_STARTED
 from homeassistant.core import CoreState, HomeAssistant
 from homeassistant.helpers import area_registry as ar
@@ -50,14 +50,15 @@ from custom_components.haeo.core.const import (
     CONF_TIER_4_DURATION,
 )
 from custom_components.haeo.flows import HUB_SECTION_ADVANCED, HUB_SECTION_COMMON, HUB_SECTION_TIERS
-from tools.live_hass import PROJECT_ROOT, LiveHomeAssistant, _find_free_port, _require_component
-
-AUTH_BOOTSTRAP_FILENAME = "haeo-sim-login.html"
-
-
-def _client_id(port: int) -> str:
-    """Return the OAuth client ID for a live Home Assistant instance."""
-    return f"http://127.0.0.1:{port}/"
+from tools.live_hass import (
+    PROJECT_ROOT,
+    LiveHomeAssistant,
+    _ensure_http_started,
+    _find_free_port,
+    _require_component,
+    auth_provider_configs,
+    ensure_dev_user,
+)
 
 
 def _ensure_haeo_symlink(config_dir: Path) -> None:
@@ -69,88 +70,24 @@ def _ensure_haeo_symlink(config_dir: Path) -> None:
         haeo_target.symlink_to(PROJECT_ROOT / "custom_components" / "haeo")
 
 
-def _find_dev_user(users: list[Any]) -> Any | None:
-    """Return the developer user if one already exists in storage."""
-    for user in users:
-        if user.system_generated:
-            continue
-        if user.name == "Test User":
-            return user
-        for credential in user.credentials:
-            if credential.data.get("username") == "testuser":
-                return user
-
-    for user in users:
-        if user.is_owner and not user.system_generated:
-            return user
-
-    return None
+async def _remove_haeo_entries(hass: HomeAssistant) -> None:
+    """Remove HAEO config entries left from prior ``uv run sim`` sessions."""
+    for entry in list(hass.config_entries.async_entries(DOMAIN)):
+        if entry.state in (ConfigEntryState.LOADED, ConfigEntryState.SETUP_IN_PROGRESS):
+            await hass.config_entries.async_unload(entry.entry_id)
+        await hass.config_entries.async_remove(entry.entry_id)
+    await hass.async_block_till_done(wait_background_tasks=True)
 
 
-def _find_testuser(users: list[Any]) -> tuple[Any, Credentials] | None:
-    """Return the user and credential for testuser when already linked."""
-    for user in users:
-        for credential in user.credentials:
-            if credential.data.get("username") == "testuser":
-                return user, credential
-    return None
-
-
-async def _ensure_dev_auth(hass: HomeAssistant, *, port: int) -> tuple[str, str]:
-    """Ensure onboarding is bypassed and testuser credentials exist."""
-    from homeassistant.components.onboarding import async_is_onboarded  # noqa: PLC0415
-
-    if not async_is_onboarded(hass):
-        msg = "Onboarding bypass failed - check storage file format and timing"
-        raise RuntimeError(msg)
-
-    client_id = _client_id(port)
-    provider = hass.auth.auth_providers[0]
-    users = await hass.auth.async_get_users()
-    linked = _find_testuser(users)
-
-    if linked is None:
-        await provider.async_add_auth("testuser", "testpass")  # pyright: ignore[reportAttributeAccessIssue]
-        owner = _find_dev_user(users)
-        if owner is None:
-            owner = await hass.auth.async_create_user(
-                name="Test User",
-                group_ids=["system-admin"],
-            )
-        credential = Credentials(
-            id="test-credential",
-            auth_provider_type="homeassistant",
-            auth_provider_id=None,
-            data={"username": "testuser"},
-            is_new=False,
-        )
-        await hass.auth.async_link_user(owner, credential)
-    else:
-        owner, credential = linked
-
-    refresh_token = await hass.auth.async_create_refresh_token(
-        owner,
-        client_id,
-        credential=credential,
-    )
-    access_token = hass.auth.async_create_access_token(refresh_token)
-    return access_token, refresh_token.token
-
-
-def _auth_token_data(live_hass: LiveHomeAssistant) -> dict[str, object]:
-    """Return frontend localStorage token payload for a live instance."""
-    return {
-        "hassUrl": live_hass.url,
-        "clientId": _client_id(live_hass.port),
-        "access_token": live_hass.access_token,
-        "refresh_token": live_hass.refresh_token,
-        "token_type": "Bearer",
-        "expires_in": 1800,
-    }
+async def wait_for_sim_idle(hass: HomeAssistant) -> None:
+    """Wait until scheduled setup/reload work on the HA loop has finished."""
+    await hass.async_block_till_done(wait_background_tasks=True)
 
 
 async def setup_haeo_entry(hass: HomeAssistant, scenario_config: dict[str, Any]) -> MockConfigEntry:
     """Create and set up a HAEO hub config entry from scenario config data."""
+    await _remove_haeo_entries(hass)
+
     tiers_data = scenario_config.get("tiers") or scenario_config
     mock_config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -193,8 +130,8 @@ async def _setup_sim_home_assistant_async(
     config_dir: str,
     *,
     timezone: str,
-) -> tuple[HomeAssistant, str, str]:
-    """Bootstrap Home Assistant for sim with port-specific, idempotent dev auth."""
+) -> HomeAssistant:
+    """Bootstrap Home Assistant for sim with loopback auto-login dev auth."""
     storage_dir = Path(config_dir) / ".storage"
     storage_dir.mkdir(parents=True, exist_ok=True)
     onboarding_storage = storage_dir / "onboarding"
@@ -233,15 +170,15 @@ async def _setup_sim_home_assistant_async(
     await rs.async_load(hass)
     await hass.config_entries.async_initialize()
 
+    # Drop entries persisted from earlier sim runs so we do not boot into a
+    # pile of parallel HAEO setups that race the browser auto-login redirect.
+    await _remove_haeo_entries(hass)
+
     hass.auth = await auth_manager_from_config(
         hass,
-        provider_configs=[{"type": "homeassistant"}],
+        provider_configs=auth_provider_configs(),
         module_configs=[],
     )
-
-    http_config = {
-        "server_port": port,
-    }
 
     warnings.filterwarnings("ignore", category=DeprecationWarning, module="aiohttp")
     try:
@@ -251,12 +188,18 @@ async def _setup_sim_home_assistant_async(
     except ImportError:
         pass
 
-    await _require_component(hass, "http", {"http": http_config})
+    await _require_component(hass, "http", {"http": {"server_port": port}})
     await _require_component(hass, "websocket_api", {})
     await _require_component(hass, "auth", {})
     await _require_component(hass, "onboarding", {})
 
-    access_token, refresh_token_value = await _ensure_dev_auth(hass, port=port)
+    from homeassistant.components.onboarding import async_is_onboarded  # noqa: PLC0415
+
+    if not async_is_onboarded(hass):
+        msg = "Onboarding bypass failed - check storage file format and timing"
+        raise RuntimeError(msg)
+
+    await ensure_dev_user(hass)
 
     await _require_component(hass, "frontend", {})
     await _require_component(hass, "config", {})
@@ -273,9 +216,9 @@ async def _setup_sim_home_assistant_async(
     hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
     await hass.async_block_till_done()
 
-    await hass.http.start()
+    await _ensure_http_started(hass)
 
-    return hass, access_token, refresh_token_value
+    return hass
 
 
 def _run_sim_hass_thread(
@@ -283,7 +226,6 @@ def _run_sim_hass_thread(
     config_dir: str,
     timezone: str,
     hass_holder: list[HomeAssistant],
-    token_holder: list[tuple[str, str]],
     loop_holder: list[asyncio.AbstractEventLoop],
     ready_event: threading.Event,
     async_stop_event_holder: list[asyncio.Event],
@@ -299,13 +241,12 @@ def _run_sim_hass_thread(
         async_stop_event_holder.append(async_stop_event)
 
         try:
-            hass, access_token, refresh_token_value = await _setup_sim_home_assistant_async(
+            hass = await _setup_sim_home_assistant_async(
                 port,
                 config_dir,
                 timezone=timezone,
             )
             hass_holder.append(hass)
-            token_holder.append((access_token, refresh_token_value))
             ready_event.set()
 
             await async_stop_event.wait()
@@ -332,7 +273,6 @@ def _start_sim_home_assistant(
     _ensure_haeo_symlink(config_dir)
     resolved_port = port if port is not None else _find_free_port()
     hass_holder: list[HomeAssistant] = []
-    token_holder: list[tuple[str, str]] = []
     loop_holder: list[asyncio.AbstractEventLoop] = []
     error_holder: list[Exception] = []
     async_stop_event_holder: list[asyncio.Event] = []
@@ -345,7 +285,6 @@ def _start_sim_home_assistant(
             str(config_dir),
             timezone,
             hass_holder,
-            token_holder,
             loop_holder,
             ready_event,
             async_stop_event_holder,
@@ -369,7 +308,6 @@ def _start_sim_home_assistant(
         raise error_holder[0]
 
     hass = hass_holder[0]
-    access_token, refresh_token_value = token_holder[0]
     loop = loop_holder[0]
     async_stop_event = async_stop_event_holder[0]
 
@@ -378,46 +316,9 @@ def _start_sim_home_assistant(
         url=f"http://127.0.0.1:{resolved_port}",
         port=resolved_port,
         loop=loop,
-        access_token=access_token,
-        refresh_token=refresh_token_value,
         _stop_event=async_stop_event,
     )
     return instance, thread
-
-
-def publish_browser_auth(live_hass: LiveHomeAssistant) -> str:
-    """Write a same-origin bootstrap page that stores auth tokens for the frontend."""
-    config_dir = Path(live_hass.hass.config.config_dir)
-    www_dir = config_dir / "www"
-    www_dir.mkdir(parents=True, exist_ok=True)
-
-    token_data = _auth_token_data(live_hass)
-    bootstrap_path = www_dir / AUTH_BOOTSTRAP_FILENAME
-    bootstrap_path.write_text(
-        f"""<!DOCTYPE html>
-<html lang="en">
-  <head>
-    <meta charset="utf-8">
-    <title>HAEO Sim Login</title>
-  </head>
-  <body>
-    <script>
-      localStorage.setItem("hassTokens", JSON.stringify({json.dumps(token_data)}));
-      window.location.replace({json.dumps(f"{live_hass.url}/")});
-    </script>
-  </body>
-</html>
-""",
-        encoding="utf-8",
-    )
-    return f"{live_hass.url}/local/{AUTH_BOOTSTRAP_FILENAME}"
-
-
-def remove_browser_auth(live_hass: LiveHomeAssistant) -> None:
-    """Remove the temporary browser auth bootstrap page."""
-    bootstrap_path = Path(live_hass.hass.config.config_dir) / "www" / AUTH_BOOTSTRAP_FILENAME
-    if bootstrap_path.exists():
-        bootstrap_path.unlink()
 
 
 @contextmanager


### PR DESCRIPTION
## Summary

- Replace guide test token injection (`inject_auth` / localStorage bootstrap) and sim bootstrap HTML with a shared `trusted_networks` auth provider for loopback auto-login
- Centralize dev user setup in `auth_provider_configs()` and `ensure_dev_user()` used by both `tools/live_hass.py` and `tools/sim_hass.py`
- Open `uv run sim` at the root URL instead of a token bootstrap page; extend guide `HAPage.goto()` timeout for the OAuth redirect chain

Extracted from `refactor-input-store` so auth can land independently of input-store/policy work.

## Test plan

- [ ] `uv run sim scenario1` opens logged-in HA at root URL without bootstrap page
- [ ] Guide tests pass with trusted login: `uv run pytest tests/guides/test_guides.py -m guide`
- [ ] Fallback login `testuser` / `testpass` still works when needed


Made with [Cursor](https://cursor.com)