### PR TITLE
Use OIDC and tokenless uploads for Codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ permissions:
   contents: write
   pull-requests: write
   checks: write
+  id-token: write
 
 jobs:
   #region Linting and formatting
@@ -230,7 +231,8 @@ jobs:
         with:
           files: frontend/haeo-forecast-card/coverage/lcov.info
           flags: frontend
-          token: ${{ secrets.CODECOV_TOKEN }}
+          use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
+          fail_ci_if_error: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
   #endregion
   #region Tests
   # =============================================================================
@@ -260,15 +262,16 @@ jobs:
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
           report_type: test_results
-          token: ${{ secrets.CODECOV_TOKEN }}
+          use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
+          fail_ci_if_error: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
 
       - name: Upload coverage to Codecov
         if: ${{ github.event_name != 'release' && !cancelled() }}
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
           flags: python
-          fail_ci_if_error: true
-          token: ${{ secrets.CODECOV_TOKEN }}
+          use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
+          fail_ci_if_error: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
 
   scenario:
     name: Scenario tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,6 +231,7 @@ jobs:
         with:
           files: frontend/haeo-forecast-card/coverage/lcov.info
           flags: frontend
+          slug: hass-energy/haeo
           use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
           fail_ci_if_error: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
   #endregion
@@ -262,6 +263,7 @@ jobs:
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
           report_type: test_results
+          slug: hass-energy/haeo
           use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
           fail_ci_if_error: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
 
@@ -270,6 +272,7 @@ jobs:
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
           flags: python
+          slug: hass-energy/haeo
           use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
           fail_ci_if_error: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
 


### PR DESCRIPTION
## Summary

- Removes dependency on the `CODECOV_TOKEN` secret from CI
- Uses GitHub OIDC (`use_oidc: true`) for upstream pushes and same-repo PRs
- Uses Codecov's built-in tokenless fork upload path for PRs from forks
- Adds `id-token: write` permission required for OIDC
- Only fails CI on Codecov upload errors for upstream builds (fork PRs won't be blocked if upload fails)

Supersedes #429, which removed the token but did not add an alternative auth method. That caused `Token required - not valid tokenless upload` on same-repo PRs because Codecov treats those as protected-branch uploads.

## Why PR 429 failed

Codecov tokenless uploads only work automatically for **fork PRs** (branch names like `forkuser:main`). Same-repo branches and `main` pushes still require authentication unless the org disables token requirements entirely. OIDC provides that auth without a stored secret.

## What you may still need to do in Codecov

If uploads still fail after merge, check these Codecov org settings (admin only):

1. **Token authentication for public repositories** — can stay "Required"; OIDC bypasses this for upstream builds
2. If you see persistent `not valid tokenless upload` errors after an org rename or visibility change, try **Danger Zone → Erase repository** and re-sync in Codecov ([known issue](https://github.com/codecov/umbrella/issues/616))

## Test plan

- [ ] CI passes on this PR (validates OIDC path for same-repo PR)
- [ ] After merge, confirm `main` push uploads coverage successfully
- [ ] Open a test PR from a fork and confirm CI passes without `CODECOV_TOKEN`


Made with [Cursor](https://cursor.com)