### PR TITLE
Bump version to 0.4.0rc6

### DIFF
--- a/custom_components/haeo/manifest.json
+++ b/custom_components/haeo/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/hass-energy/haeo/issues",
   "requirements": ["highspy>=1.12.0", "numpy>=1.21.0"],
-  "version": "0.4.0rc5"
+  "version": "0.4.0rc6"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "haeo"
-version = "0.4.0rc5"
+version = "0.4.0rc6"
 description = "Home Assistant Energy Network Optimizer"
 readme = "README.md"
 requires-python = ">=3.13.2,<3.14"

--- a/uv.lock
+++ b/uv.lock
@@ -991,7 +991,7 @@ wheels = [
 
 [[package]]
 name = "haeo"
-version = "0.4.0rc5"
+version = "0.4.0rc6"
 source = { editable = "." }
 dependencies = [
     { name = "highspy" },


### PR DESCRIPTION
## Summary

- Bump project version from `0.4.0rc5` to `0.4.0rc6` in `pyproject.toml` and `custom_components/haeo/manifest.json`
- Regenerate `uv.lock`

## Test plan

- [ ] CI passes
- [ ] Version numbers match across pyproject.toml and manifest.json


Made with [Cursor](https://cursor.com)