### PR TITLE
Align connection config with unidirectional model paths

### DIFF
--- a/custom_components/haeo/core/adapters/elements/tests/test_connection.py
+++ b/custom_components/haeo/core/adapters/elements/tests/test_connection.py
@@ -33,11 +33,8 @@ async def test_available_returns_true_with_no_optional_fields(hass: HomeAssistan
 async def test_available_returns_true_when_optional_sensors_exist(hass: HomeAssistant) -> None:
     """Connection available() should return True when all configured sensors exist."""
     _set_sensor(hass, "sensor.max_power_st", "5.0", "kW")
-    _set_sensor(hass, "sensor.max_power_ts", "3.0", "kW")
     _set_sensor(hass, "sensor.eff_st", "95.0", "%")
-    _set_sensor(hass, "sensor.eff_ts", "90.0", "%")
     _set_sensor(hass, "sensor.price_st", "0.10", "$/kWh")
-    _set_sensor(hass, "sensor.price_ts", "0.05", "$/kWh")
 
     config: connection.ConnectionConfigSchema = {
         "element_type": ElementType.CONNECTION,
@@ -48,15 +45,12 @@ async def test_available_returns_true_when_optional_sensors_exist(hass: HomeAssi
         },
         connection.SECTION_POWER_LIMITS: {
             "max_power_source_target": as_entity_value(["sensor.max_power_st"]),
-            "max_power_target_source": as_entity_value(["sensor.max_power_ts"]),
         },
         connection.SECTION_PRICING: {
             "price_source_target": as_entity_value(["sensor.price_st"]),
-            "price_target_source": as_entity_value(["sensor.price_ts"]),
         },
         connection.SECTION_EFFICIENCY: {
             "efficiency_source_target": as_entity_value(["sensor.eff_st"]),
-            "efficiency_target_source": as_entity_value(["sensor.eff_ts"]),
         },
     }
 
@@ -66,9 +60,6 @@ async def test_available_returns_true_when_optional_sensors_exist(hass: HomeAssi
 
 async def test_available_returns_false_when_optional_sensor_missing(hass: HomeAssistant) -> None:
     """Connection available() should return False when a configured optional sensor is missing."""
-    _set_sensor(hass, "sensor.max_power_st", "5.0", "kW")
-    # max_power_ts sensor is missing
-
     config: connection.ConnectionConfigSchema = {
         "element_type": ElementType.CONNECTION,
         "name": "c1",
@@ -77,8 +68,7 @@ async def test_available_returns_false_when_optional_sensor_missing(hass: HomeAs
             "target": as_connection_target("node_b"),
         },
         connection.SECTION_POWER_LIMITS: {
-            "max_power_source_target": as_entity_value(["sensor.max_power_st"]),
-            "max_power_target_source": as_entity_value(["sensor.missing"]),
+            "max_power_source_target": as_entity_value(["sensor.missing"]),
         },
         connection.SECTION_PRICING: {},
         connection.SECTION_EFFICIENCY: {},
@@ -119,15 +109,12 @@ async def test_available_returns_true_with_constant_values(hass: HomeAssistant) 
         },
         connection.SECTION_POWER_LIMITS: {
             "max_power_source_target": as_constant_value(5.0),
-            "max_power_target_source": as_constant_value(4.0),
         },
         connection.SECTION_PRICING: {
             "price_source_target": as_constant_value(0.1),
-            "price_target_source": as_constant_value(0.2),
         },
         connection.SECTION_EFFICIENCY: {
             "efficiency_source_target": as_constant_value(0.9),
-            "efficiency_target_source": as_constant_value(0.91),
         },
     }
 

--- a/custom_components/haeo/core/adapters/elements/tests/test_connection_model.py
+++ b/custom_components/haeo/core/adapters/elements/tests/test_connection_model.py
@@ -45,15 +45,12 @@ CREATE_CASES: Sequence[CreateCase] = [
             endpoints={"source": as_connection_target("s"), "target": as_connection_target("t")},
             power_limits={
                 "max_power_source_target": np.array([4.0]),
-                "max_power_target_source": np.array([2.0]),
             },
             efficiency={
                 "efficiency_source_target": np.array([0.95]),
-                "efficiency_target_source": np.array([0.90]),
             },
             pricing={
                 "price_source_target": np.array([0.1]),
-                "price_target_source": np.array([0.05]),
             },
         ),
         "model": [

--- a/custom_components/haeo/core/schema/elements/connection.py
+++ b/custom_components/haeo/core/schema/elements/connection.py
@@ -1,6 +1,6 @@
 """Connection element schema definitions."""
 
-from typing import Annotated, Final, Literal, NotRequired, TypedDict
+from typing import Annotated, Final, Literal, TypedDict
 
 from custom_components.haeo.core.model.const import OutputType
 from custom_components.haeo.core.schema import ConnectionTarget
@@ -8,11 +8,8 @@ from custom_components.haeo.core.schema.elements.element_type import ElementType
 from custom_components.haeo.core.schema.field_hints import FieldHint, SectionHints
 from custom_components.haeo.core.schema.sections import (
     CONF_EFFICIENCY_SOURCE_TARGET,
-    CONF_EFFICIENCY_TARGET_SOURCE,
     CONF_MAX_POWER_SOURCE_TARGET,
-    CONF_MAX_POWER_TARGET_SOURCE,
     CONF_PRICE_SOURCE_TARGET,
-    CONF_PRICE_TARGET_SOURCE,
     SECTION_EFFICIENCY,
     SECTION_POWER_LIMITS,
     SECTION_PRICING,
@@ -29,20 +26,15 @@ from custom_components.haeo.core.schema.sections import (
 ELEMENT_TYPE = ElementType.CONNECTION
 
 SECTION_ENDPOINTS: Final = "endpoints"
-SECTION_SEGMENT_ORDER: Final = "segment_order"
 
 CONF_SOURCE: Final = "source"
 CONF_TARGET: Final = "target"
-CONF_MIRROR_SEGMENT_ORDER: Final = "mirror_segment_order"
 
 OPTIONAL_INPUT_FIELDS: Final[frozenset[str]] = frozenset(
     {
         CONF_MAX_POWER_SOURCE_TARGET,
-        CONF_MAX_POWER_TARGET_SOURCE,
         CONF_EFFICIENCY_SOURCE_TARGET,
-        CONF_EFFICIENCY_TARGET_SOURCE,
         CONF_PRICE_SOURCE_TARGET,
-        CONF_PRICE_TARGET_SOURCE,
     }
 )
 
@@ -61,33 +53,16 @@ class EndpointsData(TypedDict):
     target: ConnectionTarget
 
 
-class SegmentOrderConfig(TypedDict, total=False):
-    """Segment order configuration values."""
-
-    mirror_segment_order: bool
-
-
-class SegmentOrderData(TypedDict, total=False):
-    """Loaded segment order values."""
-
-    mirror_segment_order: bool
-
-
 class ConnectionConfigSchema(CommonConfig):
     """Connection element configuration as stored in Home Assistant."""
 
     element_type: Literal[ElementType.CONNECTION]
     endpoints: EndpointsConfig
-    segment_order: NotRequired[SegmentOrderConfig]
     power_limits: Annotated[
         PowerLimitsConfig,
         SectionHints(
             {
                 CONF_MAX_POWER_SOURCE_TARGET: FieldHint(
-                    output_type=OutputType.POWER_LIMIT,
-                    time_series=True,
-                ),
-                CONF_MAX_POWER_TARGET_SOURCE: FieldHint(
                     output_type=OutputType.POWER_LIMIT,
                     time_series=True,
                 ),
@@ -103,11 +78,6 @@ class ConnectionConfigSchema(CommonConfig):
                     direction="-",
                     time_series=True,
                 ),
-                CONF_PRICE_TARGET_SOURCE: FieldHint(
-                    output_type=OutputType.PRICE,
-                    direction="-",
-                    time_series=True,
-                ),
             }
         ),
     ]
@@ -116,10 +86,6 @@ class ConnectionConfigSchema(CommonConfig):
         SectionHints(
             {
                 CONF_EFFICIENCY_SOURCE_TARGET: FieldHint(
-                    output_type=OutputType.EFFICIENCY,
-                    time_series=True,
-                ),
-                CONF_EFFICIENCY_TARGET_SOURCE: FieldHint(
                     output_type=OutputType.EFFICIENCY,
                     time_series=True,
                 ),
@@ -133,7 +99,6 @@ class ConnectionConfigData(CommonData):
 
     element_type: Literal[ElementType.CONNECTION]
     endpoints: EndpointsData
-    segment_order: NotRequired[SegmentOrderData]
     power_limits: PowerLimitsData
     pricing: PricingData
     efficiency: EfficiencyData
@@ -141,12 +106,8 @@ class ConnectionConfigData(CommonData):
 
 __all__ = [
     "CONF_EFFICIENCY_SOURCE_TARGET",
-    "CONF_EFFICIENCY_TARGET_SOURCE",
     "CONF_MAX_POWER_SOURCE_TARGET",
-    "CONF_MAX_POWER_TARGET_SOURCE",
-    "CONF_MIRROR_SEGMENT_ORDER",
     "CONF_PRICE_SOURCE_TARGET",
-    "CONF_PRICE_TARGET_SOURCE",
     "CONF_SOURCE",
     "CONF_TARGET",
     "ELEMENT_TYPE",
@@ -155,11 +116,8 @@ __all__ = [
     "SECTION_ENDPOINTS",
     "SECTION_POWER_LIMITS",
     "SECTION_PRICING",
-    "SECTION_SEGMENT_ORDER",
     "ConnectionConfigData",
     "ConnectionConfigSchema",
     "EndpointsConfig",
     "EndpointsData",
-    "SegmentOrderConfig",
-    "SegmentOrderData",
 ]

--- a/custom_components/haeo/core/schema/migrations/tests/test_v1_4.py
+++ b/custom_components/haeo/core/schema/migrations/tests/test_v1_4.py
@@ -1,0 +1,157 @@
+"""Tests for v1.4 connection unidirectional schema migration."""
+
+from custom_components.haeo.core.const import CONF_ELEMENT_TYPE, CONF_NAME
+from custom_components.haeo.core.schema import (
+    as_connection_target,
+    as_constant_value,
+    as_none_value,
+    get_connection_target_name,
+)
+from custom_components.haeo.core.schema.elements import connection
+from custom_components.haeo.core.schema.migrations.v1_4 import (
+    merge_reverse_into_existing,
+    migrate_connection_config,
+)
+from custom_components.haeo.core.schema.sections import (
+    CONF_EFFICIENCY_SOURCE_TARGET,
+    CONF_EFFICIENCY_TARGET_SOURCE,
+    CONF_MAX_POWER_SOURCE_TARGET,
+    CONF_MAX_POWER_TARGET_SOURCE,
+    CONF_PRICE_SOURCE_TARGET,
+    CONF_PRICE_TARGET_SOURCE,
+    SECTION_EFFICIENCY,
+    SECTION_POWER_LIMITS,
+    SECTION_PRICING,
+)
+
+
+def _connection_config(**sections: object) -> dict[str, object]:
+    return {
+        CONF_ELEMENT_TYPE: connection.ELEMENT_TYPE,
+        CONF_NAME: "Inverter link",
+        connection.SECTION_ENDPOINTS: {
+            connection.CONF_SOURCE: as_connection_target("DC Bus"),
+            connection.CONF_TARGET: as_connection_target("AC Bus"),
+        },
+        **sections,
+    }
+
+
+def test_migrate_strips_segment_order_only() -> None:
+    """Segment order is removed without creating a reverse connection."""
+    data = _connection_config(
+        segment_order={"mirror_segment_order": True},
+        power_limits={},
+        pricing={},
+        efficiency={},
+    )
+
+    forward, reverse = migrate_connection_config(data)
+
+    assert reverse is None
+    assert "segment_order" not in forward
+
+
+def test_migrate_forward_only_unchanged() -> None:
+    """Forward-only configuration is unchanged aside from cleanup."""
+    data = _connection_config(
+        power_limits={CONF_MAX_POWER_SOURCE_TARGET: as_constant_value(10.0)},
+        pricing={},
+        efficiency={},
+    )
+
+    forward, reverse = migrate_connection_config(data)
+
+    assert reverse is None
+    assert forward[SECTION_POWER_LIMITS][CONF_MAX_POWER_SOURCE_TARGET] == as_constant_value(10.0)
+    assert CONF_MAX_POWER_TARGET_SOURCE not in forward[SECTION_POWER_LIMITS]
+
+
+def test_migrate_splits_reverse_fields() -> None:
+    """Reverse-direction fields become a second connection with swapped endpoints."""
+    data = _connection_config(
+        power_limits={
+            CONF_MAX_POWER_SOURCE_TARGET: as_constant_value(10.0),
+            CONF_MAX_POWER_TARGET_SOURCE: as_constant_value(8.0),
+        },
+        pricing={
+            CONF_PRICE_SOURCE_TARGET: as_constant_value(0.1),
+            CONF_PRICE_TARGET_SOURCE: as_constant_value(0.2),
+        },
+        efficiency={
+            CONF_EFFICIENCY_SOURCE_TARGET: as_constant_value(0.95),
+            CONF_EFFICIENCY_TARGET_SOURCE: as_constant_value(0.90),
+        },
+    )
+
+    forward, reverse = migrate_connection_config(data)
+
+    assert reverse is not None
+    assert forward[CONF_NAME] == "Inverter link"
+    assert CONF_MAX_POWER_TARGET_SOURCE not in forward[SECTION_POWER_LIMITS]
+    assert reverse[CONF_NAME] == "Inverter link (AC Bus to DC Bus)"
+    assert reverse[SECTION_POWER_LIMITS][CONF_MAX_POWER_SOURCE_TARGET] == as_constant_value(8.0)
+    assert reverse[SECTION_PRICING][CONF_PRICE_SOURCE_TARGET] == as_constant_value(0.2)
+    assert reverse[SECTION_EFFICIENCY][CONF_EFFICIENCY_SOURCE_TARGET] == as_constant_value(0.90)
+    reverse_endpoints = reverse[connection.SECTION_ENDPOINTS]
+    assert isinstance(reverse_endpoints, dict)
+    assert get_connection_target_name(reverse_endpoints[connection.CONF_SOURCE]) == "AC Bus"
+    assert get_connection_target_name(reverse_endpoints[connection.CONF_TARGET]) == "DC Bus"
+
+
+def test_migrate_ignores_none_reverse_values() -> None:
+    """Explicit none reverse values do not trigger a split."""
+    data = _connection_config(
+        power_limits={
+            CONF_MAX_POWER_SOURCE_TARGET: as_constant_value(10.0),
+            CONF_MAX_POWER_TARGET_SOURCE: as_none_value(),
+        },
+        pricing={},
+        efficiency={},
+    )
+
+    forward, reverse = migrate_connection_config(data)
+
+    assert reverse is None
+    assert CONF_MAX_POWER_TARGET_SOURCE not in forward[SECTION_POWER_LIMITS]
+
+
+def test_migrate_unique_reverse_name() -> None:
+    """Reverse connection names avoid collisions with existing subentry titles."""
+    data = _connection_config(
+        power_limits={CONF_MAX_POWER_TARGET_SOURCE: as_constant_value(5.0)},
+        pricing={},
+        efficiency={},
+    )
+
+    _, reverse = migrate_connection_config(
+        data,
+        existing_names={"Inverter link (AC Bus to DC Bus)"},
+    )
+
+    assert reverse is not None
+    assert reverse[CONF_NAME] == "Inverter link (AC Bus to DC Bus) 2"
+
+
+def test_merge_reverse_into_existing() -> None:
+    """Reverse values merge only into unset fields on an existing reverse connection."""
+    existing = _connection_config(
+        power_limits={CONF_MAX_POWER_SOURCE_TARGET: as_constant_value(6.0)},
+        pricing={},
+        efficiency={},
+    )
+    existing[connection.SECTION_ENDPOINTS] = {
+        connection.CONF_SOURCE: as_connection_target("AC Bus"),
+        connection.CONF_TARGET: as_connection_target("DC Bus"),
+    }
+    reverse_data = {
+        SECTION_POWER_LIMITS: {CONF_MAX_POWER_SOURCE_TARGET: as_constant_value(8.0)},
+        SECTION_PRICING: {CONF_PRICE_SOURCE_TARGET: as_constant_value(0.2)},
+        SECTION_EFFICIENCY: {},
+    }
+
+    merged = merge_reverse_into_existing(existing, reverse_data)
+
+    assert merged[SECTION_POWER_LIMITS][CONF_MAX_POWER_SOURCE_TARGET] == as_constant_value(6.0)
+    assert merged[SECTION_PRICING][CONF_PRICE_SOURCE_TARGET] == as_constant_value(0.2)
+

--- a/custom_components/haeo/core/schema/migrations/v1_3.py
+++ b/custom_components/haeo/core/schema/migrations/v1_3.py
@@ -55,6 +55,8 @@ from custom_components.haeo.core.schema.elements import (
 from custom_components.haeo.core.schema.sections import (
     CONF_CONNECTION,
     CONF_CURTAILMENT,
+    CONF_EFFICIENCY_SOURCE_TARGET,
+    CONF_EFFICIENCY_TARGET_SOURCE,
     CONF_FORECAST,
     CONF_MAX_POWER_SOURCE_TARGET,
     CONF_MAX_POWER_TARGET_SOURCE,
@@ -284,11 +286,11 @@ def _migrate_element_to_sectioned(data: Mapping[str, Any]) -> dict[str, Any] | N
         for key in (connection.CONF_SOURCE, connection.CONF_TARGET):
             if key in endpoints:
                 endpoints[key] = normalize_connection_target(endpoints[key])
-        for key in (connection.CONF_MAX_POWER_SOURCE_TARGET, connection.CONF_MAX_POWER_TARGET_SOURCE):
+        for key in (CONF_MAX_POWER_SOURCE_TARGET, CONF_MAX_POWER_TARGET_SOURCE):
             add_if_present(power_limits, key, convert=True)
-        for key in (connection.CONF_PRICE_SOURCE_TARGET, connection.CONF_PRICE_TARGET_SOURCE):
+        for key in (CONF_PRICE_SOURCE_TARGET, CONF_PRICE_TARGET_SOURCE):
             add_if_present(pricing, key, convert=True)
-        for key in (connection.CONF_EFFICIENCY_SOURCE_TARGET, connection.CONF_EFFICIENCY_TARGET_SOURCE):
+        for key in (CONF_EFFICIENCY_SOURCE_TARGET, CONF_EFFICIENCY_TARGET_SOURCE):
             add_if_present(efficiency, key, convert=True)
         migrated |= {
             connection.SECTION_ENDPOINTS: endpoints,

--- a/custom_components/haeo/core/schema/migrations/v1_4.py
+++ b/custom_components/haeo/core/schema/migrations/v1_4.py
@@ -1,0 +1,162 @@
+"""Pure config transformation logic for v1.4 connection unidirectional migration."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from custom_components.haeo.core.const import CONF_ELEMENT_TYPE, CONF_NAME
+from custom_components.haeo.core.schema import get_connection_target_name, normalize_connection_target
+from custom_components.haeo.core.schema.elements import connection
+from custom_components.haeo.core.schema.sections import (
+    CONF_EFFICIENCY_SOURCE_TARGET,
+    CONF_EFFICIENCY_TARGET_SOURCE,
+    CONF_MAX_POWER_SOURCE_TARGET,
+    CONF_MAX_POWER_TARGET_SOURCE,
+    CONF_PRICE_SOURCE_TARGET,
+    CONF_PRICE_TARGET_SOURCE,
+    SECTION_EFFICIENCY,
+    SECTION_POWER_LIMITS,
+    SECTION_PRICING,
+)
+
+_REVERSE_TO_FORWARD: tuple[tuple[str, str], ...] = (
+    (CONF_MAX_POWER_TARGET_SOURCE, CONF_MAX_POWER_SOURCE_TARGET),
+    (CONF_PRICE_TARGET_SOURCE, CONF_PRICE_SOURCE_TARGET),
+    (CONF_EFFICIENCY_TARGET_SOURCE, CONF_EFFICIENCY_SOURCE_TARGET),
+)
+
+_REVERSE_SECTIONS: tuple[str, ...] = (SECTION_POWER_LIMITS, SECTION_PRICING, SECTION_EFFICIENCY)
+
+
+def _is_configured_value(value: Any) -> bool:
+    """Return True when a schema value represents an active configuration."""
+    return value is not None and not (isinstance(value, dict) and value.get("type") == "none")
+
+
+def _section_dict(data: dict[str, Any], section: str) -> dict[str, Any]:
+    section_data = data.get(section, {})
+    return dict(section_data) if isinstance(section_data, dict) else {}
+
+
+def _strip_reverse_from_section(section_data: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Remove reverse-direction keys and return extracted reverse values."""
+    reverse_values: dict[str, Any] = {}
+    cleaned = dict(section_data)
+    for reverse_key, forward_key in _REVERSE_TO_FORWARD:
+        if reverse_key in cleaned:
+            value = cleaned.pop(reverse_key)
+            if _is_configured_value(value):
+                reverse_values[forward_key] = value
+    return cleaned, reverse_values
+
+
+def _swap_endpoints(endpoints: dict[str, Any]) -> dict[str, Any]:
+    source = endpoints.get(connection.CONF_SOURCE)
+    target = endpoints.get(connection.CONF_TARGET)
+    return {
+        connection.CONF_SOURCE: normalize_connection_target(target),
+        connection.CONF_TARGET: normalize_connection_target(source),
+    }
+
+
+def _reverse_connection_name(base_name: str, source_name: str, target_name: str) -> str:
+    return f"{base_name} ({target_name} to {source_name})"
+
+
+def _unique_connection_name(base_name: str, existing_names: set[str]) -> str:
+    if base_name not in existing_names:
+        return base_name
+    suffix = 2
+    while f"{base_name} {suffix}" in existing_names:
+        suffix += 1
+    return f"{base_name} {suffix}"
+
+
+def migrate_connection_config(
+    data: dict[str, Any],
+    *,
+    existing_names: set[str] | None = None,
+) -> tuple[dict[str, Any], dict[str, Any] | None]:
+    """Migrate a connection config to unidirectional fields.
+
+    Returns:
+        Tuple of forward connection data and optional reverse connection data
+        when reverse-direction fields were configured.
+
+    """
+    migrated = dict(data)
+    migrated.pop("segment_order", None)
+
+    reverse_power: dict[str, Any] = {}
+    reverse_pricing: dict[str, Any] = {}
+    reverse_efficiency: dict[str, Any] = {}
+
+    power_limits, extracted_power = _strip_reverse_from_section(_section_dict(migrated, SECTION_POWER_LIMITS))
+    pricing, extracted_pricing = _strip_reverse_from_section(_section_dict(migrated, SECTION_PRICING))
+    efficiency, extracted_efficiency = _strip_reverse_from_section(_section_dict(migrated, SECTION_EFFICIENCY))
+
+    reverse_power.update(extracted_power)
+    reverse_pricing.update(extracted_pricing)
+    reverse_efficiency.update(extracted_efficiency)
+
+    migrated[SECTION_POWER_LIMITS] = power_limits
+    migrated[SECTION_PRICING] = pricing
+    migrated[SECTION_EFFICIENCY] = efficiency
+
+    has_reverse = bool(reverse_power or reverse_pricing or reverse_efficiency)
+    if not has_reverse:
+        return migrated, None
+
+    endpoints = _section_dict(migrated, connection.SECTION_ENDPOINTS)
+    source_name = get_connection_target_name(endpoints.get(connection.CONF_SOURCE)) or "source"
+    target_name = get_connection_target_name(endpoints.get(connection.CONF_TARGET)) or "target"
+    base_name = str(migrated.get(CONF_NAME, "Connection"))
+    reverse_name = _reverse_connection_name(base_name, source_name, target_name)
+    if existing_names is not None:
+        reverse_name = _unique_connection_name(reverse_name, existing_names)
+
+    reverse_data: dict[str, Any] = {
+        CONF_ELEMENT_TYPE: connection.ELEMENT_TYPE,
+        CONF_NAME: reverse_name,
+        connection.SECTION_ENDPOINTS: _swap_endpoints(endpoints),
+        SECTION_POWER_LIMITS: reverse_power,
+        SECTION_PRICING: reverse_pricing,
+        SECTION_EFFICIENCY: reverse_efficiency,
+    }
+    return migrated, reverse_data
+
+
+def endpoints_match_reverse(
+    endpoints: dict[str, Any],
+    *,
+    source_name: str,
+    target_name: str,
+) -> bool:
+    """Return True when endpoints are the reverse of the given source/target names."""
+    return (
+        get_connection_target_name(endpoints.get(connection.CONF_SOURCE)) == target_name
+        and get_connection_target_name(endpoints.get(connection.CONF_TARGET)) == source_name
+    )
+
+
+def merge_reverse_into_existing(
+    existing: dict[str, Any],
+    reverse_data: dict[str, Any],
+) -> dict[str, Any]:
+    """Merge reverse migration values into an existing reverse connection where unset."""
+    merged = dict(existing)
+    for section in _REVERSE_SECTIONS:
+        existing_section = _section_dict(merged, section)
+        reverse_section = _section_dict(reverse_data, section)
+        for key, value in reverse_section.items():
+            if key not in existing_section or not _is_configured_value(existing_section.get(key)):
+                existing_section[key] = value
+        merged[section] = existing_section
+    return merged
+
+
+__all__ = [
+    "endpoints_match_reverse",
+    "merge_reverse_into_existing",
+    "migrate_connection_config",
+]

--- a/custom_components/haeo/flows/elements/connection.py
+++ b/custom_components/haeo/flows/elements/connection.py
@@ -3,24 +3,18 @@
 from typing import Any
 
 from homeassistant.config_entries import ConfigSubentryFlow, SubentryFlowResult
-from homeassistant.helpers.selector import BooleanSelector, BooleanSelectorConfig
 import voluptuous as vol
 
 from custom_components.haeo.core.const import CONF_ELEMENT_TYPE, CONF_NAME
 from custom_components.haeo.core.schema import get_connection_target_name, normalize_connection_target
 from custom_components.haeo.core.schema.elements.connection import (
     CONF_EFFICIENCY_SOURCE_TARGET,
-    CONF_EFFICIENCY_TARGET_SOURCE,
     CONF_MAX_POWER_SOURCE_TARGET,
-    CONF_MAX_POWER_TARGET_SOURCE,
-    CONF_MIRROR_SEGMENT_ORDER,
     CONF_PRICE_SOURCE_TARGET,
-    CONF_PRICE_TARGET_SOURCE,
     CONF_SOURCE,
     CONF_TARGET,
     ELEMENT_TYPE,
     SECTION_ENDPOINTS,
-    SECTION_SEGMENT_ORDER,
 )
 from custom_components.haeo.elements import get_input_field_schema_info, get_input_fields
 from custom_components.haeo.elements.input_fields import InputFieldGroups
@@ -64,19 +58,6 @@ def _build_endpoints_fields(
     }
 
 
-def _build_segment_order_fields() -> dict[str, tuple[vol.Marker, Any]]:
-    """Build segment order field entries for config flows."""
-    return {
-        CONF_MIRROR_SEGMENT_ORDER: (
-            vol.Optional(CONF_MIRROR_SEGMENT_ORDER),
-            vol.All(
-                vol.Coerce(bool),
-                BooleanSelector(BooleanSelectorConfig()),
-            ),
-        )
-    }
-
-
 class ConnectionSubentryFlowHandler(ElementFlowMixin, ConfigSubentryFlow):
     """Handle connection element configuration flows."""
 
@@ -84,10 +65,9 @@ class ConnectionSubentryFlowHandler(ElementFlowMixin, ConfigSubentryFlow):
         """Return sections for the configuration step."""
         return (
             SectionDefinition(key=SECTION_ENDPOINTS, fields=(CONF_SOURCE, CONF_TARGET), collapsed=False),
-            SectionDefinition(key=SECTION_SEGMENT_ORDER, fields=(CONF_MIRROR_SEGMENT_ORDER,), collapsed=True),
-            power_limits_section((CONF_MAX_POWER_SOURCE_TARGET, CONF_MAX_POWER_TARGET_SOURCE), collapsed=False),
-            pricing_section((CONF_PRICE_SOURCE_TARGET, CONF_PRICE_TARGET_SOURCE), collapsed=False),
-            efficiency_section((CONF_EFFICIENCY_SOURCE_TARGET, CONF_EFFICIENCY_TARGET_SOURCE), collapsed=True),
+            power_limits_section((CONF_MAX_POWER_SOURCE_TARGET,), collapsed=False),
+            pricing_section((CONF_PRICE_SOURCE_TARGET,), collapsed=False),
+            efficiency_section((CONF_EFFICIENCY_SOURCE_TARGET,), collapsed=True),
         )
 
     async def async_step_user(self, user_input: dict[str, Any] | None = None) -> SubentryFlowResult:
@@ -173,7 +153,6 @@ class ConnectionSubentryFlowHandler(ElementFlowMixin, ConfigSubentryFlow):
             top_level_entries=build_common_fields(include_connection=False),
             extra_field_entries={
                 SECTION_ENDPOINTS: _build_endpoints_fields(participants, current_source, current_target),
-                SECTION_SEGMENT_ORDER: _build_segment_order_fields(),
             },
         )
 
@@ -187,7 +166,6 @@ class ConnectionSubentryFlowHandler(ElementFlowMixin, ConfigSubentryFlow):
     ) -> dict[str, Any]:
         """Build default values for the form."""
         endpoints_data = subentry_data.get(SECTION_ENDPOINTS, {}) if subentry_data else {}
-        segment_order_data = subentry_data.get(SECTION_SEGMENT_ORDER, {}) if subentry_data else {}
         source_default = (
             source_default
             if source_default is not None
@@ -212,9 +190,6 @@ class ConnectionSubentryFlowHandler(ElementFlowMixin, ConfigSubentryFlow):
                     SECTION_ENDPOINTS: {
                         CONF_SOURCE: source_default,
                         CONF_TARGET: target_default,
-                    },
-                    SECTION_SEGMENT_ORDER: {
-                        CONF_MIRROR_SEGMENT_ORDER: bool(segment_order_data.get(CONF_MIRROR_SEGMENT_ORDER, False)),
                     },
                 },
             ),
@@ -258,14 +233,10 @@ class ConnectionSubentryFlowHandler(ElementFlowMixin, ConfigSubentryFlow):
             self._get_sections(),
         )
         endpoints_config = config_dict.get(SECTION_ENDPOINTS, {})
-        segment_order_config = config_dict.get(SECTION_SEGMENT_ORDER, {})
         if CONF_SOURCE in endpoints_config:
             endpoints_config[CONF_SOURCE] = normalize_connection_target(endpoints_config[CONF_SOURCE])
         if CONF_TARGET in endpoints_config:
             endpoints_config[CONF_TARGET] = normalize_connection_target(endpoints_config[CONF_TARGET])
-        config_dict[SECTION_SEGMENT_ORDER] = {
-            CONF_MIRROR_SEGMENT_ORDER: bool(segment_order_config.get(CONF_MIRROR_SEGMENT_ORDER, False)),
-        }
 
         return {
             CONF_ELEMENT_TYPE: ELEMENT_TYPE,

--- a/custom_components/haeo/flows/elements/tests/test_connection_flow.py
+++ b/custom_components/haeo/flows/elements/tests/test_connection_flow.py
@@ -16,7 +16,6 @@ from custom_components.haeo.core.schema import as_connection_target, as_constant
 from custom_components.haeo.core.schema.elements import battery, grid, node
 from custom_components.haeo.core.schema.elements.connection import (
     CONF_MAX_POWER_SOURCE_TARGET,
-    CONF_MAX_POWER_TARGET_SOURCE,
     CONF_SOURCE,
     CONF_TARGET,
     ELEMENT_TYPE,
@@ -37,7 +36,7 @@ def _wrap_input(flat: dict[str, Any]) -> dict[str, Any]:
         CONF_SOURCE: flat[CONF_SOURCE],
         CONF_TARGET: flat[CONF_TARGET],
     }
-    limits = {key: flat[key] for key in (CONF_MAX_POWER_SOURCE_TARGET, CONF_MAX_POWER_TARGET_SOURCE) if key in flat}
+    limits = {key: flat[key] for key in (CONF_MAX_POWER_SOURCE_TARGET,) if key in flat}
     return {
         CONF_NAME: flat[CONF_NAME],
         SECTION_ENDPOINTS: endpoints,
@@ -146,11 +145,9 @@ def test_build_config_normalizes_endpoints(hass: HomeAssistant, hub_entry: MockC
                 CONF_SOURCE: "Battery1",
                 CONF_TARGET: "Grid1",
                 CONF_MAX_POWER_SOURCE_TARGET: as_entity_value(["sensor.max_power_st"]),
-                CONF_MAX_POWER_TARGET_SOURCE: as_entity_value(["sensor.max_power_ts"]),
             },
             {
                 CONF_MAX_POWER_SOURCE_TARGET: ["sensor.max_power_st"],
-                CONF_MAX_POWER_TARGET_SOURCE: ["sensor.max_power_ts"],
             },
             id="entity_values",
         ),
@@ -163,11 +160,9 @@ def test_build_config_normalizes_endpoints(hass: HomeAssistant, hub_entry: MockC
                 CONF_SOURCE: "DeletedBattery",
                 CONF_TARGET: "Grid1",
                 CONF_MAX_POWER_SOURCE_TARGET: as_constant_value(10.0),
-                CONF_MAX_POWER_TARGET_SOURCE: as_constant_value(10.0),
             },
             {
                 CONF_MAX_POWER_SOURCE_TARGET: 10.0,
-                CONF_MAX_POWER_TARGET_SOURCE: 10.0,
             },
             id="constant_values_deleted_source",
         ),
@@ -229,22 +224,18 @@ async def test_user_step_with_constant_creates_entry(
         }
     )
 
-    # Submit with constant values using choose selector format
     user_input = {
         CONF_NAME: "Test Connection",
         CONF_SOURCE: "Battery1",
         CONF_TARGET: "Grid1",
         CONF_MAX_POWER_SOURCE_TARGET: 10.0,
-        CONF_MAX_POWER_TARGET_SOURCE: 10.0,
     }
     result = await flow.async_step_user(user_input=user_input)
 
     assert result.get("type") == FlowResultType.CREATE_ENTRY
 
-    # Verify the config contains the constant values
     create_kwargs = flow.async_create_entry.call_args.kwargs
     assert create_kwargs["data"][SECTION_POWER_LIMITS][CONF_MAX_POWER_SOURCE_TARGET] == as_constant_value(10.0)
-    assert create_kwargs["data"][SECTION_POWER_LIMITS][CONF_MAX_POWER_TARGET_SOURCE] == as_constant_value(10.0)
 
 
 async def test_user_step_with_entity_creates_entry(
@@ -264,23 +255,17 @@ async def test_user_step_with_entity_creates_entry(
         }
     )
 
-    # Submit with entity selections
     user_input = {
         CONF_NAME: "Test Connection",
         CONF_SOURCE: "Battery1",
         CONF_TARGET: "Grid1",
         CONF_MAX_POWER_SOURCE_TARGET: ["sensor.power_st"],
-        CONF_MAX_POWER_TARGET_SOURCE: ["sensor.power_ts"],
     }
     result = await flow.async_step_user(user_input=user_input)
 
     assert result.get("type") == FlowResultType.CREATE_ENTRY
 
-    # Verify the config contains the entity schema values (single entity)
     create_kwargs = flow.async_create_entry.call_args.kwargs
     assert create_kwargs["data"][SECTION_POWER_LIMITS][CONF_MAX_POWER_SOURCE_TARGET] == as_entity_value(
         ["sensor.power_st"]
-    )
-    assert create_kwargs["data"][SECTION_POWER_LIMITS][CONF_MAX_POWER_TARGET_SOURCE] == as_entity_value(
-        ["sensor.power_ts"]
     )

--- a/custom_components/haeo/flows/hub.py
+++ b/custom_components/haeo/flows/hub.py
@@ -40,7 +40,7 @@ class HubConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for HAEO hub creation."""
 
     VERSION = 1
-    MINOR_VERSION = 3
+    MINOR_VERSION = 4
 
     def __init__(self) -> None:
         """Initialize the config flow."""

--- a/custom_components/haeo/flows/tests/test_data/connection.py
+++ b/custom_components/haeo/flows/tests/test_data/connection.py
@@ -5,7 +5,6 @@ from custom_components.haeo.core.schema import as_connection_target, as_constant
 from custom_components.haeo.core.schema.elements.connection import (
     CONF_EFFICIENCY_SOURCE_TARGET,
     CONF_MAX_POWER_SOURCE_TARGET,
-    CONF_MAX_POWER_TARGET_SOURCE,
     CONF_SOURCE,
     CONF_TARGET,
     SECTION_EFFICIENCY,
@@ -40,7 +39,6 @@ VALID_DATA = [
             },
             SECTION_POWER_LIMITS: {
                 CONF_MAX_POWER_SOURCE_TARGET: as_constant_value(10.0),
-                CONF_MAX_POWER_TARGET_SOURCE: as_constant_value(10.0),
             },
             SECTION_PRICING: {},
             SECTION_EFFICIENCY: {

--- a/custom_components/haeo/migrations/__init__.py
+++ b/custom_components/haeo/migrations/__init__.py
@@ -7,11 +7,14 @@ from collections.abc import Awaitable, Callable
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
-from . import v1_3
+from . import v1_3, v1_4
 
 type MigrationHandler = Callable[[HomeAssistant, ConfigEntry], Awaitable[bool]]
 
-MIGRATIONS: tuple[tuple[int, MigrationHandler], ...] = ((v1_3.MINOR_VERSION, v1_3.async_migrate_entry),)
+MIGRATIONS: tuple[tuple[int, MigrationHandler], ...] = (
+    (v1_3.MINOR_VERSION, v1_3.async_migrate_entry),
+    (v1_4.MINOR_VERSION, v1_4.async_migrate_entry),
+)
 
 MIGRATION_MINOR_VERSION = MIGRATIONS[-1][0] if MIGRATIONS else 0
 

--- a/custom_components/haeo/migrations/tests/test_v1_3.py
+++ b/custom_components/haeo/migrations/tests/test_v1_3.py
@@ -238,16 +238,16 @@ def test_migrate_subentry_connection_fields() -> None:
         CONF_NAME: "Connection",
         connection.SECTION_ENDPOINTS: {connection.CONF_SOURCE: "node_a", connection.CONF_TARGET: "node_b"},
         SECTION_POWER_LIMITS: {
-            connection.CONF_MAX_POWER_SOURCE_TARGET: 4.0,
-            connection.CONF_MAX_POWER_TARGET_SOURCE: 3.5,
+            CONF_MAX_POWER_SOURCE_TARGET: 4.0,
+            CONF_MAX_POWER_TARGET_SOURCE: 3.5,
         },
         SECTION_PRICING: {
-            connection.CONF_PRICE_SOURCE_TARGET: 0.1,
-            connection.CONF_PRICE_TARGET_SOURCE: 0.2,
+            CONF_PRICE_SOURCE_TARGET: 0.1,
+            CONF_PRICE_TARGET_SOURCE: 0.2,
         },
         SECTION_EFFICIENCY: {
-            connection.CONF_EFFICIENCY_SOURCE_TARGET: 0.9,
-            connection.CONF_EFFICIENCY_TARGET_SOURCE: 0.91,
+            CONF_EFFICIENCY_SOURCE_TARGET: 0.9,
+            CONF_EFFICIENCY_TARGET_SOURCE: 0.91,
         },
     }
     subentry = _create_subentry(data, subentry_type=connection.ELEMENT_TYPE)
@@ -257,9 +257,9 @@ def test_migrate_subentry_connection_fields() -> None:
     assert migrated is not None
     assert migrated[CONF_NAME] == "Connection"
     assert migrated[connection.SECTION_ENDPOINTS][connection.CONF_SOURCE] == as_connection_target("node_a")
-    assert migrated[SECTION_POWER_LIMITS][connection.CONF_MAX_POWER_SOURCE_TARGET] == as_constant_value(4.0)
-    assert migrated[SECTION_PRICING][connection.CONF_PRICE_TARGET_SOURCE] == as_constant_value(0.2)
-    assert migrated[SECTION_EFFICIENCY][connection.CONF_EFFICIENCY_TARGET_SOURCE] == as_constant_value(0.91)
+    assert migrated[SECTION_POWER_LIMITS][CONF_MAX_POWER_SOURCE_TARGET] == as_constant_value(4.0)
+    assert migrated[SECTION_PRICING][CONF_PRICE_TARGET_SOURCE] == as_constant_value(0.2)
+    assert migrated[SECTION_EFFICIENCY][CONF_EFFICIENCY_TARGET_SOURCE] == as_constant_value(0.91)
 
 
 def test_migrate_subentry_grid_legacy_fields() -> None:
@@ -390,10 +390,10 @@ def test_migrate_subentry_load_node_solar() -> None:
                 CONF_NAME: "Connection",
                 connection.CONF_SOURCE: "node_a",
                 connection.CONF_TARGET: "node_b",
-                connection.CONF_MAX_POWER_SOURCE_TARGET: 4.0,
-                connection.CONF_MAX_POWER_TARGET_SOURCE: 4.0,
-                connection.CONF_PRICE_SOURCE_TARGET: 0.1,
-                connection.CONF_PRICE_TARGET_SOURCE: 0.2,
+                CONF_MAX_POWER_SOURCE_TARGET: 4.0,
+                CONF_MAX_POWER_TARGET_SOURCE: 4.0,
+                CONF_PRICE_SOURCE_TARGET: 0.1,
+                CONF_PRICE_TARGET_SOURCE: 0.2,
             },
             id="connection-flat-v033",
         ),

--- a/custom_components/haeo/migrations/tests/test_v1_4.py
+++ b/custom_components/haeo/migrations/tests/test_v1_4.py
@@ -1,0 +1,191 @@
+"""Tests for config entry migration helpers (v1.4)."""
+
+from __future__ import annotations
+
+from types import MappingProxyType
+from typing import Any
+
+from homeassistant.config_entries import ConfigSubentry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.haeo.const import DOMAIN
+from custom_components.haeo.core.const import CONF_ELEMENT_TYPE, CONF_NAME
+from custom_components.haeo.core.schema import as_connection_target, as_constant_value
+from custom_components.haeo.core.schema.elements import connection
+from custom_components.haeo.core.schema.sections import (
+    CONF_EFFICIENCY_SOURCE_TARGET,
+    CONF_EFFICIENCY_TARGET_SOURCE,
+    CONF_MAX_POWER_SOURCE_TARGET,
+    CONF_MAX_POWER_TARGET_SOURCE,
+    CONF_PRICE_SOURCE_TARGET,
+    CONF_PRICE_TARGET_SOURCE,
+    SECTION_EFFICIENCY,
+    SECTION_POWER_LIMITS,
+    SECTION_PRICING,
+)
+from custom_components.haeo.migrations import v1_4
+
+
+def _create_subentry(data: dict[str, Any], *, subentry_type: str | None = None) -> ConfigSubentry:
+    return ConfigSubentry(
+        data=MappingProxyType(data),
+        subentry_type=subentry_type or str(data.get(CONF_ELEMENT_TYPE, "unknown")),
+        title=str(data.get(CONF_NAME, "unnamed")),
+        unique_id=None,
+    )
+
+
+async def test_async_migrate_entry_splits_reverse_connection(hass: HomeAssistant) -> None:
+    """v1.4 migration creates a reverse connection subentry from reverse-direction fields."""
+    entry = MockConfigEntry(domain=DOMAIN, title="Hub", data={CONF_NAME: "Hub"}, version=1, minor_version=3)
+    entry.add_to_hass(hass)
+
+    connection_subentry = _create_subentry(
+        {
+            CONF_ELEMENT_TYPE: connection.ELEMENT_TYPE,
+            CONF_NAME: "DC to AC",
+            connection.SECTION_ENDPOINTS: {
+                connection.CONF_SOURCE: as_connection_target("DC Bus"),
+                connection.CONF_TARGET: as_connection_target("AC Bus"),
+            },
+            SECTION_POWER_LIMITS: {
+                CONF_MAX_POWER_SOURCE_TARGET: as_constant_value(10.0),
+                CONF_MAX_POWER_TARGET_SOURCE: as_constant_value(8.0),
+            },
+            SECTION_PRICING: {
+                CONF_PRICE_TARGET_SOURCE: as_constant_value(0.2),
+            },
+            SECTION_EFFICIENCY: {},
+            "segment_order": {"mirror_segment_order": True},
+        },
+        subentry_type=connection.ELEMENT_TYPE,
+    )
+    hass.config_entries.async_add_subentry(entry, connection_subentry)
+
+    result = await v1_4.async_migrate_entry(hass, entry)
+    assert result is True
+    assert entry.minor_version == v1_4.MINOR_VERSION
+
+    connections = [s for s in entry.subentries.values() if s.subentry_type == connection.ELEMENT_TYPE]
+    assert len(connections) == 2
+
+    forward = next(s for s in connections if s.title == "DC to AC")
+    assert CONF_MAX_POWER_TARGET_SOURCE not in forward.data[SECTION_POWER_LIMITS]
+    assert "segment_order" not in forward.data
+    assert forward.data[SECTION_POWER_LIMITS][CONF_MAX_POWER_SOURCE_TARGET] == as_constant_value(10.0)
+
+    reverse = next(s for s in connections if s.title != "DC to AC")
+    assert reverse.title == "DC to AC (AC Bus to DC Bus)"
+    assert reverse.data[SECTION_POWER_LIMITS][CONF_MAX_POWER_SOURCE_TARGET] == as_constant_value(8.0)
+    assert reverse.data[SECTION_PRICING][CONF_PRICE_SOURCE_TARGET] == as_constant_value(0.2)
+
+
+async def test_async_migrate_entry_merges_into_existing_reverse(hass: HomeAssistant) -> None:
+    """v1.4 migration merges reverse values into an existing reverse connection."""
+    entry = MockConfigEntry(domain=DOMAIN, title="Hub", data={CONF_NAME: "Hub"}, version=1, minor_version=3)
+    entry.add_to_hass(hass)
+
+    forward_subentry = _create_subentry(
+        {
+            CONF_ELEMENT_TYPE: connection.ELEMENT_TYPE,
+            CONF_NAME: "DC to AC",
+            connection.SECTION_ENDPOINTS: {
+                connection.CONF_SOURCE: as_connection_target("DC Bus"),
+                connection.CONF_TARGET: as_connection_target("AC Bus"),
+            },
+            SECTION_POWER_LIMITS: {
+                CONF_MAX_POWER_TARGET_SOURCE: as_constant_value(8.0),
+            },
+            SECTION_PRICING: {},
+            SECTION_EFFICIENCY: {},
+        },
+        subentry_type=connection.ELEMENT_TYPE,
+    )
+    reverse_subentry = _create_subentry(
+        {
+            CONF_ELEMENT_TYPE: connection.ELEMENT_TYPE,
+            CONF_NAME: "DC to AC (AC Bus to DC Bus)",
+            connection.SECTION_ENDPOINTS: {
+                connection.CONF_SOURCE: as_connection_target("AC Bus"),
+                connection.CONF_TARGET: as_connection_target("DC Bus"),
+            },
+            SECTION_POWER_LIMITS: {},
+            SECTION_PRICING: {
+                CONF_PRICE_SOURCE_TARGET: as_constant_value(0.05),
+            },
+            SECTION_EFFICIENCY: {},
+        },
+        subentry_type=connection.ELEMENT_TYPE,
+    )
+    hass.config_entries.async_add_subentry(entry, forward_subentry)
+    hass.config_entries.async_add_subentry(entry, reverse_subentry)
+
+    result = await v1_4.async_migrate_entry(hass, entry)
+    assert result is True
+
+    connections = [s for s in entry.subentries.values() if s.subentry_type == connection.ELEMENT_TYPE]
+    assert len(connections) == 2
+
+    reverse = next(s for s in connections if s.title == "DC to AC (AC Bus to DC Bus)")
+    assert reverse.data[SECTION_POWER_LIMITS][CONF_MAX_POWER_SOURCE_TARGET] == as_constant_value(8.0)
+    assert reverse.data[SECTION_PRICING][CONF_PRICE_SOURCE_TARGET] == as_constant_value(0.05)
+
+
+async def test_async_migrate_entry_moves_reverse_entity_unique_id(hass: HomeAssistant) -> None:
+    """v1.4 migration re-homes input entity unique IDs for reverse-direction fields."""
+    entry = MockConfigEntry(domain=DOMAIN, title="Hub", data={CONF_NAME: "Hub"}, version=1, minor_version=3)
+    entry.add_to_hass(hass)
+
+    connection_subentry = _create_subentry(
+        {
+            CONF_ELEMENT_TYPE: connection.ELEMENT_TYPE,
+            CONF_NAME: "Line",
+            connection.SECTION_ENDPOINTS: {
+                connection.CONF_SOURCE: as_connection_target("A"),
+                connection.CONF_TARGET: as_connection_target("B"),
+            },
+            SECTION_POWER_LIMITS: {
+                CONF_MAX_POWER_TARGET_SOURCE: as_constant_value(5.0),
+            },
+            SECTION_PRICING: {},
+            SECTION_EFFICIENCY: {},
+        },
+        subentry_type=connection.ELEMENT_TYPE,
+    )
+    hass.config_entries.async_add_subentry(entry, connection_subentry)
+
+    registry = er.async_get(hass)
+    old_uid = f"{entry.entry_id}_{connection_subentry.subentry_id}_max_power_target_source"
+    registry.async_get_or_create(
+        "number",
+        DOMAIN,
+        old_uid,
+        config_entry=entry,
+        suggested_object_id="line_max_power_target_source",
+    )
+
+    result = await v1_4.async_migrate_entry(hass, entry)
+    assert result is True
+
+    reverse = next(
+        s
+        for s in entry.subentries.values()
+        if s.subentry_type == connection.ELEMENT_TYPE and s.title != "Line"
+    )
+    new_uid = f"{entry.entry_id}_{reverse.subentry_id}_max_power_source_target"
+    entry_by_uid = registry.async_get_entity_id("number", DOMAIN, new_uid)
+    assert entry_by_uid is not None
+    assert registry.async_get_entity_id("number", DOMAIN, old_uid) is None
+
+
+async def test_async_migrate_entry_skips_when_already_current(hass: HomeAssistant) -> None:
+    """v1.4 migration is a no-op when minor version is already current."""
+    entry = MockConfigEntry(domain=DOMAIN, title="Hub", data={CONF_NAME: "Hub"}, version=1, minor_version=4)
+    entry.add_to_hass(hass)
+
+    result = await v1_4.async_migrate_entry(hass, entry)
+    assert result is True
+    assert entry.minor_version == 4

--- a/custom_components/haeo/migrations/v1_4.py
+++ b/custom_components/haeo/migrations/v1_4.py
@@ -1,0 +1,206 @@
+"""Migration helpers for config entry version 1.4."""
+
+from __future__ import annotations
+
+import logging
+from types import MappingProxyType
+from typing import Any
+
+from homeassistant.config_entries import ConfigEntry, ConfigSubentry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from custom_components.haeo.const import DOMAIN
+from custom_components.haeo.core.const import CONF_ELEMENT_TYPE, CONF_NAME
+from custom_components.haeo.core.schema import get_connection_target_name
+from custom_components.haeo.core.schema.elements import connection
+from custom_components.haeo.core.schema.migrations.v1_4 import (
+    endpoints_match_reverse,
+    merge_reverse_into_existing,
+    migrate_connection_config,
+)
+from custom_components.haeo.core.schema.sections import (
+    CONF_EFFICIENCY_TARGET_SOURCE,
+    CONF_MAX_POWER_TARGET_SOURCE,
+    CONF_PRICE_TARGET_SOURCE,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+MINOR_VERSION = 4
+_CONNECTION_TYPE = connection.ELEMENT_TYPE
+_UNIQUE_ID_PART_COUNT = 3
+
+_REVERSE_FIELD_RENAMES: dict[str, str] = {
+    CONF_MAX_POWER_TARGET_SOURCE: "max_power_source_target",
+    CONF_PRICE_TARGET_SOURCE: "price_source_target",
+    CONF_EFFICIENCY_TARGET_SOURCE: "efficiency_source_target",
+}
+
+
+def _collect_subentry_names(entry: ConfigEntry) -> set[str]:
+    return {subentry.title for subentry in entry.subentries.values()}
+
+
+def _find_reverse_subentry(
+    entry: ConfigEntry,
+    *,
+    source_name: str,
+    target_name: str,
+    exclude_subentry_id: str | None,
+) -> ConfigSubentry | None:
+    for subentry in entry.subentries.values():
+        if subentry.subentry_id == exclude_subentry_id:
+            continue
+        data = dict(subentry.data)
+        if data.get(CONF_ELEMENT_TYPE) != _CONNECTION_TYPE:
+            continue
+        endpoints = data.get(connection.SECTION_ENDPOINTS, {})
+        if not isinstance(endpoints, dict):
+            continue
+        if endpoints_match_reverse(endpoints, source_name=source_name, target_name=target_name):
+            return subentry
+    return None
+
+
+async def _migrate_connection_entity_unique_ids(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    *,
+    subentry_id_map: dict[str, str],
+) -> None:
+    """Re-home connection input entities from reverse fields to the new reverse subentry."""
+    registry = er.async_get(hass)
+    candidate_unique_ids: dict[str, str] = {}
+    candidate_counts: dict[str, int] = {}
+
+    for entity_entry in er.async_entries_for_config_entry(registry, entry.entry_id):
+        uid = entity_entry.unique_id
+        if not uid:
+            continue
+
+        parts = uid.split("_", 2)
+        if len(parts) != _UNIQUE_ID_PART_COUNT:
+            continue
+
+        subentry_id = parts[1]
+        field_path_key = parts[2]
+        new_subentry_id = subentry_id_map.get(subentry_id)
+        if new_subentry_id is None:
+            continue
+
+        path_parts = field_path_key.split(".")
+        leaf = path_parts[-1]
+        new_leaf = _REVERSE_FIELD_RENAMES.get(leaf)
+        if new_leaf is None:
+            continue
+
+        new_uid = f"{parts[0]}_{new_subentry_id}_{new_leaf}"
+        if new_uid == uid:
+            continue
+
+        candidate_unique_ids[entity_entry.entity_id] = new_uid
+        candidate_counts[new_uid] = candidate_counts.get(new_uid, 0) + 1
+
+    def _migrate_unique_id(entity_entry: er.RegistryEntry) -> dict[str, Any] | None:
+        new_uid = candidate_unique_ids.get(entity_entry.entity_id)
+        if new_uid is None:
+            return None
+
+        if candidate_counts.get(new_uid, 0) > 1:
+            _LOGGER.info(
+                "Skipping unique_id migration for %s because target would collide: %s",
+                entity_entry.entity_id,
+                new_uid,
+            )
+            return None
+
+        conflict_entity_id = registry.async_get_entity_id(
+            entity_entry.domain,
+            entity_entry.platform,
+            new_uid,
+        )
+        if conflict_entity_id and conflict_entity_id != entity_entry.entity_id:
+            _LOGGER.info(
+                "Removing duplicate entity %s to keep existing stable unique_id %s",
+                entity_entry.entity_id,
+                new_uid,
+            )
+            registry.async_remove(entity_entry.entity_id)
+            return None
+
+        return {"new_unique_id": new_uid}
+
+    await er.async_migrate_entries(hass, entry.entry_id, _migrate_unique_id)
+
+
+async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Migrate existing config entries to version 1.4."""
+    if entry.minor_version >= MINOR_VERSION:
+        return True
+
+    _LOGGER.info(
+        "Migrating %s entry %s to version 1.%s",
+        DOMAIN,
+        entry.entry_id,
+        MINOR_VERSION,
+    )
+
+    subentry_id_map: dict[str, str] = {}
+    existing_names = _collect_subentry_names(entry)
+
+    for subentry in list(entry.subentries.values()):
+        data = dict(subentry.data)
+        if data.get(CONF_ELEMENT_TYPE) != _CONNECTION_TYPE:
+            continue
+
+        endpoints = data.get(connection.SECTION_ENDPOINTS, {})
+        if not isinstance(endpoints, dict):
+            endpoints = {}
+        source_name = get_connection_target_name(endpoints.get(connection.CONF_SOURCE)) or ""
+        target_name = get_connection_target_name(endpoints.get(connection.CONF_TARGET)) or ""
+
+        forward_data, reverse_data = migrate_connection_config(data, existing_names=existing_names)
+        hass.config_entries.async_update_subentry(entry, subentry, data=forward_data)
+        existing_names.add(subentry.title)
+
+        if reverse_data is None:
+            continue
+
+        existing_reverse = _find_reverse_subentry(
+            entry,
+            source_name=source_name,
+            target_name=target_name,
+            exclude_subentry_id=subentry.subentry_id,
+        )
+        if existing_reverse is not None:
+            merged = merge_reverse_into_existing(dict(existing_reverse.data), reverse_data)
+            hass.config_entries.async_update_subentry(entry, existing_reverse, data=merged)
+            _LOGGER.info(
+                "Merged reverse connection settings into existing subentry %s",
+                existing_reverse.title,
+            )
+            continue
+
+        reverse_title = str(reverse_data[CONF_NAME])
+        new_subentry = ConfigSubentry(
+            data=MappingProxyType(reverse_data),
+            subentry_type=_CONNECTION_TYPE,
+            title=reverse_title,
+            unique_id=None,
+        )
+        hass.config_entries.async_add_subentry(entry, new_subentry)
+        existing_names.add(reverse_title)
+        subentry_id_map[subentry.subentry_id] = new_subentry.subentry_id
+        _LOGGER.info(
+            "Created reverse connection subentry %s from %s",
+            reverse_title,
+            subentry.title,
+        )
+
+    if subentry_id_map:
+        await _migrate_connection_entity_unique_ids(hass, entry, subentry_id_map=subentry_id_map)
+
+    hass.config_entries.async_update_entry(entry, minor_version=MINOR_VERSION)
+    _LOGGER.info("Migration complete for %s entry %s", DOMAIN, entry.entry_id)
+    return True

--- a/custom_components/haeo/translations/en.json
+++ b/custom_components/haeo/translations/en.json
@@ -200,52 +200,35 @@
       "step": {
         "user": {
           "title": "Connection Configuration",
-          "description": "Configure connection parameters between devices",
+          "description": "Configure a unidirectional power path from source to target. For reverse flow, add a second connection with swapped endpoints.",
           "data": {
-            "efficiency_source_target": "Efficiency Source to Target",
-            "efficiency_target_source": "Efficiency Target to Source",
-            "max_power_source_target": "Max Power Source to Target",
-            "max_power_target_source": "Max Power Target to Source",
-            "mirror_segment_order": "Mirror segment order",
+            "efficiency_source_target": "Efficiency",
+            "max_power_source_target": "Max power",
             "name": "Connection Name",
-            "price_source_target": "Price Source to Target",
-            "price_target_source": "Price Target to Source",
+            "price_source_target": "Price",
             "source": "Source Device",
             "target": "Target Device"
           },
           "sections": {
             "common": { "data": { "name": "Connection Name" }, "name": "Common settings" },
             "efficiency": {
-              "data": {
-                "efficiency_source_target": "Efficiency Source to Target",
-                "efficiency_target_source": "Efficiency Target to Source"
-              },
+              "data": { "efficiency_source_target": "Efficiency" },
               "name": "Connection efficiency"
             },
             "endpoints": { "data": { "source": "Source Device", "target": "Target Device" }, "name": "Endpoints" },
             "power_limits": {
-              "data": {
-                "max_power_source_target": "Max Power Source to Target",
-                "max_power_target_source": "Max Power Target to Source"
-              },
+              "data": { "max_power_source_target": "Max power" },
               "name": "Power limits"
             },
             "pricing": {
-              "data": {
-                "price_source_target": "Price Source to Target",
-                "price_target_source": "Price Target to Source"
-              },
+              "data": { "price_source_target": "Price" },
               "name": "Pricing"
-            },
-            "segment_order": { "data": { "mirror_segment_order": "Mirror segment order" }, "name": "Segment order" }
+            }
           }
         }
       },
       "error": {
         "cannot_connect_to_self": "Cannot connect a device to itself",
-        "max_power_must_be_positive_for_bidirectional": "Maximum power must be positive for bidirectional connections",
-        "min_power_negative_not_allowed_unidirectional": "Minimum power cannot be negative for unidirectional connections",
-        "min_power_too_high": "Minimum power must be less than or equal to maximum power",
         "missing_name": "Name is required",
         "name_exists": "A device with this name already exists"
       },
@@ -484,12 +467,9 @@
       "battery_salvage_value": { "name": "Salvage value" },
       "battery_undercharge_partition_cost": { "name": "Undercharge cost" },
       "battery_undercharge_partition_percentage": { "name": "Undercharge percentage" },
-      "connection_efficiency_source_target": { "name": "Source to target efficiency" },
-      "connection_efficiency_target_source": { "name": "Target to source efficiency" },
-      "connection_max_power_source_target": { "name": "Max source to target power" },
-      "connection_max_power_target_source": { "name": "Max target to source power" },
-      "connection_price_source_target": { "name": "Source to target price" },
-      "connection_price_target_source": { "name": "Target to source price" },
+      "connection_efficiency_source_target": { "name": "Efficiency" },
+      "connection_max_power_source_target": { "name": "Max power" },
+      "connection_price_source_target": { "name": "Price" },
       "grid_max_power_source_target": { "name": "Import limit" },
       "grid_max_power_target_source": { "name": "Export limit" },
       "grid_price_source_target": { "name": "Import price" },

--- a/docs/modeling/device-layer/connection.md
+++ b/docs/modeling/device-layer/connection.md
@@ -1,7 +1,9 @@
 # Connection Modeling
 
-The Connection device provides explicit user-defined power flow paths between elements.
-Unlike implicit connections created by other devices, it allows full control over bidirectional flow, efficiency, and pricing.
+The Connection device provides explicit user-defined **unidirectional** power flow paths between elements.
+Unlike implicit connections created by other devices, it allows control over capacity, efficiency, and pricing along a single direction (source → target).
+
+Bidirectional physical paths are modeled as **two** Connection devices with swapped endpoints.
 
 ## Model Elements Created
 
@@ -14,103 +16,100 @@ graph LR
     Source[Source Element]
     Target[Target Element]
 
-    Source <-->|links via| MC
-    MC <-->|links to| Target
+    Source -->|power out| MC
+    MC -->|power in| Target
 ```
 
 | Model Element                                          | Name     | Parameters From Configuration              |
 | ------------------------------------------------------ | -------- | ------------------------------------------ |
 | [Connection](../model-layer/connections/connection.md) | `{name}` | Source, target, and segment specifications |
 
-The Connection device creates a `Connection` model element with a segment chain.
-The adapter builds power-limit, efficiency, and pricing segments based on configured fields.
+The Connection device creates one `Connection` model element with a segment chain.
+The adapter maps each configured field to a single forward segment.
 
 ## Devices Created
 
 Connection creates 1 device in Home Assistant:
 
-| Device  | Name     | Created When | Purpose                  |
-| ------- | -------- | ------------ | ------------------------ |
-| Primary | `{name}` | Always       | Explicit power flow path |
+| Device  | Name     | Created When | Purpose                    |
+| ------- | -------- | ------------ | -------------------------- |
+| Primary | `{name}` | Always       | Explicit power flow path   |
 
 ## Parameter mapping
 
 The adapter maps configuration into connection segments:
 
-| User Configuration         | Segment           | Segment Field              | Notes                          |
-| -------------------------- | ----------------- | -------------------------- | ------------------------------ |
-| `source`                   | Connection        | `source`                   | Source element name            |
-| `target`                   | Connection        | `target`                   | Target element name            |
-| `max_power_source_target`  | PowerLimitSegment | `max_power_source_target`  | Optional, unlimited if not set |
-| `max_power_target_source`  | PowerLimitSegment | `max_power_target_source`  | Optional, unlimited if not set |
-| `efficiency_source_target` | EfficiencySegment | `efficiency_source_target` | Percent converted to ratio     |
-| `efficiency_target_source` | EfficiencySegment | `efficiency_target_source` | Percent converted to ratio     |
-| `price_source_target`      | PricingSegment    | `price_source_target`      | Optional, no cost if not set   |
-| `price_target_source`      | PricingSegment    | `price_target_source`      | Optional, no cost if not set   |
-| `mirror_segment_order`     | Connection        | `mirror_segment_order`     | Optional, default is reversed  |
+| User Configuration         | Segment           | Segment field | Notes                          |
+| -------------------------- | ----------------- | ------------- | ------------------------------ |
+| `source`                   | Connection        | `source`      | Source element name            |
+| `target`                   | Connection        | `target`      | Target element name            |
+| `max_power_source_target`  | PowerLimitSegment | `max_power`   | Optional, unlimited if unset |
+| `efficiency_source_target` | EfficiencySegment | `efficiency`  | Percent converted to ratio     |
+| `price_source_target`      | PricingSegment    | `price`       | Optional, no cost if unset     |
 
 If a field is omitted, the corresponding segment defaults apply.
 Power limits and pricing are skipped when values are `None`.
 Efficiency defaults to 100% via the efficiency segment.
-Source→target flow uses the segment order provided.
-Target→source flow uses the reverse order by default.
-Set `mirror_segment_order` to use the same segment order for both flow directions.
 
 ## Sensors Created
 
 ### Connection Device
 
-| Sensor                | Unit   | Update    | Description                                   |
-| --------------------- | ------ | --------- | --------------------------------------------- |
-| `power_source_target` | kW     | Real-time | Power flow from source to target              |
-| `power_target_source` | kW     | Real-time | Power flow from target to source              |
-| `power_active`        | kW     | Real-time | Net power (source→target minus target→source) |
-| `shadow_power_max_*`  | \$/kWh | Real-time | Shadow prices for power limits                |
-| `time_slice`          | \$/kWh | Real-time | Shadow price for time-slice coupling          |
+| Sensor              | Unit | Update    | Description                        |
+| ------------------- | ---- | --------- | ---------------------------------- |
+| `connection_power`  | kW   | Real-time | Power flow from source to target   |
 
 See [Connection Configuration](../../user-guide/elements/connections.md) for detailed sensor and configuration documentation.
 
 ## Configuration Examples
 
-### AC/DC Inverter
+### One-way capacity limit
 
-| Field                           | Value    |
-| ------------------------------- | -------- |
-| **Name**                        | Inverter |
-| **Source**                      | DC Bus   |
-| **Target**                      | AC Bus   |
-| **Max Power Source to Target**  | 10.0     |
-| **Max Power Target to Source**  | 10.0     |
-| **Efficiency Source to Target** | 0.97     |
-| **Efficiency Target to Source** | 0.96     |
+| Field          | Value  |
+| -------------- | ------ |
+| **Name**       | Link   |
+| **Source**     | Zone A |
+| **Target**     | Zone B |
+| **Max power**  | 10.0   |
 
-### Wheeling Charge
+### Wheeling charge
 
-| Field                      | Value                  |
-| -------------------------- | ---------------------- |
-| **Name**                   | Grid Transfer          |
-| **Source**                 | Zone A                 |
-| **Target**                 | Zone B                 |
-| **Price Source to Target** | sensor.wheeling_charge |
-| **Price Target to Source** | sensor.wheeling_charge |
+| Field     | Value                  |
+| --------- | ---------------------- |
+| **Name**  | Grid transfer          |
+| **Source**| Zone A                 |
+| **Target**| Zone B                 |
+| **Price** | sensor.wheeling_charge |
+
+### Bidirectional path (two connections)
+
+| Connection | Source | Target | Notes                          |
+| ---------- | ------ | ------ | ------------------------------ |
+| A to B     | Zone A | Zone B | Forward limits and pricing     |
+| B to A     | Zone B | Zone A | Independent reverse parameters |
+
+For packaged AC/DC conversion with a DC bus, the [Inverter](inverter.md) device is often simpler than manual dual connections.
 
 ## Typical Use Cases
 
-**AC/DC Conversion**:
-Model inverter efficiency losses between DC battery/solar and AC loads/grid with bidirectional efficiency parameters.
+**Additional network paths**:
+Connect nodes that are not linked by implicit element connections.
 
-**Wheeling Charges**:
-Apply transmission costs for power transfer between geographic zones or utility territories.
+**Conversion and losses**:
+Model inverter or transmission efficiency on a dedicated path.
 
-**Capacity Limits**:
-Constrain power flow through physical bottlenecks like panel ratings or cable capacity using max_power parameters.
+**Wheeling charges**:
+Apply transmission costs between zones or territories.
 
-**Time-Varying Availability**:
-Use forecast sensors for max_power to model connection availability windows (e.g., scheduled maintenance).
+**Capacity limits**:
+Constrain flow through bottlenecks (panel ratings, cable capacity).
+
+**Time-varying availability**:
+Use forecast sensors for max power to model maintenance or scheduling windows.
 
 ## Physical Interpretation
 
-Connection represents a controllable power flow path between elements with optional constraints on capacity, efficiency, and cost.
+Connection represents one directed power flow path with optional constraints on capacity, efficiency, and cost.
 
 ### When to Use Explicit Connections
 
@@ -129,15 +128,10 @@ Use explicit Connection devices when you need:
 
 ### Configuration Guidelines
 
-- **Bidirectional Control**:
-    Set both `max_power_source_target` and `max_power_target_source` for asymmetric capacity (common in inverters).
-- **Efficiency Matters**:
-    Even small efficiency differences (95% vs 100%) significantly affect optimal battery dispatch strategies.
-- **Price vs Limit**:
-    Use `price` to encourage/discourage flow while allowing the optimizer freedom.
-    Use `max_power` for hard physical constraints.
-- **Implicit Connections**:
-    Don't create explicit connections that duplicate implicit ones—this creates parallel paths with potentially confusing results.
+- **Two directions**: Add two Connection subentries with swapped source and target when both directions matter.
+- **Efficiency matters**: Even small efficiency differences (95% vs 100%) significantly affect optimal dispatch.
+- **Price vs limit**: Use price to encourage or discourage flow; use max power for hard physical limits.
+- **Implicit connections**: Do not duplicate implicit paths—parallel connections can confuse results.
 
 ## Next Steps
 

--- a/docs/user-guide/elements/connections.md
+++ b/docs/user-guide/elements/connections.md
@@ -1,6 +1,6 @@
 # Connections
 
-Connections define how power flows between elements in your network with support for bidirectional flow, efficiency losses, and transmission costs.
+Connections define explicit, **unidirectional** power paths between elements, with optional capacity limits, efficiency losses, and transfer pricing.
 
 !!! warning "Advanced Element"
 
@@ -13,31 +13,29 @@ Connections define how power flows between elements in your network with support
     Many elements create implicit connections automatically.
     You only need explicit Connection elements for additional power paths not covered by element defaults.
 
+!!! note "Bidirectional paths"
+
+    Each Connection flows from **source** to **target** only.
+    To model flow in both directions (for example between two buses), add **two** Connection elements with swapped endpoints and independent limits, efficiency, and pricing.
+    For AC/DC conversion between a battery or solar and the grid, consider the [Inverter](inverter.md) element instead.
+
 ## Configuration
 
-| Field                        | Type                                     | Required | Default   | Description                                                            |
-| ---------------------------- | ---------------------------------------- | -------- | --------- | ---------------------------------------------------------------------- |
-| **Name**                     | String                                   | Yes      | -         | Unique identifier for this connection                                  |
-| **Source**                   | Element                                  | Yes      | -         | Element where power can flow from (in source→target direction)         |
-| **Target**                   | Element                                  | Yes      | -         | Element where power can flow to (in source→target direction)           |
-| **Mirror segment order**     | Boolean                                  | No       | Off       | Use the same segment order for both flow directions                    |
-| **Max Power Source→Target**  | [sensor](../forecasts-and-sensors.md)    | No       | Unlimited | Maximum power flow from source to target (kW)                          |
-| **Max Power Target→Source**  | [sensor](../forecasts-and-sensors.md)    | No       | Unlimited | Maximum power flow from target to source (kW)                          |
-| **Efficiency Source→Target** | [sensor](../forecasts-and-sensors.md)    | No       | 100%      | Efficiency percentage (0-100) for power transfer from source to target |
-| **Efficiency Target→Source** | [sensor](../forecasts-and-sensors.md)    | No       | 100%      | Efficiency percentage (0-100) for power transfer from target to source |
-| **Price Source→Target**      | [sensor(s)](../forecasts-and-sensors.md) | No       | 0         | Price (\$/kWh) for transferring power from source to target            |
-| **Price Target→Source**      | [sensor(s)](../forecasts-and-sensors.md) | No       | 0         | Price (\$/kWh) for transferring power from target to source            |
+| Field           | Type                                     | Required | Default   | Description                                         |
+| --------------- | ---------------------------------------- | -------- | --------- | --------------------------------------------------- |
+| **Name**        | String                                   | Yes      | -         | Unique identifier for this connection               |
+| **Source**      | Element                                  | Yes      | -         | Element power flows from                            |
+| **Target**      | Element                                  | Yes      | -         | Element power flows to                              |
+| **Max power**   | [sensor](../forecasts-and-sensors.md)    | No       | Unlimited | Maximum power along this path (kW)                  |
+| **Efficiency**  | [sensor](../forecasts-and-sensors.md)    | No       | 100%      | Efficiency percentage (0-100) for this direction    |
+| **Price**       | [sensor(s)](../forecasts-and-sensors.md) | No       | 0         | Price (\$/kWh) for power transferred along this path |
 
 !!! tip "Configuration tips"
 
-    **Leaving fields unset**: When a direction should allow unlimited flow with no losses or costs, leave the corresponding fields empty rather than creating sensors with maximum or default values.
+    **Leaving fields unset**: When a path should allow unlimited flow with no losses or costs, leave the optional fields empty rather than creating sensors with maximum or default values.
 
     **Segment-based behavior**: Connections compose internal segments for limits, efficiency, and pricing.
     You configure the fields above, and the model applies the corresponding segment behavior automatically.
-
-    **Segment order**: Source→target uses the segment order you provide.
-    Target→source uses the reverse order by default.
-    Enable `Mirror segment order` to use the same segment order for both flow directions.
 
     **Using constant values**: All sensor fields require sensor entities.
 
@@ -62,92 +60,73 @@ The filtering hides these elements by default to prevent common mistakes.
 This filtering ensures that connection endpoints are appropriate for your configuration level.
 Each element's documentation describes its connectivity level and when it appears in connection selectors.
 
-## Configuration Example
+## Configuration Examples
 
-Bidirectional connection between two network nodes:
+### One-way link between nodes
 
-| Field                       | Value                  |
-| --------------------------- | ---------------------- |
-| **Name**                    | DC Bus to AC Bus       |
-| **Source**                  | DC Node                |
-| **Target**                  | AC Node                |
-| **Max Power Source→Target** | input_number.max_power |
-| **Max Power Target→Source** | input_number.max_power |
+| Field         | Value                  |
+| ------------- | ---------------------- |
+| **Name**      | DC bus to AC bus       |
+| **Source**    | DC Node                |
+| **Target**    | AC Node                |
+| **Max power** | input_number.max_power |
+
+### Bidirectional link (two connections)
+
+Create one connection for each direction when both paths need limits or different parameters:
+
+| Connection | Source  | Target  | **Max power**              |
+| ---------- | ------- | ------- | -------------------------- |
+| DC to AC   | DC Node | AC Node | input_number.dc_to_ac_max  |
+| AC to DC   | AC Node | DC Node | input_number.ac_to_dc_max  |
+
+Use separate **Efficiency** and **Price** values on each connection when the directions differ.
 
 !!! note "Advanced Mode required for standard elements"
 
-    This example uses elements that are always available in connection selectors.
-    To connect standard elements that create implicit connections, enable Advanced Mode on your hub.
+    Examples that use Grid, Battery, Solar, or Load as endpoints require Advanced Mode on your hub so those elements appear in the selector.
 
 ## Physical Interpretation
 
-**Bidirectional flow:**
-Both directions are available for optimization.
-The optimizer will choose the most cost-effective direction at each time step.
+**Unidirectional flow:**
+Power optimized on this connection always travels from source to target.
+Values are zero or positive in that direction.
 
 **Efficiency modeling:**
-Power leaving a node is measured before losses.
-Power arriving at a node is reduced by efficiency.
-Example: 10kW leaves source with 95% efficiency → 9.5kW arrives at target.
-
-**Asymmetric efficiency:**
-Configure different efficiencies for each direction to model real-world devices.
+Power leaving the source is measured before losses.
+Power arriving at the target is reduced by efficiency.
+Example: 10 kW leaves the source with 95% efficiency → 9.5 kW arrives at the target.
 
 **Transmission costs:**
 Connection pricing models fees for using a power transfer path (wheeling charges, connection fees, peak demand charges).
 
 ## Common Patterns
 
-### Unlimited Bidirectional Connection
+### Unlimited one-way connection
 
-Leave both power limits unset for unlimited flow in both directions:
+Leave **Max power** unset for unlimited flow in the configured direction:
 
-| Field                       | Value            |
-| --------------------------- | ---------------- |
-| **Name**                    | DC Bus to AC Bus |
-| **Source**                  | DC Node          |
-| **Target**                  | AC Node          |
-| **Max Power Source→Target** | _(leave empty)_  |
-| **Max Power Target→Source** | _(leave empty)_  |
+| Field      | Value       |
+| ---------- | ----------- |
+| **Name**   | Bus A to B  |
+| **Source** | Bus A       |
+| **Target** | Bus B       |
 
-!!! note "Advanced Mode required for standard elements"
+### Conversion with efficiency
 
-    This example uses elements that are always available in connection selectors.
-    To connect standard elements that create implicit connections, enable Advanced Mode on your hub.
+| Field          | Value                   |
+| -------------- | ----------------------- |
+| **Name**       | DC to AC                |
+| **Source**     | DC Node                 |
+| **Target**     | AC Node                 |
+| **Max power**  | input_number.max_power  |
+| **Efficiency** | input_number.efficiency |
 
-### Unidirectional Connection
+Add a second connection (AC → DC) with its own efficiency if reverse conversion is required.
 
-Set one direction's limit to 0 to prevent flow:
+### Availability windows
 
-| Field                       | Value                  |
-| --------------------------- | ---------------------- |
-| **Name**                    | DC Bus to AC Bus       |
-| **Source**                  | DC Node                |
-| **Target**                  | AC Node                |
-| **Max Power Source→Target** | input_number.max_power |
-| **Max Power Target→Source** | input_number.zero      |
-
-!!! note
-
-    Set `input_number.zero` value to `0` to prevent reverse flow.
-
-### Bidirectional Connection with Efficiency
-
-Model power conversion with efficiency losses:
-
-| Field                        | Value                   |
-| ---------------------------- | ----------------------- |
-| **Name**                     | DC Bus to AC Bus        |
-| **Source**                   | DC_Node                 |
-| **Target**                   | AC_Node                 |
-| **Max Power Source→Target**  | input_number.max_power  |
-| **Max Power Target→Source**  | input_number.max_power  |
-| **Efficiency Source→Target** | input_number.efficiency |
-| **Efficiency Target→Source** | input_number.efficiency |
-
-### Availability Windows
-
-Use time-varying sensor to model device availability.
+Use a time-varying sensor for **Max power** to model device availability.
 Example: EV only available for charging 6 PM to 8 AM.
 
 Create a template sensor:
@@ -168,12 +147,12 @@ template:
 
 Then configure the connection:
 
-| Field                       | Value                           |
-| --------------------------- | ------------------------------- |
-| **Name**                    | Grid to EV                      |
-| **Source**                  | Grid                            |
-| **Target**                  | EV_Battery                      |
-| **Max Power Source→Target** | sensor.ev_charging_availability |
+| Field         | Value                           |
+| ------------- | ------------------------------- |
+| **Name**      | Grid to EV                      |
+| **Source**    | Grid                            |
+| **Target**    | EV_Battery                      |
+| **Max power** | sensor.ev_charging_availability |
 
 !!! note "Advanced Mode required"
 
@@ -183,17 +162,14 @@ The optimizer will only schedule charging when the sensor value is non-zero.
 
 ### Input Entities
 
-Each configuration field creates a corresponding input entity in Home Assistant.
+Each optional configuration field creates a corresponding input entity in Home Assistant.
 Input entities appear as Number entities with the `config` entity category.
 
-| Input                                    | Unit   | Description                            |
-| ---------------------------------------- | ------ | -------------------------------------- |
-| `number.{name}_max_power_source_target`  | kW     | Maximum forward power (if configured)  |
-| `number.{name}_max_power_target_source`  | kW     | Maximum reverse power (if configured)  |
-| `number.{name}_efficiency_source_target` | %      | Forward efficiency (if configured)     |
-| `number.{name}_efficiency_target_source` | %      | Reverse efficiency (if configured)     |
-| `number.{name}_price_source_target`      | \$/kWh | Forward transfer price (if configured) |
-| `number.{name}_price_target_source`      | \$/kWh | Reverse transfer price (if configured) |
+| Input                                   | Unit   | Description                        |
+| --------------------------------------- | ------ | ---------------------------------- |
+| `number.{name}_max_power_source_target` | kW     | Maximum power (if configured)      |
+| `number.{name}_efficiency_source_target`| %      | Efficiency (if configured)         |
+| `number.{name}_price_source_target`     | \$/kWh | Transfer price (if configured)     |
 
 Input entities include a `forecast` attribute showing values for each optimization period.
 See the [Input Entities developer guide](../../developer-guide/inputs.md) for details on input entity behavior.
@@ -202,120 +178,18 @@ See the [Input Entities developer guide](../../developer-guide/inputs.md) for de
 
 ### Sensor Summary
 
-A Connection element creates 1 device in Home Assistant with the following sensors.
-Not all sensors are created for every connection - only those relevant to the configuration.
+A Connection element creates one device in Home Assistant.
 
-The sensor display names use the actual source and target element names configured for the connection.
-For example, a connection between two elements would show their actual names in the sensor name instead of generic "Source to Target".
+The power sensor display name uses the configured source and target element names (for example, `{source} to {target} power`).
 
-| Sensor                                                                                     | Unit   | Description                             |
-| ------------------------------------------------------------------------------------------ | ------ | --------------------------------------- |
-| [`sensor.{name}_power_source_target`](#source-to-target-power)                             | kW     | Power flowing from source to target     |
-| [`sensor.{name}_power_target_source`](#target-to-source-power)                             | kW     | Power flowing from target to source     |
-| [`sensor.{name}_power_max_source_target`](#max-source-to-target-power)                     | kW     | Maximum forward power (when limited)    |
-| [`sensor.{name}_power_max_target_source`](#max-target-to-source-power)                     | kW     | Maximum reverse power (when limited)    |
-| [`sensor.{name}_shadow_power_max_source_target`](#max-source-to-target-power-shadow-price) | \$/kWh | Value of additional forward capacity    |
-| [`sensor.{name}_shadow_power_max_target_source`](#max-target-to-source-power-shadow-price) | \$/kWh | Value of additional reverse capacity    |
-| [`sensor.{name}_time_slice`](#time-slice-shadow-price)                                     | \$/kWh | Value of relaxing time-slice constraint |
+| Sensor                         | Unit | Description                              |
+| ------------------------------ | ---- | ---------------------------------------- |
+| `{source} to {target} power`   | kW   | Optimized power from source to target    |
 
-### Source to Target Power
+Power values are zero or positive.
+A value of 0 means no power is flowing on this connection at that time period.
 
-The optimal power flowing from the source element to the target element.
-
-Values are always positive or zero.
-A value of 0 means no power is flowing in the forward direction (may be flowing in reverse or not at all).
-The direction is determined by the connection configuration (source → target).
-
-**Example**: A value of 3.5 kW means 3.5 kW is flowing from the source element to the target element at this time period.
-
-### Target to Source Power
-
-The optimal power flowing from the target element to the source element.
-
-Values are always positive or zero.
-A value of 0 means no power is flowing in the reverse direction (may be flowing forward or not at all).
-This represents reverse flow through the connection (target → source).
-
-**Example**: A value of 2.0 kW means 2.0 kW is flowing from the target element back to the source element at this time period.
-
-### Max Source to Target Power
-
-The configured maximum forward power limit from the sensor configuration.
-Only created when a forward power limit is configured.
-
-### Max Target to Source Power
-
-The configured maximum reverse power limit from the sensor configuration.
-Only created when a reverse power limit is configured.
-
-### Max Source to Target Power Shadow Price
-
-The marginal value of additional forward capacity (source → target).
-See the [Shadow Prices modeling guide](../../modeling/shadow-prices.md) for general shadow price concepts.
-
-This shadow price shows how much the total system cost would decrease if the forward power limit were increased by 1 kW at this time period.
-Only created when a forward power limit is configured.
-
-**Interpretation**:
-
-- **Zero value**: Connection has spare capacity in the forward direction (not at limit)
-- **Positive value**: Connection is at maximum forward capacity and constraining power flow
-    - The value shows how much system cost would decrease per kW of additional forward capacity
-    - Higher values indicate the forward capacity limit is causing significant cost increases
-    - Helps identify bottlenecks where more forward capacity would be valuable
-
-**Example**: A value of 0.08 means that if the connection could transfer 1 kW more in the forward direction, the total system cost would decrease by \$0.08 at this time period.
-
-### Max Target to Source Power Shadow Price
-
-The marginal value of additional reverse capacity (target → source).
-See the [Shadow Prices modeling guide](../../modeling/shadow-prices.md) for general shadow price concepts.
-
-This shadow price shows how much the total system cost would decrease if the reverse power limit were increased by 1 kW at this time period.
-Only created when a reverse power limit is configured.
-
-**Interpretation**:
-
-- **Zero value**: Connection has spare capacity in the reverse direction (not at limit)
-- **Positive value**: Connection is at maximum reverse capacity and constraining power flow
-    - The value shows how much system cost would decrease per kW of additional reverse capacity
-    - Higher values indicate the reverse capacity limit is causing significant cost increases
-    - Helps identify bottlenecks where more reverse capacity would be valuable
-
-**Example**: A value of 0.12 means that if the connection could transfer 1 kW more in the reverse direction, the total system cost would decrease by \$0.12 at this time period.
-
-### Time Slice Shadow Price
-
-The marginal value of relaxing the time-slicing constraint.
-See the [Shadow Prices modeling guide](../../modeling/shadow-prices.md) for general shadow price concepts.
-
-This shadow price shows how much the total system cost would decrease if simultaneous bidirectional power flow were less restricted at this time period.
-Only created when both forward and reverse power limits are configured.
-
-The time-slicing constraint prevents full power flow in both directions simultaneously: `P_forward/P_max_forward + P_reverse/P_max_reverse ≤ 1.0`.
-This models real-world devices that share capacity between directions (e.g., an inverter that can't operate at full charge and discharge simultaneously).
-
-**Interpretation**:
-
-- **Zero value**: Connection is not constrained by time slicing (operating in only one direction or well below limits)
-- **Positive value**: Time slicing is constraining bidirectional operation
-    - The value shows how much system cost would decrease if the constraint were relaxed by 1% (allowing the sum to reach 1.01)
-    - Higher values indicate the connection could benefit from being able to operate more simultaneously in both directions
-    - Helps identify devices where increased bidirectional capacity would be valuable
-
-**Example**: A value of 0.15 means that if the connection could operate slightly more simultaneously in both directions (sum ≤ 1.01 instead of ≤ 1.0), the total system cost would decrease by \$0.15 at this time period.
-
-!!! warning "Unusual constraint binding"
-
-    A positive time-slice shadow price is unusual and typically indicates misconfiguration.
-    In most real-world scenarios, connections should not need to transfer power in both directions simultaneously.
-    If this constraint is binding, it often suggests arbitrage opportunities caused by:
-
-    - Inconsistent pricing across elements (e.g., different import/export prices creating profitable round-trip power flow)
-    - Efficiency values greater than 100% allowing energy creation through cycling
-    - Connection prices that don't reflect the true cost of bidirectional operation
-
-    Review your element configurations to ensure prices, efficiencies, and power limits accurately represent the physical system.
+**Example**: A value of 3.5 kW means 3.5 kW is flowing from the source element to the target element at that time period.
 
 ---
 


### PR DESCRIPTION
## Summary

- Trim connection schema and config flow to source→target only (remove reverse power/price/efficiency fields and `mirror_segment_order`).
- Add config entry migration v1.4 that splits legacy reverse-direction settings into a second Connection subentry when configured, including entity registry unique ID updates.
- Update translations, tests, and user/model documentation to match unidirectional connections.

## Test plan

- [x] `uv run pytest custom_components/haeo/migrations/tests/test_v1_4.py custom_components/haeo/core/schema/migrations/tests/test_v1_4.py custom_components/haeo/flows/elements/tests/test_connection_flow.py`
- [ ] Reload integration on a hub with an existing bidirectional Connection and confirm forward + reverse subentries after migration
- [ ] Add a new Connection in Advanced Mode and confirm the flow shows only max power, efficiency, and price for one direction


Made with [Cursor](https://cursor.com)