### PR TITLE
Rename Advanced Mode to Expose raw model elements

### DIFF
--- a/custom_components/haeo/translations/en.json
+++ b/custom_components/haeo/translations/en.json
@@ -5,10 +5,10 @@
       "user": {
         "title": "HAEO Setup",
         "description": "Configure your system and choose a planning horizon that matches your forecast data availability.",
-        "data": { "advanced_mode": "Advanced Mode", "horizon_preset": "Planning Horizon", "name": "System Name" },
-        "data_description": { "advanced_mode": "Reveals additional element types for complex energy systems." },
+        "data": { "advanced_mode": "Expose raw model elements", "horizon_preset": "Planning Horizon", "name": "System Name" },
+        "data_description": { "advanced_mode": "Shows low-level model elements you connect manually. Leave off unless you are deliberately building the optimization model yourself." },
         "sections": {
-          "advanced": { "data": { "advanced_mode": "Advanced Mode" }, "name": "Advanced settings" },
+          "advanced": { "data": { "advanced_mode": "Expose raw model elements" }, "name": "Advanced settings" },
           "common": {
             "data": { "horizon_preset": "Planning Horizon", "name": "System Name" },
             "name": "Common settings"
@@ -53,19 +53,19 @@
         "title": "HAEO Settings",
         "description": "Configure optimization settings. Choose a planning horizon that matches your forecast data availability.",
         "data": {
-          "advanced_mode": "Advanced Mode",
+          "advanced_mode": "Expose raw model elements",
           "debounce_seconds": "Debounce Window (seconds)",
           "horizon_preset": "Planning Horizon",
           "record_forecasts": "Record forecast data"
         },
         "data_description": {
-          "advanced_mode": "Reveals additional element types for complex energy systems.",
+          "advanced_mode": "Shows low-level model elements you connect manually. Leave off unless you are deliberately building the optimization model yourself.",
           "record_forecasts": "When enabled, forecast attributes are saved to the recorder database. This significantly increases database size but allows debugging historical forecasts. Disabled by default to reduce database load."
         },
         "sections": {
           "advanced": {
             "data": {
-              "advanced_mode": "Advanced Mode",
+              "advanced_mode": "Expose raw model elements",
               "debounce_seconds": "Debounce Window (seconds)",
               "record_forecasts": "Record forecast data"
             },

--- a/docs/developer-guide/config-flow.md
+++ b/docs/developer-guide/config-flow.md
@@ -165,13 +165,13 @@ The element flow mixin is in `custom_components/haeo/flows/element_flow.py`.
 ### Connection endpoint filtering
 
 Connection elements require selecting source and target endpoints from other configured elements.
-The element flow filters available elements based on connectivity level and Advanced Mode setting.
+The element flow filters available elements based on connectivity level and the **Expose raw model elements** hub setting.
 
 Each element type in the `ELEMENT_TYPES` registry defines a connectivity level that controls when it appears in connection selectors.
 The `ConnectivityLevel` enum has three values:
 
 - **`ALWAYS`**: Always shown in connection selectors
-- **`ADVANCED`**: Only shown when Advanced Mode is enabled
+- **`ADVANCED`**: Only shown when **Expose raw model elements** is enabled
 - **`NEVER`**: Never shown in connection selectors
 
 This filtering ensures connection endpoints are appropriate for the user's configuration level.
@@ -371,7 +371,7 @@ The options flow implementation is in `custom_components/haeo/flows/options.py`.
 
 ### Key points
 
-- Options flow edits hub-level optimization settings (planning horizon preset, tier configuration, debounce window, advanced mode, forecast recording)
+- Options flow edits hub-level optimization settings (planning horizon preset, tier configuration, debounce window, expose raw model elements, forecast recording)
 - Element configuration happens via separate config entries
 - Settings stored in `config_entry.data` under section keys
 - Changes trigger coordinator reload to apply new parameters

--- a/docs/modeling/device-layer/node.md
+++ b/docs/modeling/device-layer/node.md
@@ -35,8 +35,8 @@ The adapter transforms user configuration into model parameters:
 | `is_source`        | Node          | `is_source`     | Whether node can produce power (default: false) |
 | `is_sink`          | Node          | `is_sink`       | Whether node can consume power (default: false) |
 
-In standard mode (Advanced Mode disabled), nodes are pure junctions (`is_source=false, is_sink=false`).
-When Advanced Mode is enabled, `is_source` and `is_sink` can be configured to create:
+In standard mode (with raw model elements not exposed), nodes are pure junctions (`is_source=false, is_sink=false`).
+When **Expose raw model elements** is enabled, `is_source` and `is_sink` can be configured to create:
 
 - **Grid-like nodes** (`is_source=true, is_sink=true`): Can import and export power
 - **Load-like nodes** (`is_source=false, is_sink=true`): Can only consume power

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -75,20 +75,20 @@ Presets automatically adjust the Tier 4 count to match the selected horizon.
 HAEO uses intelligent forecast cycling to extend partial forecast data across the full horizon.
 A 24-hour solar forecast automatically cycles to cover longer horizons with time-of-day alignment preserved.
 
-#### Advanced Mode
+#### Expose raw model elements
 
-Advanced Mode is a hub-level setting that enables access to raw modeling elements for advanced users.
+**Expose raw model elements** is a hub-level toggle that shows low-level model building blocks you connect manually.
 
-**When enabled**, Advanced Mode makes additional element types available that provide direct access to model layer components.
-These advanced elements require manual connection configuration and are intended for users who understand the underlying optimization model.
+**When enabled**, additional element types become available with direct access to model layer components.
+These raw model elements require manual connection configuration and are intended for deliberate model composition.
 
 **When disabled** (default), only standard elements are available.
-Standard elements provide automatic connections and optimized behavior suitable for most use cases.
+Standard elements provide automatic connections and behavior suitable for most use cases.
 
-Most users should leave Advanced Mode disabled.
-Enable Advanced Mode only if you need direct control over the underlying model layer components.
+Most users should leave this toggle off.
+Turn it on only if you are deliberately building the optimization model yourself.
 
-See the [elements overview](elements/index.md) for details on which elements require Advanced Mode.
+See the [elements overview](elements/index.md) for details on which elements require raw model elements to be exposed.
 
 Click **Submit** to create your hub.
 If you selected **Custom**, complete the custom tier step before the hub is created.
@@ -149,7 +149,7 @@ HAEO provides element types for modeling different aspects of energy systems:
 energy storage, power generation, consumption, grid connections, and network topology.
 
 Most elements create automatic connections to simplify configuration.
-Some advanced elements provide direct access to model layer components and require manual connection setup.
+Some raw model elements provide direct access to model layer components and require manual connection setup.
 
 See the [elements overview](elements/index.md) for detailed configuration guides for each element type.
 

--- a/docs/user-guide/elements/battery.md
+++ b/docs/user-guide/elements/battery.md
@@ -7,7 +7,7 @@ Internally, HAEO represents batteries as a single storage element and applies SO
 
 !!! note "Connection endpoints"
 
-    Battery elements appear in connection selectors only when Advanced Mode is enabled on your hub.
+    Battery elements appear in connection selectors only when **Expose raw model elements** is enabled on your hub.
 
 For mathematical details, see [Battery Modeling](../../modeling/device-layer/battery.md).
 

--- a/docs/user-guide/elements/battery_section.md
+++ b/docs/user-guide/elements/battery_section.md
@@ -6,13 +6,13 @@ this element creates a single battery section that must be connected manually vi
 
 !!! warning "Advanced Element"
 
-    Battery Section is only available when **Advanced Mode** is enabled on your hub.
-    This element is intended for advanced users who need direct control over battery modeling.
+    Battery Section is only available when **Expose raw model elements** is enabled on your hub.
+    This element is for direct control over battery modeling when building the model manually.
     Most users should use the standard [Battery](battery.md) element instead.
 
 !!! note "Connection endpoints"
 
-    Battery Section elements always appear in connection selectors regardless of Advanced Mode setting.
+    Battery Section elements always appear in connection selectors regardless of the hub setting.
 
 For mathematical details, see [Battery Section Modeling](../../modeling/device-layer/battery_section.md).
 
@@ -200,8 +200,8 @@ All sensors include a `forecast` attribute containing future optimized values fo
 
 **Problem**: The Battery Section element type does not appear in the element selection list.
 
-**Solution**: Enable Advanced Mode in your hub configuration.
-Battery Section is only available when Advanced Mode is enabled.
+**Solution**: Enable **Expose raw model elements** in your hub configuration.
+Battery Section is only available when that setting is enabled.
 
 ### No Power Flow
 
@@ -245,12 +245,12 @@ Check that the Battery Section element exists before creating connections.
 
     [:material-arrow-right: Battery Section modeling](../../modeling/device-layer/battery_section.md)
 
-- :material-cog-outline:{ .lg .middle } **Advanced mode**
+- :material-cog-outline:{ .lg .middle } **Expose raw model elements**
 
     ---
 
-    Learn about advanced mode and other advanced elements.
+    Learn when to expose raw model elements and which elements require it.
 
-    [:material-arrow-right: Configuration guide](../configuration.md#advanced-mode)
+    [:material-arrow-right: Configuration guide](../configuration.md#expose-raw-model-elements)
 
 </div>

--- a/docs/user-guide/elements/connections.md
+++ b/docs/user-guide/elements/connections.md
@@ -4,8 +4,8 @@ Connections define how power flows between elements in your network with support
 
 !!! warning "Advanced Element"
 
-    Connection is only available when **Advanced Mode** is enabled on your hub.
-    This element is intended for advanced users who need explicit control over power flow paths.
+    Connection is only available when **Expose raw model elements** is enabled on your hub.
+    This element is for explicit control over power flow paths when you are building the model manually.
     Most users should rely on implicit connections created automatically by other elements.
 
 !!! note "Implicit connections"
@@ -46,7 +46,7 @@ Use [input number helpers](https://www.home-assistant.io/integrations/input_numb
 ### Connection Endpoint Selection
 
 The **Source** and **Target** fields show a dropdown of available elements that can be used as connection endpoints.
-The list of available elements is filtered based on connectivity level and your hub's Advanced Mode setting.
+The list of available elements is filtered based on connectivity level and whether **Expose raw model elements** is enabled on your hub.
 
 **Why filtering?**
 Standard elements (Grid, Battery, Solar, Load) create implicit connections automatically.
@@ -55,8 +55,8 @@ The filtering hides these elements by default to prevent common mistakes.
 
 **Filtering behavior:**
 
-- Advanced elements that require manual connection setup always appear in the selector regardless of Advanced Mode.
-- Standard elements that create implicit connections automatically only appear when Advanced Mode is enabled.
+- Raw model elements that require manual connection setup always appear in the selector regardless of the hub setting.
+- Standard elements that create implicit connections automatically only appear when **Expose raw model elements** is enabled.
 - Connection elements never appear as endpoints to prevent invalid connection topologies.
 
 This filtering ensures that connection endpoints are appropriate for your configuration level.
@@ -74,10 +74,10 @@ Bidirectional connection between two network nodes:
 | **Max Power Source→Target** | input_number.max_power |
 | **Max Power Target→Source** | input_number.max_power |
 
-!!! note "Advanced Mode required for standard elements"
+!!! note "Expose raw model elements required for standard elements"
 
     This example uses elements that are always available in connection selectors.
-    To connect standard elements that create implicit connections, enable Advanced Mode on your hub.
+    To connect standard elements that create implicit connections, enable **Expose raw model elements** on your hub.
 
 ## Physical Interpretation
 
@@ -110,10 +110,10 @@ Leave both power limits unset for unlimited flow in both directions:
 | **Max Power Source→Target** | _(leave empty)_  |
 | **Max Power Target→Source** | _(leave empty)_  |
 
-!!! note "Advanced Mode required for standard elements"
+!!! note "Expose raw model elements required for standard elements"
 
     This example uses elements that are always available in connection selectors.
-    To connect standard elements that create implicit connections, enable Advanced Mode on your hub.
+    To connect standard elements that create implicit connections, enable **Expose raw model elements** on your hub.
 
 ### Unidirectional Connection
 
@@ -175,9 +175,9 @@ Then configure the connection:
 | **Target**                  | EV_Battery                      |
 | **Max Power Source→Target** | sensor.ev_charging_availability |
 
-!!! note "Advanced Mode required"
+!!! note "Expose raw model elements required"
 
-    This example uses standard elements that require Advanced Mode to appear in connection selectors.
+    This example uses standard elements that require **Expose raw model elements** to appear in connection selectors.
 
 The optimizer will only schedule charging when the sensor value is non-zero.
 

--- a/docs/user-guide/elements/grid.md
+++ b/docs/user-guide/elements/grid.md
@@ -5,7 +5,7 @@ It allows bidirectional power flow: importing (buying) and exporting (selling) e
 
 !!! note "Connection endpoints"
 
-    Grid elements appear in connection selectors only when Advanced Mode is enabled on your hub.
+    Grid elements appear in connection selectors only when **Expose raw model elements** is enabled on your hub.
 
 ## Configuration
 

--- a/docs/user-guide/elements/index.md
+++ b/docs/user-guide/elements/index.md
@@ -52,21 +52,21 @@ When configuring elements:
 3. **Verify each step**: Check that optimization produces reasonable results
 4. **Use realistic values**: Base constraints on actual device specifications
 
-## Advanced Elements
+## Raw model elements
 
-Some elements are only available when **Advanced Mode** is enabled on your hub.
-These elements provide direct access to raw modeling components for advanced users who need fine-grained control.
+Some elements are only available when **Expose raw model elements** is enabled on your hub.
+These elements provide direct access to low-level model building blocks for deliberate model composition.
 
-Advanced elements include:
+Raw model elements include:
 
 - **Connection**: Explicit power flow paths between elements
-- **Node**: Virtual power balance points (with advanced source/sink configuration)
+- **Node**: Virtual power balance points (with source/sink configuration when exposed)
 - **Battery Section**: Direct access to model layer Battery element
 
 Most users should use the standard elements which provide automatic connections and optimized behavior.
-Advanced elements require manual connection configuration and are intended for users who understand the underlying model layer.
+Raw model elements require manual connection configuration.
 
-See the [Configuration guide](../configuration.md#advanced-mode) for details on enabling Advanced Mode.
+See the [Configuration guide](../configuration.md#expose-raw-model-elements) for details on when to enable this setting.
 
 ## Next Steps
 

--- a/docs/user-guide/elements/inverter.md
+++ b/docs/user-guide/elements/inverter.md
@@ -5,7 +5,7 @@ They provide a DC bus for connecting batteries and solar panels, with bidirectio
 
 !!! note "Connection endpoints"
 
-    Inverter elements always appear in connection selectors regardless of Advanced Mode setting.
+    Inverter elements always appear in connection selectors regardless of the hub setting.
 
 ## Configuration
 

--- a/docs/user-guide/elements/load.md
+++ b/docs/user-guide/elements/load.md
@@ -5,7 +5,7 @@ The Load element uses forecast data to model any type of consumption pattern fro
 
 !!! note "Connection endpoints"
 
-    Load elements appear in connection selectors only when Advanced Mode is enabled on your hub.
+    Load elements appear in connection selectors only when **Expose raw model elements** is enabled on your hub.
 
 ## Configuration
 

--- a/docs/user-guide/elements/node.md
+++ b/docs/user-guide/elements/node.md
@@ -5,23 +5,23 @@ Virtual balance points enforcing power conservation (Kirchhoff's law).
 !!! warning "Advanced Element"
 
     A switchboard node is created automatically when you set up a HAEO hub.
-    Creating **additional** nodes requires **Advanced Mode** to be enabled on your hub.
+    Creating **additional** nodes requires **Expose raw model elements** to be enabled on your hub.
     In standard mode, the automatic switchboard node is sufficient for most residential systems.
 
-    Advanced source/sink configuration (`is_source` and `is_sink` fields) is only available when Advanced Mode is enabled.
+    Source/sink configuration (`is_source` and `is_sink` fields) is only available when **Expose raw model elements** is enabled.
     In standard mode, nodes are pure junctions with no generation or consumption capability.
 
 !!! note "Connection endpoints"
 
-    Node elements always appear in connection selectors regardless of Advanced Mode setting.
+    Node elements always appear in connection selectors regardless of the hub setting.
 
 ## Configuration
 
 | Field                       | Type    | Required | Default | Description                                         |
 | --------------------------- | ------- | -------- | ------- | --------------------------------------------------- |
 | **[Name](#name)**           | String  | Yes      | -       | Unique identifier for this node                     |
-| **[Is Source](#is-source)** | Boolean | No       | false   | Whether node can produce power (Advanced Mode only) |
-| **[Is Sink](#is-sink)**     | Boolean | No       | false   | Whether node can consume power (Advanced Mode only) |
+| **[Is Source](#is-source)** | Boolean | No       | false   | Whether node can produce power (raw model elements exposed only) |
+| **[Is Sink](#is-sink)**     | Boolean | No       | false   | Whether node can consume power (raw model elements exposed only) |
 
 ## Name
 
@@ -37,7 +37,7 @@ When `true`, the node can generate power that flows out through connections.
 
 **Default**: `false` (node cannot produce power)
 
-**Available only when Advanced Mode is enabled**.
+**Available only when Expose raw model elements is enabled**.
 
 ## Is Sink
 
@@ -46,7 +46,7 @@ When `true`, the node can accept power that flows in through connections.
 
 **Default**: `false` (node cannot consume power)
 
-**Available only when Advanced Mode is enabled**.
+**Available only when Expose raw model elements is enabled**.
 
 ### Source and Sink Combinations
 
@@ -57,7 +57,7 @@ The combination of `is_source` and `is_sink` determines the node's behavior:
 - Power must balance: all power flowing in equals all power flowing out
 - No power generation or consumption at the node itself
 - Most common configuration for standard nodes
-- Available in standard mode (Advanced Mode not required)
+- Available in standard mode (raw model elements not required)
 
 **Source Only** (`is_source=true, is_sink=false`):
 
@@ -101,7 +101,7 @@ Nodes are not physical devices - they represent electrical junctions where Kirch
     This central connection point is sufficient for most residential energy systems.
     You only need to create additional nodes if you have complex multi-bus topologies (e.g., separate AC/DC buses).
 
-    If the switchboard node is accidentally deleted in non-advanced mode, HAEO will automatically recreate it on the next integration reload to maintain network connectivity.
+    If the switchboard node is accidentally deleted with raw model elements not exposed, HAEO will automatically recreate it on the next integration reload to maintain network connectivity.
 
 !!! tip "Key insight"
 
@@ -156,7 +156,7 @@ Then connect elements to "Main Node" via connections.
     If you delete a node element, you must update all connections that reference it.
     Connections cannot have endpoints that don't exist.
 
-    **In non-advanced mode**: If you delete the switchboard node, HAEO will automatically recreate it the next time the integration reloads (on restart or configuration change) to ensure network connectivity is maintained.
+    **In standard mode**: If you delete the switchboard node, HAEO will automatically recreate it the next time the integration reloads (on restart or configuration change) to ensure network connectivity is maintained.
 
 ### Input Entities
 
@@ -168,7 +168,7 @@ Input entities appear as Switch entities with the `config` entity category.
 | `switch.{name}_is_source` | Whether node can produce power |
 | `switch.{name}_is_sink`   | Whether node can consume power |
 
-These switch inputs are only created when Advanced Mode is enabled.
+These switch inputs are only created when **Expose raw model elements** is enabled.
 Input entities include a `forecast` attribute showing values for each optimization period.
 See the [Input Entities developer guide](../../developer-guide/inputs.md) for details on input entity behavior.
 
@@ -225,7 +225,7 @@ All sensors include a `forecast` attribute containing future optimized values fo
 - Intermediate limits (inverter capacity, feeder constraints)
 - Hierarchical distribution (main panel and sub-panels)
 
-**Configuration**: Enable Advanced Mode on your hub, then create additional node elements and link them with connections.
+**Configuration**: Enable **Expose raw model elements** on your hub, then create additional node elements and link them with connections.
 
 **Complexity**: Requires more configuration and adds more constraints, but accurately models real system architecture.
 

--- a/docs/user-guide/elements/solar.md
+++ b/docs/user-guide/elements/solar.md
@@ -5,7 +5,7 @@ HAEO optimizes how generated power flows through your energy network.
 
 !!! note "Connection endpoints"
 
-    Solar elements appear in connection selectors only when Advanced Mode is enabled on your hub.
+    Solar elements appear in connection selectors only when **Expose raw model elements** is enabled on your hub.
 
 ## Configuration
 

--- a/docs/walkthroughs/index.md
+++ b/docs/walkthroughs/index.md
@@ -46,7 +46,7 @@ Walkthroughs are generated from a live Home Assistant instance, so the screensho
 
     ---
 
-    Detailed reference for hub configuration, tiers, and advanced mode.
+    Detailed reference for hub configuration, tiers, and exposing raw model elements.
 
     [:material-arrow-right: Configuration guide](../user-guide/configuration.md)
 


### PR DESCRIPTION
## Summary

- Renames the hub toggle label from "Advanced Mode" to **Expose raw model elements** with copy that discourages casual use
- Updates user-facing documentation and cross-links to use consistent terminology
- Leaves the `advanced_mode` config key, Python constants, and "Advanced settings" section title unchanged

## Test plan

- [x] `uv run pytest custom_components/haeo/flows/tests/`
- [ ] Confirm hub setup and options UI show the new label and description in Home Assistant


Made with [Cursor](https://cursor.com)