### PR TITLE
Align tier 4 horizons to local timezone in half-hour offsets

### DIFF
--- a/custom_components/haeo/coordinator/coordinator.py
+++ b/custom_components/haeo/coordinator/coordinator.py
@@ -406,12 +406,13 @@ class HaeoDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
 
         # Subscribe to horizon manager changes (requires full re-optimization)
         network = self.network
+        horizon_manager = runtime_data.horizon_manager
 
         @callback
         def _on_horizon_change() -> None:
-            self._handle_horizon_change(network)
+            self._handle_horizon_change(network, horizon_manager)
 
-        runtime_data.horizon_manager.subscribe(_on_horizon_change)
+        horizon_manager.subscribe(_on_horizon_change)
 
         # Subscribe to auto-optimize switch state changes
         if runtime_data.auto_optimize_switch is not None:
@@ -459,18 +460,14 @@ class HaeoDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
         self.signal_optimization_stale()
 
     @callback
-    def _handle_horizon_change(self, network: Network) -> None:
+    def _handle_horizon_change(self, network: Network, horizon_manager: "HorizonManager") -> None:
         """Handle horizon manager changes.
 
         Updates network periods with new durations from the horizon manager,
         then triggers optimization. The period update propagates to all elements
         and segments, invalidating dependent constraints and costs.
         """
-        # Update network periods with new horizon durations
-        runtime_data = self._get_runtime_data()
-        if runtime_data is None:
-            return
-        periods_seconds = runtime_data.horizon_manager.periods_seconds
+        periods_seconds = horizon_manager.periods_seconds
         periods_hours = np.asarray(periods_seconds, dtype=float) / 3600
         network.update_periods(periods_hours)
 

--- a/custom_components/haeo/coordinator/coordinator.py
+++ b/custom_components/haeo/coordinator/coordinator.py
@@ -32,7 +32,6 @@ from custom_components.haeo.const import (
 from custom_components.haeo.core.adapters.registry import ELEMENT_TYPES
 from custom_components.haeo.core.const import CONF_DEBOUNCE_SECONDS, CONF_ELEMENT_TYPE, DEFAULT_DEBOUNCE_SECONDS
 from custom_components.haeo.core.context import OptimizationContext
-from custom_components.haeo.core.data.forecast_times import tiers_to_periods_seconds
 from custom_components.haeo.core.data.loader.config_loader import load_element_config_from_values
 from custom_components.haeo.core.model import ModelOutputName, Network, OutputData, OutputType
 from custom_components.haeo.core.model.topology import serialize_topology
@@ -360,7 +359,7 @@ class HaeoDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
             msg = "Runtime data not available"
             raise RuntimeError(msg)
 
-        periods_seconds = tiers_to_periods_seconds(self.config_entry.data)
+        periods_seconds = runtime_data.horizon_manager.periods_seconds
         loaded_configs = self._load_from_input_stores()
 
         _LOGGER.debug("Initializing network with %d participants", len(loaded_configs))
@@ -468,7 +467,10 @@ class HaeoDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
         and segments, invalidating dependent constraints and costs.
         """
         # Update network periods with new horizon durations
-        periods_seconds = tiers_to_periods_seconds(self.config_entry.data)
+        runtime_data = self._get_runtime_data()
+        if runtime_data is None:
+            return
+        periods_seconds = runtime_data.horizon_manager.periods_seconds
         periods_hours = np.asarray(periods_seconds, dtype=float) / 3600
         network.update_periods(periods_hours)
 

--- a/custom_components/haeo/coordinator/coordinator.py
+++ b/custom_components/haeo/coordinator/coordinator.py
@@ -46,6 +46,7 @@ from custom_components.haeo.elements import (
     get_element_configs,
 )
 from custom_components.haeo.flows import HUB_SECTION_ADVANCED
+from custom_components.haeo.horizon import HorizonManager
 from custom_components.haeo.repairs import dismiss_optimization_failure_issue
 
 from . import network as network_module
@@ -54,7 +55,6 @@ if TYPE_CHECKING:
     from custom_components.haeo import HaeoConfigEntry, HaeoRuntimeData
     from custom_components.haeo.core.data.input_store import InputStore
     from custom_components.haeo.elements import InputFieldPath
-    from custom_components.haeo.horizon import HorizonManager
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -231,7 +231,7 @@ def _build_optimization_context(
     hub_config: Mapping[str, Any],
     participant_configs: Mapping[str, ElementConfigSchema],
     input_stores: Mapping[Any, "InputStore"],
-    horizon_manager: "HorizonManager",
+    horizon_manager: HorizonManager,
 ) -> OptimizationContext:
     """Build an optimization context by pulling from existing sources."""
     source_states: dict[str, EntityState] = {}
@@ -460,7 +460,7 @@ class HaeoDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
         self.signal_optimization_stale()
 
     @callback
-    def _handle_horizon_change(self, network: Network, horizon_manager: "HorizonManager") -> None:
+    def _handle_horizon_change(self, network: Network, horizon_manager: HorizonManager) -> None:
         """Handle horizon manager changes.
 
         Updates network periods with new durations from the horizon manager,

--- a/custom_components/haeo/coordinator/tests/test_coordinator.py
+++ b/custom_components/haeo/coordinator/tests/test_coordinator.py
@@ -858,7 +858,7 @@ def test_horizon_change_triggers_optimization(
     coordinator.network = Mock()
 
     with patch.object(coordinator, "signal_optimization_stale") as trigger_mock:
-        coordinator._handle_horizon_change(coordinator.network)
+        coordinator._handle_horizon_change(coordinator.network, mock_runtime_data.horizon_manager)
 
     trigger_mock.assert_called_once()
 

--- a/custom_components/haeo/core/data/forecast_times.py
+++ b/custom_components/haeo/core/data/forecast_times.py
@@ -11,6 +11,11 @@ _PRESET_DAYS: dict[str, int] = {
 }
 
 
+def floor_timestamp(epoch_seconds: float, period_seconds: int) -> float:
+    """Round epoch seconds down to the nearest period boundary."""
+    return epoch_seconds // period_seconds * period_seconds
+
+
 def minutes_to_next_boundary(current_minute: int, boundary_interval: int) -> int:
     """Calculate minutes until the next boundary of the given interval.
 
@@ -94,7 +99,8 @@ def calculate_aligned_tier_counts(
     step is added to T4 to ensure the total duration exactly matches horizon_minutes.
 
     Args:
-        start_time: The optimization start time.
+        start_time: Optimization start time in the installation local timezone
+            (timezone-aware). Wall-clock minute within the hour drives alignment.
         tier_durations: Duration of each tier in minutes (1, 5, 30, 60).
         min_counts: Minimum step counts for tiers 1-3 (T4 count is computed).
         total_steps: Total number of steps to distribute across all tiers.
@@ -229,7 +235,9 @@ def tiers_to_periods_seconds(
     Args:
         config: Tier configuration dictionary with tier_N_count and tier_N_duration keys,
             plus optional horizon_preset key.
-        start_time: Optional start time for alignment. If None, uses current time.
+        start_time: Optional start time for preset alignment. Pass the installation
+            local timezone (timezone-aware) from Home Assistant. If None, uses
+            current UTC time (for tests and CLI only).
 
     Returns:
         List of period durations in seconds.
@@ -304,7 +312,7 @@ def generate_forecast_timestamps(periods_seconds: Sequence[int], start_time: flo
     if start_time is None:
         epoch_seconds = datetime.now(UTC).timestamp()
         smallest_period = min(periods_seconds) if periods_seconds else 60
-        start_time = epoch_seconds // smallest_period * smallest_period
+        start_time = floor_timestamp(epoch_seconds, smallest_period)
 
     timestamps: list[float] = [start_time]
     for period in periods_seconds:

--- a/custom_components/haeo/core/data/forecast_times.py
+++ b/custom_components/haeo/core/data/forecast_times.py
@@ -235,9 +235,10 @@ def tiers_to_periods_seconds(
     Args:
         config: Tier configuration dictionary with tier_N_count and tier_N_duration keys,
             plus optional horizon_preset key.
-        start_time: Optional start time for preset alignment. Pass the installation
-            local timezone (timezone-aware) from Home Assistant. If None, uses
-            current UTC time (for tests and CLI only).
+        start_time: Optional start time for preset alignment. When None, uses
+            ``datetime.now(UTC)`` for tier boundary calculations. Pass a
+            timezone-aware datetime in the installation local time zone when
+            wall-clock alignment matters (for example from ``dt_util.now()``).
 
     Returns:
         List of period durations in seconds.

--- a/custom_components/haeo/core/data/tests/test_forecast_times.py
+++ b/custom_components/haeo/core/data/tests/test_forecast_times.py
@@ -2,6 +2,7 @@
 
 from datetime import UTC, datetime
 from typing import TypedDict
+from zoneinfo import ZoneInfo
 
 from freezegun import freeze_time
 import pytest
@@ -398,6 +399,55 @@ PRESET_HORIZON_MINUTES = {
     "5_days": 5 * 24 * 60,
     "7_days": 7 * 24 * 60,
 }
+
+
+ADELAIDE = ZoneInfo("Australia/Adelaide")
+PRESET_CONFIG_5_DAYS = {
+    "horizon_preset": "5_days",
+    "tier_1_duration": 1,
+    "tier_2_duration": 5,
+    "tier_3_duration": 30,
+    "tier_4_duration": 60,
+}
+
+
+def _t4_boundary_local_minutes(
+    periods_seconds: list[int],
+    start_ts: float,
+    tz: ZoneInfo,
+) -> list[int]:
+    """Return local minutes-of-hour for each end-of-period T4 (3600s) boundary."""
+    timestamps = generate_forecast_timestamps(periods_seconds, start_ts)
+    minutes: list[int] = []
+    for index, period in enumerate(periods_seconds):
+        if period == 3600:
+            local_dt = datetime.fromtimestamp(timestamps[index + 1], tz=tz)
+            minutes.append(local_dt.minute)
+    return minutes
+
+
+def test_adelaide_utc_start_time_misaligns_t4_to_half_hour() -> None:
+    """UTC start_time at Adelaide noon aligns T4 to :30 local (issue #457 bug)."""
+    local_noon = datetime(2025, 6, 2, 12, 0, 0, tzinfo=ADELAIDE)
+    utc_start = local_noon.astimezone(UTC)
+
+    periods = tiers_to_periods_seconds(PRESET_CONFIG_5_DAYS, start_time=utc_start)
+    t4_minutes = _t4_boundary_local_minutes(periods, utc_start.timestamp(), ADELAIDE)
+
+    assert t4_minutes, "expected at least one T4 boundary"
+    assert t4_minutes[0] == 30, "UTC alignment should place first T4 boundary at :30 local"
+
+
+def test_adelaide_local_start_time_aligns_t4_to_hour() -> None:
+    """Local start_time at Adelaide noon aligns T4 to :00 local."""
+    local_noon = datetime(2025, 6, 2, 12, 0, 0, tzinfo=ADELAIDE)
+
+    periods = tiers_to_periods_seconds(PRESET_CONFIG_5_DAYS, start_time=local_noon)
+    t4_minutes = _t4_boundary_local_minutes(periods, local_noon.timestamp(), ADELAIDE)
+
+    assert t4_minutes, "expected at least one T4 boundary"
+    assert t4_minutes[0] == 0, "local alignment should place first T4 boundary at :00 local"
+    assert all(minute == 0 for minute in t4_minutes), "all T4 boundaries should fall on local hour"
 
 
 @pytest.mark.parametrize("preset", ["2_days", "3_days", "5_days", "7_days"])

--- a/custom_components/haeo/entities/tests/test_haeo_horizon.py
+++ b/custom_components/haeo/entities/tests/test_haeo_horizon.py
@@ -1,10 +1,12 @@
 """Tests for the HAEO horizon entity."""
 
+from collections.abc import Iterator
 from datetime import datetime, timedelta
 import logging
 from unittest.mock import Mock
 from zoneinfo import ZoneInfo
 
+from freezegun import freeze_time
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceEntry
@@ -13,8 +15,6 @@ from homeassistant.helpers.entity_platform import EntityPlatform
 from homeassistant.util import dt as dt_util
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
-
-from freezegun import freeze_time
 
 from custom_components.haeo.const import DOMAIN
 from custom_components.haeo.core.const import CONF_HORIZON_PRESET, CONF_NAME
@@ -297,7 +297,7 @@ def _horizon_t4_boundary_local_minutes(
 
 
 @pytest.fixture
-def adelaide_timezone(hass: HomeAssistant) -> None:
+def adelaide_timezone(hass: HomeAssistant) -> Iterator[None]:
     """Set Home Assistant default timezone to Adelaide for the test."""
     original = dt_util.get_default_time_zone()
     dt_util.set_default_time_zone(ADELAIDE)

--- a/custom_components/haeo/entities/tests/test_haeo_horizon.py
+++ b/custom_components/haeo/entities/tests/test_haeo_horizon.py
@@ -3,6 +3,7 @@
 from datetime import datetime, timedelta
 import logging
 from unittest.mock import Mock
+from zoneinfo import ZoneInfo
 
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
@@ -13,11 +14,21 @@ from homeassistant.util import dt as dt_util
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
+from freezegun import freeze_time
+
 from custom_components.haeo.const import DOMAIN
-from custom_components.haeo.core.const import CONF_NAME
+from custom_components.haeo.core.const import CONF_HORIZON_PRESET, CONF_NAME
 from custom_components.haeo.entities.haeo_horizon import HaeoHorizonEntity
-from custom_components.haeo.flows import HUB_SECTION_ADVANCED, HUB_SECTION_COMMON, HUB_SECTION_TIERS
+from custom_components.haeo.flows import (
+    HORIZON_PRESET_5_DAYS,
+    HUB_SECTION_ADVANCED,
+    HUB_SECTION_COMMON,
+    HUB_SECTION_TIERS,
+)
 from custom_components.haeo.horizon import HorizonManager
+
+ADELAIDE = ZoneInfo("Australia/Adelaide")
+T4_PERIOD_SECONDS = 3600
 
 # --- Fixtures ---
 
@@ -270,6 +281,57 @@ async def test_horizon_entity_updates_on_manager_change(
 
 
 # --- Tests for HorizonManager ---
+
+
+def _horizon_t4_boundary_local_minutes(
+    periods_seconds: list[int],
+    timestamps: tuple[float, ...],
+) -> list[int]:
+    """Return local minutes-of-hour for each T4 period end boundary."""
+    minutes: list[int] = []
+    for index, period in enumerate(periods_seconds):
+        if period == T4_PERIOD_SECONDS:
+            local_dt = datetime.fromtimestamp(timestamps[index + 1], tz=ADELAIDE)
+            minutes.append(local_dt.minute)
+    return minutes
+
+
+@pytest.fixture
+def adelaide_timezone(hass: HomeAssistant) -> None:
+    """Set Home Assistant default timezone to Adelaide for the test."""
+    original = dt_util.get_default_time_zone()
+    dt_util.set_default_time_zone(ADELAIDE)
+    yield
+    dt_util.set_default_time_zone(original)
+
+
+@freeze_time(datetime(2025, 6, 2, 12, 0, 0, tzinfo=ADELAIDE))
+def test_horizon_manager_adelaide_preset_aligns_t4_to_local_hour(
+    hass: HomeAssistant,
+    adelaide_timezone: None,
+) -> None:
+    """HorizonManager preset horizons align T4 boundaries to local :00 in Adelaide."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Adelaide Network",
+        data={
+            HUB_SECTION_COMMON: {CONF_NAME: "Adelaide Network", CONF_HORIZON_PRESET: HORIZON_PRESET_5_DAYS},
+            HUB_SECTION_TIERS: {},
+            HUB_SECTION_ADVANCED: {},
+        },
+        entry_id="test_adelaide_horizon_entry",
+    )
+    entry.add_to_hass(hass)
+
+    manager = HorizonManager(hass, entry)
+    t4_minutes = _horizon_t4_boundary_local_minutes(
+        manager.periods_seconds,
+        manager.get_forecast_timestamps(),
+    )
+
+    assert t4_minutes, "expected at least one T4 boundary"
+    assert t4_minutes[0] == 0, "first T4 boundary should align to local hour (:00)"
+    assert all(minute == 0 for minute in t4_minutes), "all T4 boundaries should fall on local hour"
 
 
 def test_horizon_manager_current_start_time(

--- a/custom_components/haeo/entities/tests/test_haeo_horizon.py
+++ b/custom_components/haeo/entities/tests/test_haeo_horizon.py
@@ -305,6 +305,20 @@ def adelaide_timezone(hass: HomeAssistant) -> Iterator[None]:
     dt_util.set_default_time_zone(original)
 
 
+def test_update_timestamps_refreshes_smallest_period(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+) -> None:
+    """Smallest period is recomputed when tier durations change in config."""
+    manager = HorizonManager(hass, config_entry)
+    assert manager.smallest_period == 300
+
+    config_entry.data[HUB_SECTION_TIERS]["tier_1_duration"] = 1
+    manager._update_timestamps()
+
+    assert manager.smallest_period == 60
+
+
 @freeze_time(datetime(2025, 6, 2, 12, 0, 0, tzinfo=ADELAIDE))
 def test_horizon_manager_adelaide_preset_aligns_t4_to_local_hour(
     hass: HomeAssistant,

--- a/custom_components/haeo/horizon.py
+++ b/custom_components/haeo/horizon.py
@@ -47,9 +47,8 @@ class HorizonManager:
         self._hass = hass
         self._config_entry = config_entry
 
-        # Calculate period durations from config (local-time alignment applied on update)
-        self._periods_seconds = tiers_to_periods_seconds(config_entry.data, start_time=dt_util.now())
-        self._smallest_period = min(self._periods_seconds)
+        self._periods_seconds: list[int] = []
+        self._smallest_period = 60
 
         # Timer for next update
         self._unsub_timer: CALLBACK_TYPE | None = None
@@ -66,6 +65,9 @@ class HorizonManager:
     def _update_timestamps(self) -> None:
         """Update the cached forecast timestamps."""
         now = dt_util.now()
+        periods_for_min = tiers_to_periods_seconds(self._config_entry.data, start_time=now)
+        if periods_for_min:
+            self._smallest_period = min(periods_for_min)
         start_ts = floor_timestamp(now.timestamp(), self._smallest_period)
         start_dt = datetime.fromtimestamp(start_ts, tz=now.tzinfo)
         self._periods_seconds = tiers_to_periods_seconds(self._config_entry.data, start_time=start_dt)
@@ -123,7 +125,7 @@ class HorizonManager:
         epoch_seconds = now.timestamp()
 
         # Calculate next period boundary
-        current_boundary = epoch_seconds // self._smallest_period * self._smallest_period
+        current_boundary = floor_timestamp(epoch_seconds, self._smallest_period)
         next_boundary = current_boundary + self._smallest_period
 
         # Convert to datetime for scheduling

--- a/custom_components/haeo/horizon.py
+++ b/custom_components/haeo/horizon.py
@@ -19,7 +19,11 @@ from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.helpers.event import async_track_point_in_time
 from homeassistant.util import dt as dt_util
 
-from custom_components.haeo.core.data.forecast_times import generate_forecast_timestamps, tiers_to_periods_seconds
+from custom_components.haeo.core.data.forecast_times import (
+    floor_timestamp,
+    generate_forecast_timestamps,
+    tiers_to_periods_seconds,
+)
 
 
 class HorizonManager:
@@ -43,8 +47,8 @@ class HorizonManager:
         self._hass = hass
         self._config_entry = config_entry
 
-        # Calculate period durations from config
-        self._periods_seconds = tiers_to_periods_seconds(config_entry.data)
+        # Calculate period durations from config (local-time alignment applied on update)
+        self._periods_seconds = tiers_to_periods_seconds(config_entry.data, start_time=dt_util.now())
         self._smallest_period = min(self._periods_seconds)
 
         # Timer for next update
@@ -61,8 +65,11 @@ class HorizonManager:
 
     def _update_timestamps(self) -> None:
         """Update the cached forecast timestamps."""
-        self._periods_seconds = tiers_to_periods_seconds(self._config_entry.data)
-        self._forecast_timestamps = generate_forecast_timestamps(self._periods_seconds)
+        now = dt_util.now()
+        start_ts = floor_timestamp(now.timestamp(), self._smallest_period)
+        start_dt = datetime.fromtimestamp(start_ts, tz=now.tzinfo)
+        self._periods_seconds = tiers_to_periods_seconds(self._config_entry.data, start_time=start_dt)
+        self._forecast_timestamps = generate_forecast_timestamps(self._periods_seconds, start_ts)
 
     def start(self) -> Callable[[], None]:
         """Start the scheduled updates.

--- a/docs/developer-guide/horizon-manager.md
+++ b/docs/developer-guide/horizon-manager.md
@@ -48,7 +48,7 @@ Each tier specifies a period duration and count:
 | 2    | 30 min | 6     | 3 hours  |
 | 3    | 1 hour | 20    | 20 hours |
 
-The HorizonManager computes period start times aligned to natural boundaries (for example, 12:00, 12:01, 12:02 for 1-minute periods).
+The HorizonManager computes period start times aligned to natural boundaries in the Home Assistant configured timezone (for example, 12:00, 12:01, 12:02 for 1-minute periods). This matters for UTC offsets with non-zero minutes (such as Australia/Adelaide at +10:30), where preset tier 4 hourly steps must align to local wall-clock hours rather than UTC hours.
 
 The `horizon` property returns the current forecast timestamps as a tuple of datetime objects.
 Components access this to align their data loading with the optimization time grid.

--- a/docs/developer-guide/horizon-manager.md
+++ b/docs/developer-guide/horizon-manager.md
@@ -54,8 +54,11 @@ Preset horizons use the [Home Assistant configured time zone](https://www.home-a
 Installations with UTC offsets that include half-hour or quarter-hour components therefore keep coarser tiers on local clock hours rather than UTC hours.
 The implementation is in `custom_components/haeo/horizon.py` and `custom_components/haeo/core/data/forecast_times.py`.
 
-The `horizon` property returns the current forecast timestamps as a tuple of datetime objects.
-Components access this to align their data loading with the optimization time grid.
+`HorizonManager.get_forecast_timestamps()` returns boundary timestamps as epoch seconds.
+
+Input entities and the coordinator use these values to align data loading with the optimization time grid.
+
+The diagnostic `HaeoHorizonEntity` in `custom_components/haeo/entities/haeo_horizon.py` exposes the same boundaries as timezone-aware `datetime` objects in its `forecast` attribute.
 
 ## Subscription Pattern
 

--- a/docs/developer-guide/horizon-manager.md
+++ b/docs/developer-guide/horizon-manager.md
@@ -48,7 +48,11 @@ Each tier specifies a period duration and count:
 | 2    | 30 min | 6     | 3 hours  |
 | 3    | 1 hour | 20    | 20 hours |
 
-The HorizonManager computes period start times aligned to natural boundaries in the Home Assistant configured timezone (for example, 12:00, 12:01, 12:02 for 1-minute periods). This matters for UTC offsets with non-zero minutes (such as Australia/Adelaide at +10:30), where preset tier 4 hourly steps must align to local wall-clock hours rather than UTC hours.
+The HorizonManager computes period start times aligned to natural boundaries in the installation wall clock (for example, 12:00, 12:01, 12:02 for 1-minute periods).
+
+Preset horizons use the [Home Assistant configured time zone](https://www.home-assistant.io/docs/configuration/customizing/#time-zone) when aligning tier boundaries to forecast data.
+Installations with UTC offsets that include half-hour or quarter-hour components therefore keep coarser tiers on local clock hours rather than UTC hours.
+The implementation is in `custom_components/haeo/horizon.py` and `custom_components/haeo/core/data/forecast_times.py`.
 
 The `horizon` property returns the current forecast timestamps as a tuple of datetime objects.
 Components access this to align their data loading with the optimization time grid.


### PR DESCRIPTION
## Summary

Fixes #457

- Build preset horizon alignment from Home Assistant local time (`dt_util.now()`) instead of UTC, so tier 4 hourly steps line up with local `:00` boundaries in zones like Australia/Adelaide (+10:30)
- Coordinator uses `HorizonManager.periods_seconds` so the optimization grid cannot drift from the horizon
- Add Adelaide regression tests (core + `HorizonManager`) and document local timezone alignment in the horizon manager guide

## Test plan

- [x] `uv run pytest custom_components/haeo/core/data/tests/test_forecast_times.py -q`
- [x] `uv run pytest custom_components/haeo/entities/tests/test_haeo_horizon.py -q`
- [x] `uv run pytest custom_components/haeo/coordinator/tests/ -q -k horizon`
- [ ] Manual: set HA timezone to Adelaide, confirm plan table hourly columns align with forecasts at local `:00`


Made with [Cursor](https://cursor.com)