### PR TITLE
Refresh installation docs and align documentation standards

### DIFF
--- a/.github/instructions/documentation.instructions.md
+++ b/.github/instructions/documentation.instructions.md
@@ -53,7 +53,7 @@ Use mermaid for all diagrams:
 
 ## Next steps sections
 
-All user-facing pages must end with a **Next Steps** section using Material grid cards:
+All user-facing pages must end with a **Next steps** section (heading `## Next steps`) using Material grid cards:
 
 ```markdown
 ## Next steps

--- a/README.md
+++ b/README.md
@@ -95,19 +95,15 @@ See the [elements documentation](https://hass-energy.github.io/haeo/user-guide/e
 
 ## 📦 Installation
 
-### HACS Installation (Recommended)
+### HACS installation (recommended)
+
+HAEO is published in the [default HACS store](https://github.com/hacs/default).
+You do not need to [add a custom repository](https://hacs.xyz/docs/faq/custom_repositories/).
+See the [installation guide](https://hass-energy.github.io/haeo/user-guide/installation/) for step-by-step instructions.
 
 [![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=hass-energy&repository=haeo&category=integration)
 
-1. Open HACS in your Home Assistant instance
-2. Click on "Integrations"
-3. Click the three dots in the top right corner
-4. Select "Custom repositories"
-5. Add this repository URL: `https://github.com/hass-energy/haeo`
-6. Select "Integration" as the category
-7. Click "Add"
-8. Search for "HAEO" and click "Download"
-9. Restart Home Assistant
+You can use the My Home Assistant link above to open HAEO directly in HACS, then download and restart Home Assistant.
 
 ### Manual Installation
 

--- a/docs/developer-guide/adapter-layer.md
+++ b/docs/developer-guide/adapter-layer.md
@@ -128,7 +128,7 @@ The adapter architecture supports future composite elements that group multiple 
 
 Composite adapters would create nested element structures and aggregate their outputs, presenting a unified interface to users while maintaining full optimization capability.
 
-## Next Steps
+## Next steps
 
 <div class="grid cards" markdown>
 

--- a/docs/developer-guide/documentation-guidelines.md
+++ b/docs/developer-guide/documentation-guidelines.md
@@ -208,12 +208,12 @@ Before committing documentation changes, verify:
 
 ## Next steps requirements
 
-All user-facing pages must end with a **Next Steps** section.
-This replaces the traditional "Related Documentation" bullet list pattern, use Next Steps cards instead.
+All user-facing pages must end with a **Next steps** section (heading `## Next steps`).
+This replaces the traditional "Related Documentation" bullet list pattern, use Next steps cards instead.
 
 ### Purpose
 
-Next Steps sections help users discover related topics and continue their learning journey.
+Next steps sections help users discover related topics and continue their learning journey.
 They prevent dead-ends and guide users toward completing common workflows.
 They also provide links to deeper technical resources (like modeling documentation) for readers who want more detail.
 
@@ -222,7 +222,7 @@ They also provide links to deeper technical resources (like modeling documentati
 Use Material for MkDocs grid cards format (match `docs/index.md`):
 
 ```markdown
-## Next Steps
+## Next steps
 
 <div class="grid cards" markdown>
 
@@ -245,7 +245,7 @@ Use Material for MkDocs grid cards format (match `docs/index.md`):
 - **Actionable descriptions**: Focus on what users will do or learn, not just topic names
 - **Appropriate icons**: Use Material icons that match the topic (`:material-battery-charging:`, `:material-chart-line:`, etc.)
 
-### Examples of good Next Steps
+### Examples of good next steps
 
 From solar configuration:
 
@@ -298,8 +298,8 @@ Keep snippets minimal and focused on the concept being explained.
 
 - Confirm terminology matches the glossary above.
 - Compare duplicate topics (for example, battery configuration vs battery modeling) to ensure they complement rather than repeat one another.
-- Ensure every user-facing page ends with a **Next Steps** section that links to the most relevant follow-up topics, and refresh those links whenever nearby content changes.
-- Match the **Next Steps** layout in `docs/index.md`.
+- Ensure every user-facing page ends with a **Next steps** section that links to the most relevant follow-up topics, and refresh those links whenever nearby content changes.
+- Match the **Next steps** layout in `docs/index.md`.
     Use a Material grid, apply `{ .lg .middle }` to the icon, follow with a descriptive sentence, and finish with an arrow-link call to action.
 - Summarise directory layouts at a high level; avoid listing every file because those inventories fall out of date quickly.
 - Make sure each page introduces a concept once and references it elsewhere instead of re-explaining it.
@@ -481,7 +481,7 @@ Before opening a pull request:
 - [ ] Templates applied or intentionally adapted with justification in the PR description
 - [ ] No duplicate information (checked against primary references)
 - [ ] Technical details verified for accuracy (units, sensor behavior, implementation)
-- [ ] User-facing pages include Next Steps sections
+- [ ] User-facing pages include Next steps sections
 - [ ] Developer documentation focuses on architecture, not code reproduction
 
 Following these guidelines keeps HAEO documentation lean, accurate, and easy to maintain.

--- a/docs/developer-guide/setup.md
+++ b/docs/developer-guide/setup.md
@@ -87,7 +87,7 @@ Visit http://127.0.0.1:8000
 
 Documentation automatically deploys via GitHub Actions on push to main.
 
-## Next Steps
+## Next steps
 
 - Read [Contributing](contributing.md) guidelines
 - Explore [Architecture](architecture.md)

--- a/docs/developer-guide/templates/device-layer-template.md
+++ b/docs/developer-guide/templates/device-layer-template.md
@@ -97,7 +97,7 @@ Provide practical advice for setting configuration values:
 - Guideline 2: Common mistakes and how to avoid them
 - Guideline 3: Performance or accuracy considerations
 
-## Next Steps
+## Next steps
 
 !!! note "Template Instructions"
 

--- a/docs/developer-guide/templates/element-user-guide-template.md
+++ b/docs/developer-guide/templates/element-user-guide-template.md
@@ -118,7 +118,7 @@ Focus on actionable problems users are likely to encounter.
 
 **Solution**: Clear steps to resolve the issue
 
-## Next Steps
+## Next steps
 
 !!! note "Template Instructions"
 

--- a/docs/developer-guide/templates/model-layer-template.md
+++ b/docs/developer-guide/templates/model-layer-template.md
@@ -82,7 +82,7 @@ Note any real-world behaviors not captured by the model:
 - Limitation one and when it matters
 - Limitation two and potential workarounds
 
-## Next Steps
+## Next steps
 
 !!! note "Template Instructions"
 

--- a/docs/developer-guide/typing.md
+++ b/docs/developer-guide/typing.md
@@ -202,7 +202,7 @@ These assertions:
 - Document the architectural invariant being relied upon
 - Return the narrowed type for continued type-safe use
 
-## Next Steps
+## Next steps
 
 <div class="grid cards" markdown>
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -107,7 +107,7 @@ If HAEO has helped you save on your energy bills, consider buying us a coffee!
 
 <script type="text/javascript" src="https://cdnjs.buymeacoffee.com/1.0.0/button.prod.min.js" data-name="bmc-button" data-slug="haeo.io" data-color="#5F7FFF" data-emoji="" data-font="Lato" data-text="Buy us a coffee" data-outline-color="#000000" data-font-color="#ffffff" data-coffee-color="#FFDD00"></script>
 
-## Next Steps
+## Next steps
 
 <div class="grid cards" markdown>
 

--- a/docs/modeling/device-layer/battery.md
+++ b/docs/modeling/device-layer/battery.md
@@ -102,7 +102,7 @@ The adapter maps model outputs directly from the battery element:
 
 See [Battery Configuration](../../user-guide/elements/battery.md#sensors-created) for complete sensor documentation.
 
-## Next Steps
+## Next steps
 
 <div class="grid cards" markdown>
 

--- a/docs/modeling/device-layer/battery_section.md
+++ b/docs/modeling/device-layer/battery_section.md
@@ -87,7 +87,7 @@ All power flow must be explicitly configured via Connection elements.
     For multi-section behavior, use the standard Battery element or compose multiple Battery Section elements manually.
 - **Direct Model Mapping**: All configuration parameters map directly to the model layer Battery element with no transformation.
 
-## Next Steps
+## Next steps
 
 <div class="grid cards" markdown>
 

--- a/docs/modeling/device-layer/connection.md
+++ b/docs/modeling/device-layer/connection.md
@@ -139,7 +139,7 @@ Use explicit Connection devices when you need:
 - **Implicit Connections**:
     Don't create explicit connections that duplicate implicit ones—this creates parallel paths with potentially confusing results.
 
-## Next Steps
+## Next steps
 
 <div class="grid cards" markdown>
 

--- a/docs/modeling/device-layer/grid.md
+++ b/docs/modeling/device-layer/grid.md
@@ -109,7 +109,7 @@ Grid represents the utility connection that can supply power (import) when local
 - **Pricing Strategy**: Flat pricing provides limited optimization value (battery only useful for solar storage). Time-varying pricing enables full optimization benefits.
 - **Zero Prices**: Avoid setting both import and export prices to zero simultaneously—optimizer has no economic preference and may produce unexpected results.
 
-## Next Steps
+## Next steps
 
 <div class="grid cards" markdown>
 

--- a/docs/modeling/device-layer/index.md
+++ b/docs/modeling/device-layer/index.md
@@ -34,7 +34,7 @@ When adapters create multiple model elements or devices, they use a colon-separa
 
 This prevents naming collisions and groups related components visually in Home Assistant.
 
-## Next Steps
+## Next steps
 
 <div class="grid cards" markdown>
 

--- a/docs/modeling/device-layer/inverter.md
+++ b/docs/modeling/device-layer/inverter.md
@@ -114,7 +114,7 @@ while the AC side connects to your home's AC network.
     Peak/surge ratings should not be used as they are not sustainable.
 - **DC Bus Connections**: Other elements (batteries, PV) should connect to the inverter's DC bus by specifying the inverter name as their connection target.
 
-## Next Steps
+## Next steps
 
 <div class="grid cards" markdown>
 

--- a/docs/modeling/device-layer/loads.md
+++ b/docs/modeling/device-layer/loads.md
@@ -112,7 +112,7 @@ This means reduced power can be interpreted as partial operation in whatever way
     When curtailment is disabled, consumption equals the forecast exactly.
     When enabled, consumption may be reduced below the forecast based on economics and constraints.
 
-## Next Steps
+## Next steps
 
 <div class="grid cards" markdown>
 

--- a/docs/modeling/device-layer/node.md
+++ b/docs/modeling/device-layer/node.md
@@ -97,7 +97,7 @@ Node represents an electrical bus where Kirchhoff's current law applies—total 
 - **No Storage**: Nodes have no capacity—power balance is instantaneous. Use Battery elements for energy storage.
 - **Connection Target**: All other elements (Grid, Battery, Solar, Loads) specify which node they connect to via their `connection.target` field.
 
-## Next Steps
+## Next steps
 
 <div class="grid cards" markdown>
 

--- a/docs/modeling/device-layer/solar.md
+++ b/docs/modeling/device-layer/solar.md
@@ -103,7 +103,7 @@ Solar represents a solar generation system that produces power based on weather 
     generation equals forecast exactly.
     When enabled, generation can be reduced below forecast.
 
-## Next Steps
+## Next steps
 
 <div class="grid cards" markdown>
 

--- a/docs/modeling/index.md
+++ b/docs/modeling/index.md
@@ -284,7 +284,7 @@ HAEO uses consistent units for numerical stability:
 This keeps values in similar numerical ranges, improving solver performance.
 See [units documentation](../developer-guide/units.md) for details.
 
-## Next Steps
+## Next steps
 
 <div class="grid cards" markdown>
 

--- a/docs/modeling/model-layer/connections/connection.md
+++ b/docs/modeling/model-layer/connections/connection.md
@@ -184,7 +184,7 @@ into the appropriate device-level outputs (e.g., grid import power, grid export 
 Use Connection for all power-flow paths.
 Select the segment chain that matches the physical behavior you need.
 
-## Next Steps
+## Next steps
 
 <div class="grid cards" markdown>
 

--- a/docs/modeling/model-layer/connections/index.md
+++ b/docs/modeling/model-layer/connections/index.md
@@ -62,7 +62,7 @@ Connections are kept separate from elements to enable flexible network topologie
 
 This separation allows the same element types to be connected in different ways depending on the physical system being modeled.
 
-## Next Steps
+## Next steps
 
 <div class="grid cards" markdown>
 

--- a/docs/modeling/model-layer/elements/battery.md
+++ b/docs/modeling/model-layer/elements/battery.md
@@ -207,7 +207,7 @@ The single-section battery model is a building block for more complex battery be
 
 See the [Battery Device Layer documentation](../../device-layer/battery.md) for how these are composed.
 
-## Next Steps
+## Next steps
 
 <div class="grid cards" markdown>
 

--- a/docs/modeling/model-layer/elements/index.md
+++ b/docs/modeling/model-layer/elements/index.md
@@ -54,7 +54,7 @@ Complex device behavior (multi-section batteries, cost incentives, efficiency lo
 
 This separation keeps the Model Layer focused on optimization mathematics while the Device Layer handles user-facing complexity.
 
-## Next Steps
+## Next steps
 
 <div class="grid cards" markdown>
 

--- a/docs/modeling/model-layer/elements/node.md
+++ b/docs/modeling/model-layer/elements/node.md
@@ -100,7 +100,7 @@ Consumption draws from `inbound_tags` for tagged power routing.
 **Junction behavior**: Represents an electrical bus or node where power must balance.
 Used to connect multiple elements at a common point (Kirchhoff's law).
 
-## Next Steps
+## Next steps
 
 <div class="grid cards" markdown>
 

--- a/docs/modeling/model-layer/index.md
+++ b/docs/modeling/model-layer/index.md
@@ -81,7 +81,7 @@ $$
 
 This selective rebuilding (warm start optimization) is more efficient than reconstructing the entire problem, particularly when only a subset of forecasts or parameters change between optimization cycles.
 
-## Next Steps
+## Next steps
 
 <div class="grid cards" markdown>
 

--- a/docs/modeling/shadow-prices.md
+++ b/docs/modeling/shadow-prices.md
@@ -63,7 +63,7 @@ The optimizer has headroom, so relaxing the limit would not change its decisions
 **Non-zero values**: When a shadow price is non-zero, the constraint is binding.
 The magnitude indicates how valuable additional capacity would be at that point.
 
-## Next Steps
+## Next steps
 
 <div class="grid cards" markdown>
 

--- a/docs/modeling/tagged-power.md
+++ b/docs/modeling/tagged-power.md
@@ -155,7 +155,7 @@ Practical variable growth therefore tracks the number of *distinguishable* polic
 State-of-charge partitioning could be expressed as separate tags assigned to different SOC regions of a storage element, enabling SOC-dependent valuation through the same tag machinery.
 This remains an open modelling direction.
 
-## Next Steps
+## Next steps
 
 <div class="grid cards" markdown>
 

--- a/docs/user-guide/automations.md
+++ b/docs/user-guide/automations.md
@@ -209,7 +209,7 @@ If you have questions or need help creating automations:
 - Review existing automation examples from the community
 - Ask in the Home Assistant Community forums with the `haeo` tag
 
-## Next Steps
+## Next steps
 
 <div class="grid cards" markdown>
 

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -236,7 +236,7 @@ Watch optimization duration in the sensor.
 If it takes too long, adjust interval tiers (increase durations or reduce counts).
 See [performance considerations](optimization.md#performance-considerations) for more details.
 
-## Next Steps
+## Next steps
 
 Use these resources to expand your configuration and understand the results.
 

--- a/docs/user-guide/data-updates.md
+++ b/docs/user-guide/data-updates.md
@@ -176,7 +176,7 @@ No. Configuration changes through the UI take effect immediately:
 
 Only changes to integration code (development) require restart.
 
-## Next Steps
+## Next steps
 
 Focus on these areas to keep data updates reliable and useful.
 

--- a/docs/user-guide/elements/battery.md
+++ b/docs/user-guide/elements/battery.md
@@ -457,7 +457,7 @@ This allows HAEO to:
 - Optimize total system cost
 - Handle different battery characteristics
 
-## Next Steps
+## Next steps
 
 Build on your battery configuration with these guides.
 

--- a/docs/user-guide/elements/battery_section.md
+++ b/docs/user-guide/elements/battery_section.md
@@ -217,7 +217,7 @@ Battery Section does not create implicit connections like the standard Battery e
 **Solution**: Ensure the Battery Section name matches exactly in both the Connection source and target fields.
 Check that the Battery Section element exists before creating connections.
 
-## Next Steps
+## Next steps
 
 <div class="grid cards" markdown>
 

--- a/docs/user-guide/elements/connections.md
+++ b/docs/user-guide/elements/connections.md
@@ -325,7 +325,7 @@ All sensors include a `forecast` attribute containing future optimized values fo
 
 See [troubleshooting guide](../troubleshooting.md#graph-isnt-connected-properly) for connection issues.
 
-## Next Steps
+## Next steps
 
 <div class="grid cards" markdown>
 

--- a/docs/user-guide/elements/grid.md
+++ b/docs/user-guide/elements/grid.md
@@ -320,7 +320,7 @@ All sensors include a `forecast` attribute containing future optimized values fo
 - Review connections in network configuration
 - Check grid import limit vs total load
 
-## Next Steps
+## Next steps
 
 <div class="grid cards" markdown>
 

--- a/docs/user-guide/elements/index.md
+++ b/docs/user-guide/elements/index.md
@@ -68,7 +68,7 @@ Advanced elements require manual connection configuration and are intended for u
 
 See the [Configuration guide](../configuration.md#advanced-mode) for details on enabling Advanced Mode.
 
-## Next Steps
+## Next steps
 
 Explore detailed configuration for each element type:
 

--- a/docs/user-guide/elements/inverter.md
+++ b/docs/user-guide/elements/inverter.md
@@ -205,7 +205,7 @@ Verify power limits and efficiency values are realistic.
 Set efficiency values slightly lower to account for real-world losses.
 Avoid using 100% efficiency unless your inverter truly has no losses.
 
-## Next Steps
+## Next steps
 
 <div class="grid cards" markdown>
 

--- a/docs/user-guide/elements/load.md
+++ b/docs/user-guide/elements/load.md
@@ -328,7 +328,7 @@ If optimization fails with loads:
 - Only include loads that represent required consumption in the Load element.
     For controllable/deferrable loads today, schedule them externally (for example EMHASS) and drive this element from forecast sensors, or wait for planned native deferrable support in HAEO.
 
-## Next Steps
+## Next steps
 
 <div class="grid cards" markdown>
 

--- a/docs/user-guide/elements/node.md
+++ b/docs/user-guide/elements/node.md
@@ -252,7 +252,7 @@ Set connection power limits to match the inverter rating.
 
 See [Connections](connections.md) for detailed configuration guidance.
 
-## Next Steps
+## Next steps
 
 <div class="grid cards" markdown>
 

--- a/docs/user-guide/elements/solar.md
+++ b/docs/user-guide/elements/solar.md
@@ -178,7 +178,7 @@ It indicates whether more solar generation would be beneficial or detrimental.
 - Verify forecast covers daytime hours
 - Review HAEO logs for format detection warnings
 
-## Next Steps
+## Next steps
 
 <div class="grid cards" markdown>
 

--- a/docs/user-guide/forecasts-and-sensors.md
+++ b/docs/user-guide/forecasts-and-sensors.md
@@ -447,7 +447,7 @@ However, higher resolution forecasts improve accuracy:
 - Use reputable forecast providers with proven track records
 - Consider multiple forecast sources for critical elements
 
-## Next Steps
+## Next steps
 
 <div class="grid cards" markdown>
 

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -19,7 +19,7 @@ This guide covers everything you need to know as an end user:
 
 Before installing HAEO, confirm:
 
-- Your Home Assistant core version is 2025.4.4 or newer
+- Your Home Assistant core version is 2026.1.1 or newer
 - You can add integrations through the UI or [HACS](https://hacs.xyz/) if you prefer managed updates
 - The data you plan to optimize (prices, forecasts, sensor readings) is already available in Home Assistant or will be added with other integrations
 
@@ -94,7 +94,7 @@ If you run into issues:
 
     Always include your Home Assistant version, HAEO version, and relevant configuration (with sensitive data removed) when asking for help.
 
-## Next Steps
+## Next steps
 
 Continue with these guides to get HAEO running smoothly in your environment.
 

--- a/docs/user-guide/installation.md
+++ b/docs/user-guide/installation.md
@@ -1,6 +1,6 @@
 # Installation
 
-[![hacs_badge](https://img.shields.io/badge/HACS-Custom-41BDF5.svg)](https://github.com/hass-community/hacs)
+[![hacs_badge](https://img.shields.io/badge/HACS-Default-41BDF5.svg)](https://github.com/hacs/integration)
 
 This guide will walk you through installing HAEO on your Home Assistant instance.
 
@@ -8,33 +8,31 @@ This guide will walk you through installing HAEO on your Home Assistant instance
 
 Before installing HAEO, ensure you have:
 
-- **Home Assistant** version 2025.4.4 or newer
-- **HACS** (Home Assistant Community Store) installed (recommended)
+- **Home Assistant** version 2026.1.1 or newer
+- **[HACS](https://hacs.xyz/)** (Home Assistant Community Store) installed (recommended)
 
-## Method 1: HACS Installation (Recommended)
+## Method 1: HACS installation (recommended)
 
-HACS provides automatic updates and easy installation.
+HAEO is published in the [default HACS store](https://github.com/hacs/default).
+You do not need to [add a custom repository](https://hacs.xyz/docs/faq/custom_repositories/).
+HACS provides automatic updates after installation.
 
-### Step 1: Add Custom Repository
+For the general download workflow, see the [HACS dashboard documentation](https://hacs.xyz/docs/use/repositories/dashboard/).
+
+[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=hass-energy&repository=haeo&category=integration)
+
+### Step 1: Install HAEO
 
 1. Open your Home Assistant instance
-2. Navigate to **HACS** → **Integrations**
-3. Click the three dots (⋮) in the top right corner
-4. Select **Custom repositories**
-5. Add the following details:
-    - **Repository**: `https://github.com/hass-energy/haeo`
-    - **Category**: `Integration`
-6. Click **Add**
+2. Open **HACS** from the sidebar
+3. Go to **Integrations**
+4. Search for **HAEO** or **Home Assistant Energy Optimizer**
+5. Open the repository entry and select **Download** (see [downloading a repository](https://hacs.xyz/docs/use/repositories/dashboard/#downloading-a-repository) in the HACS docs)
+6. Confirm the latest version
 
-### Step 2: Install HAEO
+You can also use the [My Home Assistant](https://my.home-assistant.io/) link above to open HAEO directly in HACS.
 
-1. In HACS, search for **HAEO** or **Home Assistant Energy Optimizer**
-2. Click on the integration
-3. Click **Download**
-4. Select the latest version
-5. Click **Download** again to confirm
-
-### Step 3: Restart Home Assistant
+### Step 2: Restart Home Assistant
 
 After installation, restart Home Assistant:
 
@@ -136,7 +134,7 @@ Manual removal:
 1. Delete the `custom_components/haeo` directory
 2. Restart Home Assistant
 
-## Next Steps
+## Next steps
 
 Move on to these topics once the integration is installed.
 

--- a/docs/user-guide/optimization.md
+++ b/docs/user-guide/optimization.md
@@ -149,7 +149,7 @@ HAEO re-optimizes periodically. Balance:
 The optimization cost represents the total forecasted cost over the full horizon, not just the immediate step.
 Track changes in this value when you adjust configuration parameters to confirm the optimiser is producing the expected behaviour.
 
-## Next Steps
+## Next steps
 
 Explore these guides to act on the optimization outputs.
 

--- a/docs/user-guide/troubleshooting.md
+++ b/docs/user-guide/troubleshooting.md
@@ -201,7 +201,7 @@ Include:
 - Configuration (sanitized)
 - Relevant logs
 
-## Next Steps
+## Next steps
 
 Try these resources if you still need assistance after working through the troubleshooting steps.
 

--- a/docs/walkthroughs/power-policies.md
+++ b/docs/walkthroughs/power-policies.md
@@ -153,7 +153,7 @@ In practical terms:
 If you need to route policied flow through a junction, model the junction as a plain `Node` (with `is_source=false` and `is_sink=false`) and hang the real sink/source elements off it.
 See [Node roles and policy scope](../modeling/tagged-power.md#node-roles-and-policy-scope) for the full rules.
 
-## Next Steps
+## Next steps
 
 <div class="grid cards" markdown>
 

--- a/docs/walkthroughs/sigenergy-system.md
+++ b/docs/walkthroughs/sigenergy-system.md
@@ -273,7 +273,7 @@ The Inverter element simplifies configuration compared to manual DC/AC nets with
 
 See [Node](../user-guide/elements/node.md) for more on hybrid inverter modeling.
 
-## Next Steps
+## Next steps
 
 <div class="grid cards" markdown>
 


### PR DESCRIPTION
## Summary

Documentation housekeeping across the user guide, README, and site-wide conventions.

### Installation and HACS (fixes #268)

- Remove outdated custom-repository steps; HAEO is in the [default HACS store](https://github.com/hacs/default)
- Rewrite `docs/user-guide/installation.md` with official HACS dashboard links, semantic line breaks, and the My Home Assistant shortcut
- Simplify the README install section to defer step-by-step detail to the published installation guide

### Prerequisites

- Update the user guide Home Assistant minimum to **2026.1.1**, matching `hacs.json` and `pyproject.toml`

### Documentation standards

- Normalize `## Next steps` headings to sentence case across the docs site (44 pages)
- Update `documentation-guidelines.md` and `documentation.instructions.md` so future pages follow the same convention

Fixes #268

## Test plan

- [x] `uv run mdformat` on changed markdown files
- [ ] Review README and [installation guide](https://hass-energy.github.io/haeo/user-guide/installation/) preview on GitHub
- [ ] Spot-check a few updated pages render correctly on the docs site (Next steps cards unchanged aside from heading)
- [ ] Confirm HACS install flow matches current HACS UI (search → Download from Integrations)