### PR TITLE
Handle policy-pruned connections in element adapters

### DIFF
--- a/custom_components/haeo/core/adapters/elements/battery.py
+++ b/custom_components/haeo/core/adapters/elements/battery.py
@@ -6,13 +6,12 @@ from typing import Any, Final, Literal
 
 import numpy as np
 
-from custom_components.haeo.core.adapters.output_utils import expect_output_data
+from custom_components.haeo.core.adapters.output_utils import connection_power, expect_output_data
 from custom_components.haeo.core.const import ConnectivityLevel
 from custom_components.haeo.core.model import ModelElementConfig, ModelOutputName, ModelOutputValue
 from custom_components.haeo.core.model import battery as model_battery
 from custom_components.haeo.core.model.const import OutputType
 from custom_components.haeo.core.model.elements import MODEL_ELEMENT_TYPE_BATTERY, MODEL_ELEMENT_TYPE_CONNECTION
-from custom_components.haeo.core.model.elements.connection import CONNECTION_POWER
 from custom_components.haeo.core.model.elements.segments import SegmentSpec, SocPricingSegmentSpec
 from custom_components.haeo.core.model.output_data import OutputData
 from custom_components.haeo.core.model.util import broadcast_to_sequence
@@ -218,12 +217,12 @@ class BatteryAdapter:
         **_kwargs: Any,
     ) -> Mapping[BatteryDeviceName, Mapping[BatteryOutputName, OutputData]]:
         """Map model outputs to battery-specific output names."""
-        # Power from connections (same pattern as solar/load/grid adapters)
-        discharge_conn = model_outputs[f"{name}:discharge"]
-        charge_conn = model_outputs[f"{name}:charge"]
+        discharge_conn = model_outputs.get(f"{name}:discharge")
+        charge_conn = model_outputs.get(f"{name}:charge")
+        period_count = len(expect_output_data(model_outputs[name][model_battery.BATTERY_POWER_CHARGE]).values)
 
-        power_discharge = replace(expect_output_data(discharge_conn[CONNECTION_POWER]), type=OutputType.POWER)
-        power_charge = replace(expect_output_data(charge_conn[CONNECTION_POWER]), type=OutputType.POWER, direction="-")
+        power_discharge = replace(connection_power(discharge_conn, period_count), type=OutputType.POWER)
+        power_charge = replace(connection_power(charge_conn, period_count), type=OutputType.POWER, direction="-")
 
         # Battery-internal outputs (energy, SOC, shadow prices)
         battery_outputs = {key: expect_output_data(value) for key, value in model_outputs[name].items()}

--- a/custom_components/haeo/core/adapters/elements/grid.py
+++ b/custom_components/haeo/core/adapters/elements/grid.py
@@ -7,12 +7,12 @@ from typing import Any, Final, Literal
 import numpy as np
 from numpy.typing import NDArray
 
-from custom_components.haeo.core.adapters.output_utils import expect_output_data
+from custom_components.haeo.core.adapters.output_utils import connection_power, expect_output_data
 from custom_components.haeo.core.const import ConnectivityLevel
 from custom_components.haeo.core.model import ModelElementConfig, ModelOutputName, ModelOutputValue
 from custom_components.haeo.core.model.const import OutputType
 from custom_components.haeo.core.model.elements import MODEL_ELEMENT_TYPE_CONNECTION, MODEL_ELEMENT_TYPE_NODE
-from custom_components.haeo.core.model.elements.connection import CONNECTION_POWER, CONNECTION_SEGMENTS
+from custom_components.haeo.core.model.elements.connection import CONNECTION_SEGMENTS
 from custom_components.haeo.core.model.output_data import OutputData
 from custom_components.haeo.core.model.util import broadcast_to_sequence
 from custom_components.haeo.core.schema import extract_connection_target
@@ -122,15 +122,15 @@ class GridAdapter:
         **_kwargs: Any,
     ) -> Mapping[GridDeviceName, Mapping[GridOutputName, OutputData]]:
         """Map model outputs to grid-specific output names."""
-        import_conn = model_outputs[f"{name}:import"]
-        export_conn = model_outputs[f"{name}:export"]
+        import_conn = model_outputs.get(f"{name}:import")
+        export_conn = model_outputs.get(f"{name}:export")
 
         grid_outputs: dict[GridOutputName, OutputData] = {}
 
         # source_target = grid to system = IMPORT
         # target_source = system to grid = EXPORT
-        power_import = expect_output_data(import_conn[CONNECTION_POWER])
-        power_export = expect_output_data(export_conn[CONNECTION_POWER])
+        power_import = connection_power(import_conn, len(periods))
+        power_export = connection_power(export_conn, len(periods))
 
         grid_outputs[GRID_POWER_EXPORT] = replace(power_export, type=OutputType.POWER, direction="-")
         grid_outputs[GRID_POWER_IMPORT] = replace(power_import, type=OutputType.POWER, direction="+")
@@ -176,13 +176,14 @@ class GridAdapter:
         )
 
         # Output the shadow prices from power_limit segments on each connection
-        shadow_price_mappings: tuple[tuple[Mapping[ModelOutputName, ModelOutputValue], GridOutputName], ...] = (
+        shadow_price_mappings: tuple[tuple[Mapping[ModelOutputName, ModelOutputValue] | None, GridOutputName], ...] = (
             (export_conn, GRID_POWER_MAX_EXPORT_PRICE),
             (import_conn, GRID_POWER_MAX_IMPORT_PRICE),
         )
         for conn, output_name in shadow_price_mappings:
             if (
-                isinstance(segments_output := conn.get(CONNECTION_SEGMENTS), Mapping)
+                conn is not None
+                and isinstance(segments_output := conn.get(CONNECTION_SEGMENTS), Mapping)
                 and isinstance(power_limit_outputs := segments_output.get("power_limit"), Mapping)
                 and (shadow := expect_output_data(power_limit_outputs.get("power_limit"))) is not None
             ):

--- a/custom_components/haeo/core/adapters/elements/inverter.py
+++ b/custom_components/haeo/core/adapters/elements/inverter.py
@@ -4,13 +4,13 @@ from collections.abc import Mapping
 from dataclasses import replace
 from typing import Any, Final, Literal
 
-from custom_components.haeo.core.adapters.output_utils import expect_output_data
+from custom_components.haeo.core.adapters.output_utils import connection_power, expect_output_data
 from custom_components.haeo.core.const import ConnectivityLevel
 from custom_components.haeo.core.model import ModelElementConfig, ModelOutputName, ModelOutputValue
 from custom_components.haeo.core.model.const import OutputType
 from custom_components.haeo.core.model.element import ELEMENT_POWER_BALANCE
 from custom_components.haeo.core.model.elements import MODEL_ELEMENT_TYPE_CONNECTION, MODEL_ELEMENT_TYPE_NODE
-from custom_components.haeo.core.model.elements.connection import CONNECTION_POWER, CONNECTION_SEGMENTS
+from custom_components.haeo.core.model.elements.connection import CONNECTION_SEGMENTS
 from custom_components.haeo.core.model.output_data import OutputData
 from custom_components.haeo.core.schema import extract_connection_target
 from custom_components.haeo.core.schema.elements import ElementType
@@ -113,11 +113,12 @@ class InverterAdapter:
         **_kwargs: Any,
     ) -> Mapping[InverterDeviceName, Mapping[InverterOutputName, OutputData]]:
         """Map model outputs to inverter-specific output names."""
-        forward_conn = model_outputs[f"{name}:dc_to_ac"]
-        reverse_conn = model_outputs[f"{name}:ac_to_dc"]
+        forward_conn = model_outputs.get(f"{name}:dc_to_ac")
+        reverse_conn = model_outputs.get(f"{name}:ac_to_dc")
         dc_bus = model_outputs[name]
-        power_forward = expect_output_data(forward_conn[CONNECTION_POWER])
-        power_reverse = expect_output_data(reverse_conn[CONNECTION_POWER])
+        period_count = len(expect_output_data(dc_bus[ELEMENT_POWER_BALANCE]).values)
+        power_forward = connection_power(forward_conn, period_count)
+        power_reverse = connection_power(reverse_conn, period_count)
 
         inverter_outputs: dict[InverterOutputName, OutputData] = {}
 
@@ -145,13 +146,17 @@ class InverterAdapter:
         inverter_outputs[INVERTER_DC_BUS_POWER_BALANCE] = expect_output_data(dc_bus[ELEMENT_POWER_BALANCE])
 
         # Shadow prices from power_limit segments on each connection
-        shadow_price_mappings: tuple[tuple[Mapping[ModelOutputName, ModelOutputValue], InverterOutputName], ...] = (
+        shadow_price_mappings: tuple[
+            tuple[Mapping[ModelOutputName, ModelOutputValue] | None, InverterOutputName],
+            ...,
+        ] = (
             (forward_conn, INVERTER_MAX_POWER_DC_TO_AC_PRICE),
             (reverse_conn, INVERTER_MAX_POWER_AC_TO_DC_PRICE),
         )
         for conn, output_name in shadow_price_mappings:
             if (
-                isinstance(segments_output := conn.get(CONNECTION_SEGMENTS), Mapping)
+                conn is not None
+                and isinstance(segments_output := conn.get(CONNECTION_SEGMENTS), Mapping)
                 and isinstance(power_limit_outputs := segments_output.get("power_limit"), Mapping)
                 and (shadow := expect_output_data(power_limit_outputs.get("power_limit"))) is not None
             ):

--- a/custom_components/haeo/core/adapters/elements/load.py
+++ b/custom_components/haeo/core/adapters/elements/load.py
@@ -4,12 +4,14 @@ from collections.abc import Mapping
 from dataclasses import replace
 from typing import Any, Final, Literal
 
+import numpy as np
+
 from custom_components.haeo.core.adapters.output_utils import connection_power, expect_output_data
 from custom_components.haeo.core.const import ConnectivityLevel
 from custom_components.haeo.core.model import ModelElementConfig, ModelOutputName, ModelOutputValue
 from custom_components.haeo.core.model.const import OutputType
 from custom_components.haeo.core.model.elements import MODEL_ELEMENT_TYPE_CONNECTION, MODEL_ELEMENT_TYPE_NODE
-from custom_components.haeo.core.model.elements.connection import CONNECTION_SEGMENTS
+from custom_components.haeo.core.model.elements.connection import CONNECTION_POWER, CONNECTION_SEGMENTS
 from custom_components.haeo.core.model.output_data import OutputData
 from custom_components.haeo.core.schema import extract_connection_target
 from custom_components.haeo.core.schema.elements import ElementType
@@ -88,7 +90,11 @@ class LoadAdapter:
         """Map model outputs to load-specific output names."""
         connection = model_outputs.get(f"{name}:connection")
         fixed = not config[SECTION_CURTAILMENT].get(CONF_CURTAILMENT, False)
-        period_count = len(config[SECTION_FORECAST][CONF_FORECAST])
+        forecast = config[SECTION_FORECAST][CONF_FORECAST]
+        if connection is not None:
+            period_count = len(expect_output_data(connection[CONNECTION_POWER]).values)
+        else:
+            period_count = int(np.atleast_1d(forecast).size)
 
         power = connection_power(connection, period_count)
         load_outputs: dict[LoadOutputName, OutputData] = {

--- a/custom_components/haeo/core/adapters/elements/load.py
+++ b/custom_components/haeo/core/adapters/elements/load.py
@@ -4,12 +4,12 @@ from collections.abc import Mapping
 from dataclasses import replace
 from typing import Any, Final, Literal
 
-from custom_components.haeo.core.adapters.output_utils import expect_output_data
+from custom_components.haeo.core.adapters.output_utils import connection_power, expect_output_data
 from custom_components.haeo.core.const import ConnectivityLevel
 from custom_components.haeo.core.model import ModelElementConfig, ModelOutputName, ModelOutputValue
 from custom_components.haeo.core.model.const import OutputType
 from custom_components.haeo.core.model.elements import MODEL_ELEMENT_TYPE_CONNECTION, MODEL_ELEMENT_TYPE_NODE
-from custom_components.haeo.core.model.elements.connection import CONNECTION_POWER, CONNECTION_SEGMENTS
+from custom_components.haeo.core.model.elements.connection import CONNECTION_SEGMENTS
 from custom_components.haeo.core.model.output_data import OutputData
 from custom_components.haeo.core.schema import extract_connection_target
 from custom_components.haeo.core.schema.elements import ElementType
@@ -86,17 +86,19 @@ class LoadAdapter:
         **_kwargs: Any,
     ) -> Mapping[LoadDeviceName, Mapping[LoadOutputName, OutputData]]:
         """Map model outputs to load-specific output names."""
-        connection = model_outputs[f"{name}:connection"]
+        connection = model_outputs.get(f"{name}:connection")
         fixed = not config[SECTION_CURTAILMENT].get(CONF_CURTAILMENT, False)
+        period_count = len(config[SECTION_FORECAST][CONF_FORECAST])
 
-        power = expect_output_data(connection[CONNECTION_POWER])
+        power = connection_power(connection, period_count)
         load_outputs: dict[LoadOutputName, OutputData] = {
             LOAD_POWER: replace(power, type=OutputType.POWER, direction="-", fixed=fixed),
         }
 
         # Shadow price from power_limit segment (if present)
         if (
-            isinstance(segments_output := connection.get(CONNECTION_SEGMENTS), Mapping)
+            connection is not None
+            and isinstance(segments_output := connection.get(CONNECTION_SEGMENTS), Mapping)
             and isinstance(power_limit_outputs := segments_output.get("power_limit"), Mapping)
             and (shadow := expect_output_data(power_limit_outputs.get("power_limit"))) is not None
         ):

--- a/custom_components/haeo/core/adapters/elements/solar.py
+++ b/custom_components/haeo/core/adapters/elements/solar.py
@@ -4,12 +4,12 @@ from collections.abc import Mapping
 from dataclasses import replace
 from typing import Any, Final, Literal
 
-from custom_components.haeo.core.adapters.output_utils import expect_output_data
+from custom_components.haeo.core.adapters.output_utils import connection_power, expect_output_data
 from custom_components.haeo.core.const import ConnectivityLevel
 from custom_components.haeo.core.model import ModelElementConfig, ModelOutputName, ModelOutputValue
 from custom_components.haeo.core.model.const import OutputType
 from custom_components.haeo.core.model.elements import MODEL_ELEMENT_TYPE_CONNECTION, MODEL_ELEMENT_TYPE_NODE
-from custom_components.haeo.core.model.elements.connection import CONNECTION_POWER, CONNECTION_SEGMENTS
+from custom_components.haeo.core.model.elements.connection import CONNECTION_SEGMENTS
 from custom_components.haeo.core.model.output_data import OutputData
 from custom_components.haeo.core.schema import extract_connection_target
 from custom_components.haeo.core.schema.elements import ElementType
@@ -84,17 +84,19 @@ class SolarAdapter:
         **_kwargs: Any,
     ) -> Mapping[SolarDeviceName, Mapping[SolarOutputName, OutputData]]:
         """Map model outputs to solar-specific output names."""
-        connection = model_outputs[f"{name}:connection"]
+        connection = model_outputs.get(f"{name}:connection")
         fixed = not config[SECTION_CURTAILMENT].get(CONF_CURTAILMENT, True)
+        period_count = len(config[SECTION_FORECAST][CONF_FORECAST])
 
-        power = expect_output_data(connection[CONNECTION_POWER])
+        power = connection_power(connection, period_count)
         solar_outputs: dict[SolarOutputName, OutputData] = {
             SOLAR_POWER: replace(power, type=OutputType.POWER, fixed=fixed),
         }
 
         # Shadow price from power_limit segment (if present)
         if (
-            isinstance(segments_output := connection.get(CONNECTION_SEGMENTS), Mapping)
+            connection is not None
+            and isinstance(segments_output := connection.get(CONNECTION_SEGMENTS), Mapping)
             and isinstance(power_limit_outputs := segments_output.get("power_limit"), Mapping)
             and (shadow := expect_output_data(power_limit_outputs.get("power_limit"))) is not None
         ):

--- a/custom_components/haeo/core/adapters/elements/solar.py
+++ b/custom_components/haeo/core/adapters/elements/solar.py
@@ -4,12 +4,14 @@ from collections.abc import Mapping
 from dataclasses import replace
 from typing import Any, Final, Literal
 
+import numpy as np
+
 from custom_components.haeo.core.adapters.output_utils import connection_power, expect_output_data
 from custom_components.haeo.core.const import ConnectivityLevel
 from custom_components.haeo.core.model import ModelElementConfig, ModelOutputName, ModelOutputValue
 from custom_components.haeo.core.model.const import OutputType
 from custom_components.haeo.core.model.elements import MODEL_ELEMENT_TYPE_CONNECTION, MODEL_ELEMENT_TYPE_NODE
-from custom_components.haeo.core.model.elements.connection import CONNECTION_SEGMENTS
+from custom_components.haeo.core.model.elements.connection import CONNECTION_POWER, CONNECTION_SEGMENTS
 from custom_components.haeo.core.model.output_data import OutputData
 from custom_components.haeo.core.schema import extract_connection_target
 from custom_components.haeo.core.schema.elements import ElementType
@@ -86,7 +88,11 @@ class SolarAdapter:
         """Map model outputs to solar-specific output names."""
         connection = model_outputs.get(f"{name}:connection")
         fixed = not config[SECTION_CURTAILMENT].get(CONF_CURTAILMENT, True)
-        period_count = len(config[SECTION_FORECAST][CONF_FORECAST])
+        forecast = config[SECTION_FORECAST][CONF_FORECAST]
+        if connection is not None:
+            period_count = len(expect_output_data(connection[CONNECTION_POWER]).values)
+        else:
+            period_count = int(np.atleast_1d(forecast).size)
 
         power = connection_power(connection, period_count)
         solar_outputs: dict[SolarOutputName, OutputData] = {

--- a/custom_components/haeo/core/adapters/elements/tests/test_battery_model.py
+++ b/custom_components/haeo/core/adapters/elements/tests/test_battery_model.py
@@ -330,6 +330,82 @@ OUTPUTS_CASES: Sequence[OutputsCase] = [
         },
     },
     {
+        "description": "Battery charge connection pruned - charge carries no flow",
+        "name": "battery_no_balance",
+        "data": BatteryConfigData(
+            element_type=ElementType.BATTERY,
+            name="battery_no_balance",
+            connection=as_connection_target("network"),
+            storage={
+                "capacity": np.array([10.0, 10.0]),
+                "initial_charge_percentage": 0.5,
+            },
+            limits={
+                "min_charge_percentage": np.array([0.0, 0.0]),
+                "max_charge_percentage": np.array([1.0, 1.0]),
+            },
+            power_limits={
+                "max_power_source_target": np.array([5.0]),
+                "max_power_target_source": np.array([5.0]),
+            },
+            pricing={
+                "salvage_value": 0.0,
+            },
+            efficiency={
+                "efficiency_source_target": np.array([0.95]),
+                "efficiency_target_source": np.array([0.95]),
+            },
+            partitioning={},
+            undercharge={},
+            overcharge={},
+        ),
+        "model_outputs": {
+            "battery_no_balance": {
+                battery_model.BATTERY_POWER_CHARGE: OutputData(
+                    type=OutputType.POWER, unit="kW", values=(0.0,), direction="-"
+                ),
+                battery_model.BATTERY_POWER_DISCHARGE: OutputData(
+                    type=OutputType.POWER, unit="kW", values=(0.5,), direction="+"
+                ),
+                battery_model.BATTERY_ENERGY_STORED: OutputData(type=OutputType.ENERGY, unit="kWh", values=(4.0, 4.0)),
+                battery_model.BATTERY_POWER_BALANCE: OutputData(
+                    type=OutputType.SHADOW_PRICE, unit="$/kWh", values=(0.1,)
+                ),
+                battery_model.BATTERY_ENERGY_IN_FLOW: OutputData(
+                    type=OutputType.SHADOW_PRICE, unit="$/kWh", values=(0.0,)
+                ),
+                battery_model.BATTERY_ENERGY_OUT_FLOW: OutputData(
+                    type=OutputType.SHADOW_PRICE, unit="$/kWh", values=(0.0,)
+                ),
+                battery_model.BATTERY_SOC_MAX: OutputData(type=OutputType.SHADOW_PRICE, unit="$/kWh", values=(0.0,)),
+                battery_model.BATTERY_SOC_MIN: OutputData(type=OutputType.SHADOW_PRICE, unit="$/kWh", values=(0.0,)),
+            },
+            "battery_no_balance:discharge": {
+                connection.CONNECTION_POWER: OutputData(
+                    type=OutputType.POWER_FLOW, unit="kW", values=(0.5,), direction="+"
+                ),
+            },
+        },
+        "outputs": {
+            BATTERY_DEVICE_BATTERY: {
+                BATTERY_POWER_CHARGE: OutputData(type=OutputType.POWER, unit="kW", values=(0.0,), direction="-"),
+                BATTERY_POWER_DISCHARGE: OutputData(type=OutputType.POWER, unit="kW", values=(0.5,), direction="+"),
+                BATTERY_POWER_ACTIVE: OutputData(type=OutputType.POWER, unit="kW", values=(0.5,), direction=None),
+                BATTERY_ENERGY_STORED: OutputData(type=OutputType.ENERGY, unit="kWh", values=(4.0, 4.0)),
+                BATTERY_STATE_OF_CHARGE: OutputData(type=OutputType.STATE_OF_CHARGE, unit="%", values=(0.4, 0.4)),
+                BATTERY_POWER_BALANCE: OutputData(type=OutputType.SHADOW_PRICE, unit="$/kWh", values=(0.1,)),
+                BATTERY_ENERGY_IN_FLOW: OutputData(
+                    type=OutputType.SHADOW_PRICE, unit="$/kWh", values=(0.0,), advanced=True
+                ),
+                BATTERY_ENERGY_OUT_FLOW: OutputData(
+                    type=OutputType.SHADOW_PRICE, unit="$/kWh", values=(0.0,), advanced=True
+                ),
+                BATTERY_SOC_MAX: OutputData(type=OutputType.SHADOW_PRICE, unit="$/kWh", values=(0.0,), advanced=True),
+                BATTERY_SOC_MIN: OutputData(type=OutputType.SHADOW_PRICE, unit="$/kWh", values=(0.0,), advanced=True),
+            },
+        },
+    },
+    {
         "description": "Battery outputs include undercharge offset",
         "name": "battery_with_thresholds",
         "data": BatteryConfigData(

--- a/custom_components/haeo/core/adapters/elements/tests/test_grid_model.py
+++ b/custom_components/haeo/core/adapters/elements/tests/test_grid_model.py
@@ -154,6 +154,50 @@ OUTPUTS_CASES: Sequence[OutputsCase] = [
         },
     },
     {
+        "description": "Grid export connection pruned - export carries no flow",
+        "name": "grid_main",
+        "config": GridConfigData(
+            element_type=ElementType.GRID,
+            name="grid_main",
+            connection=as_connection_target("network"),
+            pricing={
+                "price_source_target": np.array([0.10]),
+                "price_target_source": np.array([0.05]),
+            },
+            power_limits={},
+        ),
+        "model_outputs": {
+            "grid_main:import": {
+                connection.CONNECTION_POWER: OutputData(
+                    type=OutputType.POWER_FLOW, unit="kW", values=(5.0,), direction="+"
+                ),
+                connection.CONNECTION_SEGMENTS: {
+                    "power_limit": {
+                        "power_limit": OutputData(type=OutputType.SHADOW_PRICE, unit="$/kWh", values=(0.02,)),
+                    }
+                },
+            },
+        },
+        "periods": np.array([1.0]),
+        "outputs": {
+            GRID_DEVICE_GRID: {
+                GRID_POWER_EXPORT: OutputData(type=OutputType.POWER, unit="kW", values=(0.0,), direction="-"),
+                GRID_POWER_IMPORT: OutputData(type=OutputType.POWER, unit="kW", values=(5.0,), direction="+"),
+                GRID_POWER_ACTIVE: OutputData(type=OutputType.POWER, unit="kW", values=(5.0,), direction=None),
+                GRID_COST_IMPORT: OutputData(
+                    type=OutputType.COST, unit="$", values=(0.50,), direction="-", state_last=True
+                ),
+                GRID_REVENUE_EXPORT: OutputData(
+                    type=OutputType.COST, unit="$", values=(0.0,), direction="+", state_last=True
+                ),
+                GRID_COST_NET: OutputData(
+                    type=OutputType.COST, unit="$", values=(0.50,), direction=None, state_last=True
+                ),
+                GRID_POWER_MAX_IMPORT_PRICE: OutputData(type=OutputType.SHADOW_PRICE, unit="$/kWh", values=(0.02,)),
+            }
+        },
+    },
+    {
         "description": "Grid with multiple periods - cumulative cost/revenue",
         "name": "grid_multi",
         "config": GridConfigData(

--- a/custom_components/haeo/core/adapters/elements/tests/test_inverter_model.py
+++ b/custom_components/haeo/core/adapters/elements/tests/test_inverter_model.py
@@ -178,6 +178,40 @@ OUTPUTS_CASES: Sequence[OutputsCase] = [
             }
         },
     },
+    {
+        "description": "Inverter AC-to-DC connection pruned - rectifier carries no flow",
+        "name": "inverter_main",
+        "model_outputs": {
+            "inverter_main": {
+                NODE_POWER_BALANCE: OutputData(type=OutputType.SHADOW_PRICE, unit="$/kWh", values=(0.0,)),
+            },
+            "inverter_main:dc_to_ac": {
+                connection.CONNECTION_POWER: OutputData(
+                    type=OutputType.POWER_FLOW, unit="kW", values=(5.0,), direction="+"
+                ),
+                connection.CONNECTION_SEGMENTS: {
+                    "power_limit": {
+                        "power_limit": OutputData(type=OutputType.SHADOW_PRICE, unit="$/kWh", values=(0.01,)),
+                    }
+                },
+            },
+        },
+        "outputs": {
+            INVERTER_DEVICE_INVERTER: {
+                INVERTER_DC_BUS_POWER_BALANCE: OutputData(type=OutputType.SHADOW_PRICE, unit="$/kWh", values=(0.0,)),
+                INVERTER_POWER_DC_TO_AC: OutputData(
+                    type=OutputType.POWER_FLOW, unit="kW", values=(5.0,), direction="+"
+                ),
+                INVERTER_POWER_AC_TO_DC: OutputData(
+                    type=OutputType.POWER_FLOW, unit="kW", values=(0.0,), direction="-"
+                ),
+                INVERTER_POWER_ACTIVE: OutputData(type=OutputType.POWER_FLOW, unit="kW", values=(5.0,), direction=None),
+                INVERTER_MAX_POWER_DC_TO_AC_PRICE: OutputData(
+                    type=OutputType.SHADOW_PRICE, unit="$/kWh", values=(0.01,)
+                ),
+            }
+        },
+    },
 ]
 
 

--- a/custom_components/haeo/core/adapters/elements/tests/test_load_model.py
+++ b/custom_components/haeo/core/adapters/elements/tests/test_load_model.py
@@ -138,9 +138,7 @@ OUTPUTS_CASES: Sequence[OutputsCase] = [
         "model_outputs": {},
         "outputs": {
             LOAD_DEVICE_LOAD: {
-                LOAD_POWER: OutputData(
-                    type=OutputType.POWER, unit="kW", values=(0.0, 0.0), direction="-", fixed=True
-                ),
+                LOAD_POWER: OutputData(type=OutputType.POWER, unit="kW", values=(0.0, 0.0), direction="-", fixed=True),
             }
         },
     },

--- a/custom_components/haeo/core/adapters/elements/tests/test_load_model.py
+++ b/custom_components/haeo/core/adapters/elements/tests/test_load_model.py
@@ -125,6 +125,25 @@ OUTPUTS_CASES: Sequence[OutputsCase] = [
             }
         },
     },
+    {
+        "description": "Load connection pruned - load carries no flow",
+        "name": "load_main",
+        "config": LoadConfigData(
+            element_type=ElementType.LOAD,
+            name="load_main",
+            connection=as_connection_target("network"),
+            forecast={"forecast": np.array([1.0, 2.0])},
+            curtailment={},
+        ),
+        "model_outputs": {},
+        "outputs": {
+            LOAD_DEVICE_LOAD: {
+                LOAD_POWER: OutputData(
+                    type=OutputType.POWER, unit="kW", values=(0.0, 0.0), direction="-", fixed=True
+                ),
+            }
+        },
+    },
 ]
 
 

--- a/custom_components/haeo/core/adapters/elements/tests/test_solar_model.py
+++ b/custom_components/haeo/core/adapters/elements/tests/test_solar_model.py
@@ -136,6 +136,23 @@ OUTPUTS_CASES: Sequence[OutputsCase] = [
             }
         },
     },
+    {
+        "description": "Solar connection pruned - solar carries no flow",
+        "name": "pv_main",
+        "config": SolarConfigData(
+            element_type=ElementType.SOLAR,
+            name="pv_main",
+            connection=as_connection_target("network"),
+            forecast={"forecast": np.array([2.0, 3.0])},
+            curtailment={"curtailment": True},
+        ),
+        "model_outputs": {},
+        "outputs": {
+            SOLAR_DEVICE_SOLAR: {
+                SOLAR_POWER: OutputData(type=OutputType.POWER, unit="kW", values=(0.0, 0.0), direction="+"),
+            }
+        },
+    },
 ]
 
 

--- a/custom_components/haeo/core/adapters/output_utils.py
+++ b/custom_components/haeo/core/adapters/output_utils.py
@@ -1,8 +1,11 @@
 """Utilities for validating adapter output mappings."""
 
+from collections.abc import Mapping
 from typing import overload
 
-from custom_components.haeo.core.model import ModelOutputValue
+from custom_components.haeo.core.model import ModelOutputName, ModelOutputValue
+from custom_components.haeo.core.model.const import OutputType
+from custom_components.haeo.core.model.elements.connection import CONNECTION_POWER
 from custom_components.haeo.core.model.output_data import OutputData
 
 
@@ -27,4 +30,19 @@ def expect_output_data(value: ModelOutputValue | None) -> OutputData | None:
     return value
 
 
-__all__ = ["expect_output_data"]
+def connection_power(
+    connection_outputs: Mapping[ModelOutputName, ModelOutputValue] | None,
+    period_count: int,
+) -> OutputData:
+    """Return a connection's power output, or zeros when the connection is absent.
+
+    Policy compilation drops connections that no tagged source can reach. Adapters
+    still run for the configured element, so a pruned connection is treated as
+    carrying no flow rather than failing output extraction.
+    """
+    if connection_outputs is None:
+        return OutputData(type=OutputType.POWER_FLOW, unit="kW", values=[0.0] * period_count, direction="+")
+    return expect_output_data(connection_outputs[CONNECTION_POWER])
+
+
+__all__ = ["connection_power", "expect_output_data"]


### PR DESCRIPTION
## Summary

- Add shared `connection_power()` helper for adapters when policy compilation prunes a connection from the model
- Apply to bidirectional elements (grid, battery, inverter) and single-connection elements (load, solar)
- Skip shadow price extraction when the pruned connection is absent

## Test plan

- [x] Grid export pruned case
- [x] Battery charge pruned case
- [x] Inverter AC-to-DC pruned case
- [x] Load and solar fully pruned connection cases
- [x] `uv run pytest custom_components/haeo/core/adapters/elements/tests/test_{grid,battery,inverter,load,solar}_model.py`


Made with [Cursor](https://cursor.com)