### PR TITLE
Ban typing.cast and replace usages with proper typing

### DIFF
--- a/custom_components/haeo/core/adapters/elements/tests/test_load_stats.py
+++ b/custom_components/haeo/core/adapters/elements/tests/test_load_stats.py
@@ -11,7 +11,6 @@ cases.
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import cast
 
 import numpy as np
 import pytest
@@ -39,16 +38,13 @@ from custom_components.haeo.core.schema.elements.load import LoadConfigData
 
 
 def _config(*, sheddable: bool = True, source: str = "main_bus", n: int = 4) -> LoadConfigData:
-    return cast(
-        "LoadConfigData",
-        {
-            "element_type": ElementType.LOAD,
-            "name": "load",
-            "connection": as_connection_target(source),
-            "forecast": {"forecast": np.array([1.0] * n)},
-            "curtailment": {"curtailment": sheddable},
-        },
-    )
+    return {
+        "element_type": ElementType.LOAD,
+        "name": "load",
+        "connection": as_connection_target(source),
+        "forecast": {"forecast": np.array([1.0] * n)},
+        "curtailment": {"curtailment": sheddable},
+    }
 
 
 def _outputs_with_dual(
@@ -59,17 +55,14 @@ def _outputs_with_dual(
     source: str = "main_bus",
 ) -> Mapping[str, Mapping[ModelOutputName, ModelOutputValue]]:
     """Build a model_outputs mapping with a connection power output and a source node dual."""
-    return cast(
-        "Mapping[str, Mapping[ModelOutputName, ModelOutputValue]]",
-        {
-            "load:connection": {
-                CONNECTION_POWER: OutputData(type=OutputType.POWER_FLOW, unit="kW", values=power, direction="+"),
-            },
-            source: {
-                ELEMENT_POWER_BALANCE: OutputData(type=OutputType.SHADOW_PRICE, unit="$/kW", values=dual),
-            },
+    return {
+        "load:connection": {
+            CONNECTION_POWER: OutputData(type=OutputType.POWER_FLOW, unit="kW", values=power, direction="+"),
         },
-    )
+        source: {
+            ELEMENT_POWER_BALANCE: OutputData(type=OutputType.SHADOW_PRICE, unit="$/kW", values=dual),
+        },
+    }
 
 
 def test_horizon_sensors_are_cumulative_with_state_last_set() -> None:
@@ -298,16 +291,13 @@ def test_stats_omitted_when_source_node_has_no_dual() -> None:
     publishing a misleading zero-cost figure would be worse than omitting the sensor.
     """
     adapter = LoadAdapter()
-    model_outputs = cast(
-        "Mapping[str, Mapping[ModelOutputName, ModelOutputValue]]",
-        {
-            "load:connection": {
-                CONNECTION_POWER: OutputData(type=OutputType.POWER_FLOW, unit="kW", values=(1.0, 1.0), direction="+"),
-            },
-            # source node exists but has no element_power_balance entry
-            "main_bus": {},
+    model_outputs: Mapping[str, Mapping[ModelOutputName, ModelOutputValue]] = {
+        "load:connection": {
+            CONNECTION_POWER: OutputData(type=OutputType.POWER_FLOW, unit="kW", values=(1.0, 1.0), direction="+"),
         },
-    )
+        # source node exists but has no element_power_balance entry
+        "main_bus": {},
+    }
 
     result = adapter.outputs("load", model_outputs, config=_config(n=2), periods=(1.0, 1.0))
     load_outputs = result[LOAD_DEVICE_LOAD]

--- a/custom_components/haeo/core/data/loader/constant_loader.py
+++ b/custom_components/haeo/core/data/loader/constant_loader.py
@@ -1,7 +1,9 @@
 """Loader for constant (scalar) configuration values."""
 
 from numbers import Real
-from typing import Any, TypeGuard, cast
+from typing import Any, TypeGuard, TypeVar, overload
+
+T = TypeVar("T")
 
 
 class ConstantLoader[T]:
@@ -12,10 +14,21 @@ class ConstantLoader[T]:
 
     """
 
-    def __init__(self, cls: type[T]) -> None:
+    @overload
+    def __new__(cls, loader_type: type[float]) -> "FloatConstantLoader": ...
+
+    @overload
+    def __new__(cls, loader_type: type[T]) -> "ConstantLoader[T]": ...
+
+    def __new__(cls, loader_type: type[Any]) -> "ConstantLoader[Any] | FloatConstantLoader":
+        """Return a float-specialized loader when ``loader_type`` is ``float``."""
+        if loader_type is float:
+            return object.__new__(FloatConstantLoader)
+        return super().__new__(cls)
+
+    def __init__(self, loader_type: type[T]) -> None:
         """Initialize with the expected constant type."""
-        super().__init__()
-        self._type = cls
+        self._type = loader_type
 
     def available(self, value: Any, **_kwargs: Any) -> bool:
         """Return True if the constant field is available."""
@@ -40,13 +53,26 @@ class ConstantLoader[T]:
 
     def _convert(self, value: Any) -> T | None:
         """Return the converted value when it matches the expected type."""
-
-        if self._type is float:
-            if isinstance(value, Real):
-                return cast("T", float(value))
-            return None
-
         if isinstance(value, self._type):
             return value
+
+        return None
+
+
+class FloatConstantLoader(ConstantLoader[float]):
+    """Constant loader that coerces numeric values to float."""
+
+    def __init__(self, loader_type: type[Any]) -> None:
+        """Initialize as a float constant loader.
+
+        ``loader_type`` must be ``float`` when created via ``ConstantLoader(float)``.
+        """
+        _ = loader_type
+        super().__init__(float)
+
+    def _convert(self, value: Any) -> float | None:
+        """Accept any Real value and normalize to float."""
+        if isinstance(value, Real):
+            return float(value)
 
         return None

--- a/custom_components/haeo/core/data/loader/extractors/utils/entity_metadata.py
+++ b/custom_components/haeo/core/data/loader/extractors/utils/entity_metadata.py
@@ -2,9 +2,14 @@
 
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import cast
+from typing import TypeGuard
 
 from custom_components.haeo.core.schema.util import UnitSpec
+
+
+def _is_unit_spec(value: UnitSpec | Sequence[UnitSpec]) -> TypeGuard[UnitSpec]:
+    """Narrow to a single spec (not a list of alternative specs)."""
+    return not isinstance(value, list)
 
 
 @dataclass(frozen=True)
@@ -25,4 +30,7 @@ class EntityMetadata:
         if isinstance(accepted_units, list):
             return any(matches_unit_spec(self.unit_of_measurement, spec) for spec in accepted_units)
 
-        return matches_unit_spec(self.unit_of_measurement, cast("UnitSpec", accepted_units))
+        if _is_unit_spec(accepted_units):
+            return matches_unit_spec(self.unit_of_measurement, accepted_units)
+
+        return False

--- a/custom_components/haeo/core/data/loader/extractors/utils/entity_metadata.py
+++ b/custom_components/haeo/core/data/loader/extractors/utils/entity_metadata.py
@@ -1,14 +1,8 @@
 """Entity metadata utilities."""
 
 from dataclasses import dataclass
-from typing import TypeGuard
 
 from custom_components.haeo.core.schema.util import UnitSpec
-
-
-def _is_unit_spec(value: UnitSpec | list[UnitSpec]) -> TypeGuard[UnitSpec]:
-    """Narrow to a single spec (not a list of alternative specs)."""
-    return not isinstance(value, list)
 
 
 @dataclass(frozen=True)
@@ -29,7 +23,4 @@ class EntityMetadata:
         if isinstance(accepted_units, list):
             return any(matches_unit_spec(self.unit_of_measurement, spec) for spec in accepted_units)
 
-        if _is_unit_spec(accepted_units):
-            return matches_unit_spec(self.unit_of_measurement, accepted_units)
-
-        return False
+        return matches_unit_spec(self.unit_of_measurement, accepted_units)

--- a/custom_components/haeo/core/data/loader/extractors/utils/entity_metadata.py
+++ b/custom_components/haeo/core/data/loader/extractors/utils/entity_metadata.py
@@ -1,13 +1,12 @@
 """Entity metadata utilities."""
 
-from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import TypeGuard
 
 from custom_components.haeo.core.schema.util import UnitSpec
 
 
-def _is_unit_spec(value: UnitSpec | Sequence[UnitSpec]) -> TypeGuard[UnitSpec]:
+def _is_unit_spec(value: UnitSpec | list[UnitSpec]) -> TypeGuard[UnitSpec]:
     """Narrow to a single spec (not a list of alternative specs)."""
     return not isinstance(value, list)
 
@@ -19,7 +18,7 @@ class EntityMetadata:
     entity_id: str
     unit_of_measurement: str | None
 
-    def is_compatible_with(self, accepted_units: "UnitSpec | Sequence[UnitSpec]") -> bool:
+    def is_compatible_with(self, accepted_units: UnitSpec | list[UnitSpec]) -> bool:
         """Check if this entity's unit is compatible with the accepted units."""
         # Avoid circular import with schema module
         from custom_components.haeo.core.schema.util import matches_unit_spec  # noqa: PLC0415

--- a/custom_components/haeo/core/data/loader/tests/test_config_loader.py
+++ b/custom_components/haeo/core/data/loader/tests/test_config_loader.py
@@ -1,7 +1,7 @@
 """Tests for the core config loader."""
 
 from collections.abc import Sequence
-from typing import Any, cast
+from typing import Any
 
 import numpy as np
 import pytest
@@ -20,7 +20,6 @@ from custom_components.haeo.core.schema.elements.battery import CONF_CAPACITY, S
 from custom_components.haeo.core.schema.elements.policy import CONF_PRICE, CONF_RULES
 from custom_components.haeo.core.schema.field_hints import FieldHint, ListFieldHints
 from custom_components.haeo.core.schema.sections import CONF_EFFICIENCY_SOURCE_TARGET, SECTION_EFFICIENCY
-from custom_components.haeo.elements import ElementConfigSchema
 
 FORECAST_TIMES = (0.0, 3600.0, 7200.0, 10800.0)
 
@@ -548,7 +547,7 @@ def _load_config_from_values(
     """Load an element config from store values and return as a plain dict."""
     result: Any = load_element_config_from_values(
         name,
-        cast("ElementConfigSchema", config),
+        config,  # type: ignore[arg-type]  # fixtures use loose dicts; loader validates at runtime
         field_values,
         FORECAST_TIMES,
     )
@@ -639,7 +638,12 @@ def test_load_element_config_from_values_skips_invalid_list_container() -> None:
         "rules": "not-a-list",
     }
 
-    result = _load_config_from_values("Policies", config, {})
+    result: Any = load_element_config_from_values(
+        "Policies",
+        config,  # type: ignore[arg-type]  # rules is not a list; is_element_config_schema rejects this fixture
+        {},
+        FORECAST_TIMES,
+    )
 
     assert result["rules"] == "not-a-list"
 
@@ -649,7 +653,7 @@ def test_load_element_config_from_values_unknown_element_type_raises() -> None:
     with pytest.raises(ValueError, match="Unknown element type"):
         load_element_config_from_values(
             "Bad",
-            cast("ElementConfigSchema", {"element_type": "not_real", "name": "Bad"}),
+            {"element_type": "not_real", "name": "Bad"},  # type: ignore[typeddict-item]  # invalid element_type must reach runtime validation
             {},
             FORECAST_TIMES,
         )

--- a/custom_components/haeo/core/data/loader/tests/test_scalar_loader.py
+++ b/custom_components/haeo/core/data/loader/tests/test_scalar_loader.py
@@ -23,10 +23,13 @@ async def test_scalar_loader_available_empty_list() -> None:
 async def test_scalar_loader_available_invalid_entity_value() -> None:
     """Scalar loader is unavailable for invalid entity value types."""
     loader = ScalarLoader()
-    assert loader.available(
-        sm=FakeStateMachine({}),
-        value={"type": "entity", "value": 123},  # type: ignore[arg-type]  # invalid entity id type; must not satisfy EntityValue for this test
-    ) is False
+    assert (
+        loader.available(
+            sm=FakeStateMachine({}),
+            value={"type": "entity", "value": 123},  # type: ignore[arg-type]  # invalid entity id type; must not satisfy EntityValue for this test
+        )
+        is False
+    )
 
 
 async def test_scalar_loader_available_false_for_non_numeric_state() -> None:

--- a/custom_components/haeo/core/data/loader/tests/test_scalar_loader.py
+++ b/custom_components/haeo/core/data/loader/tests/test_scalar_loader.py
@@ -1,12 +1,10 @@
 """Tests for ScalarLoader handling current sensor values."""
 
-from typing import cast
-
 import pytest
 
 from conftest import FakeEntityState, FakeStateMachine
 from custom_components.haeo.core.data.loader.scalar_loader import ScalarLoader
-from custom_components.haeo.core.schema import EntityValue, as_entity_value
+from custom_components.haeo.core.schema import as_entity_value
 
 
 async def test_scalar_loader_available_missing_sensor() -> None:
@@ -25,9 +23,10 @@ async def test_scalar_loader_available_empty_list() -> None:
 async def test_scalar_loader_available_invalid_entity_value() -> None:
     """Scalar loader is unavailable for invalid entity value types."""
     loader = ScalarLoader()
-    value = cast("EntityValue", {"type": "entity", "value": 123})
-
-    assert loader.available(sm=FakeStateMachine({}), value=value) is False
+    assert loader.available(
+        sm=FakeStateMachine({}),
+        value={"type": "entity", "value": 123},  # type: ignore[arg-type]  # invalid entity id type; must not satisfy EntityValue for this test
+    ) is False
 
 
 async def test_scalar_loader_available_false_for_non_numeric_state() -> None:
@@ -79,10 +78,11 @@ async def test_scalar_loader_load_raises_for_non_numeric_state() -> None:
 async def test_scalar_loader_load_raises_for_invalid_entity_value() -> None:
     """Scalar loader raises when entity value is invalid."""
     loader = ScalarLoader()
-    value = cast("EntityValue", {"type": "entity", "value": 123})
-
     with pytest.raises(TypeError, match="sensor entity ID"):
-        await loader.load(sm=FakeStateMachine({}), value=value)
+        await loader.load(
+            sm=FakeStateMachine({}),
+            value={"type": "entity", "value": 123},  # type: ignore[arg-type]  # invalid entity id type; must not satisfy EntityValue for this test
+        )
 
 
 async def test_scalar_loader_loads_and_converts_units() -> None:

--- a/custom_components/haeo/core/data/loader/tests/test_time_series_loader_unit.py
+++ b/custom_components/haeo/core/data/loader/tests/test_time_series_loader_unit.py
@@ -8,7 +8,6 @@ Lower-level fusion and cycling logic is tested in:
 """
 
 from collections.abc import Sequence
-from typing import cast
 
 import pytest
 
@@ -16,7 +15,7 @@ from conftest import FakeStateMachine
 from custom_components.haeo.core.data.loader import time_series_loader as tsl
 from custom_components.haeo.core.data.loader.sensor_loader import normalize_entity_ids
 from custom_components.haeo.core.data.loader.time_series_loader import TimeSeriesLoader
-from custom_components.haeo.core.schema import EntityValue, as_entity_value
+from custom_components.haeo.core.schema import as_entity_value
 
 
 def test_normalize_entity_ids_rejects_invalid_type() -> None:
@@ -68,7 +67,7 @@ def test_time_series_loader_available_invalid_value(monkeypatch: pytest.MonkeyPa
     monkeypatch.setattr(tsl, "load_sensors", fail_load_sensors)
 
     with pytest.raises(TypeError):
-        loader.available(sm=FakeStateMachine({}), value=cast(EntityValue, object()))  # noqa: TC006 (cast needed to test runtime behavior with invalid type)
+        loader.available(sm=FakeStateMachine({}), value=object())  # type: ignore[arg-type]  # deliberate non-EntityValue; TypeGuard would make the call ill-typed
 
 
 @pytest.mark.asyncio

--- a/custom_components/haeo/core/model/elements/tests/test_connections.py
+++ b/custom_components/haeo/core/model/elements/tests/test_connections.py
@@ -1,6 +1,6 @@
 """Model connection output tests covering reporting and validation helpers."""
 
-from typing import Any, TypeGuard, cast
+from typing import Any, TypeGuard
 
 from highspy import Highs
 from highspy.highs import highs_linear_expression
@@ -90,6 +90,10 @@ def _is_expected_output(value: ExpectedOutputFixture) -> TypeGuard[ExpectedOutpu
     return {"type", "unit", "values"}.issubset(value.keys())
 
 
+def _is_nested_outputs(value: ExpectedOutputFixture) -> TypeGuard[ExpectedOutputs]:
+    return not _is_expected_output(value)
+
+
 def _assert_outputs_match(actual: ExpectedOutputFixture, expected: ExpectedOutputFixture) -> None:
     if _is_expected_output(expected):
         assert _is_expected_output(actual)
@@ -99,9 +103,10 @@ def _assert_outputs_match(actual: ExpectedOutputFixture, expected: ExpectedOutpu
         assert actual["values"] == pytest.approx(expected["values"], rel=tol[0], abs=tol[1])
         return
 
-    assert not _is_expected_output(actual)
-    actual_map = cast("ExpectedOutputs", actual)
-    expected_map = cast("ExpectedOutputs", expected)
+    assert _is_nested_outputs(actual)
+    assert _is_nested_outputs(expected)
+    actual_map = actual
+    expected_map = expected
     for output_name, expected_value in expected_map.items():
         assert output_name in actual_map, f"Missing expected key: {output_name}"
         _assert_outputs_match(actual_map[output_name], expected_value)

--- a/custom_components/haeo/core/model/tests/test_policy_scenario.py
+++ b/custom_components/haeo/core/model/tests/test_policy_scenario.py
@@ -19,7 +19,6 @@ This tests the model layer's tag infrastructure directly, without
 depending on the policy compilation adapter.
 """
 
-
 import numpy as np
 import pytest
 

--- a/custom_components/haeo/core/model/tests/test_policy_scenario.py
+++ b/custom_components/haeo/core/model/tests/test_policy_scenario.py
@@ -19,7 +19,6 @@ This tests the model layer's tag infrastructure directly, without
 depending on the policy compilation adapter.
 """
 
-from typing import Any, cast
 
 import numpy as np
 import pytest
@@ -45,7 +44,7 @@ def _build_tagged_system(
     battery_capacity: float = 5.0,
     battery_initial_kwh: float = 2.5,
     battery_max_power: float = 5.0,
-) -> list[dict[str, Any]]:
+) -> list[ModelElementConfig]:
     """Build model elements with pre-assigned tags."""
     n = len(periods)
     return [
@@ -192,7 +191,7 @@ def test_tagged_power_flow_scenario() -> None:
 
     network = Network(name="tagged_scenario", periods=periods)
     for elem in sorted(elements, key=lambda e: e.get("element_type") == "connection"):
-        network.add(cast("ModelElementConfig", elem))
+        network.add(elem)
 
     cost = network.optimize()
     h = network._solver

--- a/custom_components/haeo/core/schema/elements/battery.py
+++ b/custom_components/haeo/core/schema/elements/battery.py
@@ -1,6 +1,6 @@
 """Battery element schema definitions."""
 
-from typing import Annotated, Any, Final, Literal, NotRequired, TypedDict
+from typing import Annotated, Any, Final, Literal, NotRequired, TypedDict, TypeGuard
 
 import numpy as np
 from numpy.typing import NDArray
@@ -321,6 +321,11 @@ class BatteryConfigData(ConnectedCommonData):
     overcharge: NotRequired[PartitionData]
 
 
+def is_battery_config_data(config: Any) -> TypeGuard[BatteryConfigData]:
+    """Narrow a loaded element config to battery data using the element_type discriminator."""
+    return isinstance(config, dict) and config.get("element_type") == ELEMENT_TYPE
+
+
 __all__ = [
     "CONF_CAPACITY",
     "CONF_CONFIGURE_PARTITIONS",
@@ -358,4 +363,5 @@ __all__ = [
     "PartitioningData",
     "StorageSocConfig",
     "StorageSocData",
+    "is_battery_config_data",
 ]

--- a/custom_components/haeo/core/schema/migrations/v1_3.py
+++ b/custom_components/haeo/core/schema/migrations/v1_3.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from numbers import Real
-from typing import Any, cast
+from typing import Any
 
 from custom_components.haeo.core.const import (
     CONF_ADVANCED_MODE,
@@ -174,9 +174,9 @@ def _migrate_element_to_sectioned(data: Mapping[str, Any]) -> dict[str, Any] | N
             return data[key]
         for value in data.values():
             if isinstance(value, Mapping):
-                mapping_value = cast("Mapping[str, Any]", value)
-                if key in mapping_value:
-                    return mapping_value[key]
+                for mapping_key, mapping_value in value.items():
+                    if isinstance(mapping_key, str) and mapping_key == key:
+                        return mapping_value
         return None
 
     def to_schema_value(value: Any) -> SchemaValue:

--- a/custom_components/haeo/core/schema/tests/test_connection_target.py
+++ b/custom_components/haeo/core/schema/tests/test_connection_target.py
@@ -1,6 +1,5 @@
 """Tests for connection target schema helpers."""
 
-
 import pytest
 
 from custom_components.haeo.core.schema.connection_target import (

--- a/custom_components/haeo/core/schema/tests/test_connection_target.py
+++ b/custom_components/haeo/core/schema/tests/test_connection_target.py
@@ -1,6 +1,5 @@
 """Tests for connection target schema helpers."""
 
-from typing import Any, cast
 
 import pytest
 
@@ -31,7 +30,7 @@ def test_normalize_connection_target_handles_str_and_schema_value() -> None:
 def test_normalize_connection_target_rejects_invalid_type() -> None:
     """normalize_connection_target rejects unsupported input types."""
     with pytest.raises(TypeError, match="Unsupported connection target"):
-        normalize_connection_target(cast("Any", 123))
+        normalize_connection_target(123)  # type: ignore[arg-type]  # deliberate invalid input; TypeGuard would skip the runtime check under test
 
 
 def test_get_connection_target_name_handles_variants() -> None:
@@ -44,4 +43,4 @@ def test_get_connection_target_name_handles_variants() -> None:
 def test_get_connection_target_name_rejects_invalid_type() -> None:
     """get_connection_target_name rejects unsupported input types."""
     with pytest.raises(TypeError, match="Unsupported connection target"):
-        get_connection_target_name(cast("Any", 123))
+        get_connection_target_name(123)  # type: ignore[arg-type]  # deliberate invalid input; TypeGuard would skip the runtime check under test

--- a/custom_components/haeo/diagnostics/collector.py
+++ b/custom_components/haeo/diagnostics/collector.py
@@ -3,10 +3,9 @@
 from collections.abc import Mapping
 from dataclasses import asdict, dataclass
 from datetime import datetime, timedelta
-from typing import Any, cast
+from typing import Any
 
 from homeassistant.components.diagnostics import async_redact_data
-from homeassistant.components.recorder import history as recorder_history
 from homeassistant.const import __version__ as ha_version
 from homeassistant.core import HomeAssistant, State
 from homeassistant.helpers.recorder import get_instance as get_recorder_instance
@@ -19,6 +18,7 @@ from custom_components.haeo.core.const import CONF_ELEMENT_TYPE, CONF_NAME
 from custom_components.haeo.core.context import OptimizationContext
 from custom_components.haeo.core.schema import SchemaValue, is_schema_value
 from custom_components.haeo.core.schema.elements import ElementConfigSchema
+from custom_components.haeo.diagnostics.recorder_history import get_significant_states_full
 from custom_components.haeo.elements import is_element_config_schema
 from custom_components.haeo.sensor_utils import (
     SensorStateDict,
@@ -204,7 +204,7 @@ async def _fetch_inputs_at(
     entity_id_list = sorted(all_entity_ids)
 
     def _query() -> dict[str, list[State]]:
-        result = recorder_history.get_significant_states(
+        return get_significant_states_full(
             hass,
             start_time=target_time,
             end_time=target_time,
@@ -213,7 +213,6 @@ async def _fetch_inputs_at(
             significant_changes_only=False,
             no_attributes=False,
         )
-        return cast("dict[str, list[State]]", result)
 
     states = await recorder.async_add_executor_job(_query)
     entity_states = {eid: slist[0] for eid, slist in states.items() if slist}
@@ -252,7 +251,7 @@ async def _get_last_run_before(
     recorder = get_recorder_instance(hass)
 
     def _query() -> dict[str, list[State]]:
-        result = recorder_history.get_significant_states(
+        return get_significant_states_full(
             hass,
             start_time=target_time,
             end_time=target_time,
@@ -261,7 +260,6 @@ async def _get_last_run_before(
             significant_changes_only=False,
             no_attributes=False,
         )
-        return cast("dict[str, list[State]]", result)
 
     states = await recorder.async_add_executor_job(_query)
 

--- a/custom_components/haeo/diagnostics/historical_state_provider.py
+++ b/custom_components/haeo/diagnostics/historical_state_provider.py
@@ -2,11 +2,11 @@
 
 from collections.abc import Iterable
 from datetime import datetime
-from typing import Any, cast
 
-from homeassistant.components.recorder import history as recorder_history
 from homeassistant.core import HomeAssistant, State
 from homeassistant.helpers.recorder import get_instance as get_recorder_instance
+
+from custom_components.haeo.diagnostics.recorder_history import get_significant_states_full
 
 
 class HistoricalStateProvider:
@@ -64,9 +64,7 @@ class HistoricalStateProvider:
 
         Run this in an executor to avoid blocking the event loop.
         """
-        # get_significant_states handles session scope internally
-        # With minimal_response=False (default), it returns full State objects
-        result: dict[str, list[State | dict[str, Any]]] = recorder_history.get_significant_states(
+        return get_significant_states_full(
             self._hass,
             start_time=self._timestamp,
             end_time=self._timestamp,
@@ -75,5 +73,3 @@ class HistoricalStateProvider:
             significant_changes_only=False,  # include attribute-only changes
             no_attributes=False,  # preserve attributes (needed for forecasts)
         )
-        # Cast since we're not using minimal_response, so we get full State objects
-        return cast("dict[str, list[State]]", result)

--- a/custom_components/haeo/diagnostics/recorder_history.py
+++ b/custom_components/haeo/diagnostics/recorder_history.py
@@ -1,0 +1,47 @@
+"""Recorder history helpers with runtime State validation."""
+
+from datetime import datetime
+from typing import Any
+
+from homeassistant.components.recorder import history as recorder_history
+from homeassistant.core import HomeAssistant, State
+
+
+def get_significant_states_full(
+    hass: HomeAssistant,
+    *,
+    start_time: datetime,
+    end_time: datetime,
+    entity_ids: list[str],
+    include_start_time_state: bool = True,
+    significant_changes_only: bool = False,
+    no_attributes: bool = False,
+) -> dict[str, list[State]]:
+    """Return significant states as full State objects.
+
+    Home Assistant stubs type this as ``State | dict`` when minimal_response may be true.
+    This helper always requests full states (``no_attributes=False`` by default) and
+    keeps only values that are ``State`` instances at runtime.
+    """
+    raw = recorder_history.get_significant_states(
+        hass,
+        start_time=start_time,
+        end_time=end_time,
+        entity_ids=entity_ids,
+        include_start_time_state=include_start_time_state,
+        significant_changes_only=significant_changes_only,
+        no_attributes=no_attributes,
+    )
+    return _states_only_history(raw)
+
+
+def _states_only_history(
+    result: dict[str, list[State | dict[str, Any]]],
+) -> dict[str, list[State]]:
+    """Drop minimal-response dict entries; keep full State objects only."""
+    narrowed: dict[str, list[State]] = {}
+    for entity_id, states in result.items():
+        full_states = [state for state in states if isinstance(state, State)]
+        if full_states:
+            narrowed[entity_id] = full_states
+    return narrowed

--- a/custom_components/haeo/flows/elements/tests/test_battery_flow.py
+++ b/custom_components/haeo/flows/elements/tests/test_battery_flow.py
@@ -1,7 +1,7 @@
 """Tests for battery element config flow."""
 
 from types import MappingProxyType
-from typing import Any, cast
+from typing import Any
 from unittest.mock import Mock
 
 from homeassistant.config_entries import SOURCE_RECONFIGURE, ConfigSubentry
@@ -481,7 +481,7 @@ async def test_reconfigure_partition_defaults_entity_links(hass: HomeAssistant, 
     }
     flow._get_reconfigure_subentry = Mock(return_value=existing_subentry)
 
-    input_fields = get_input_fields(cast("Any", {CONF_ELEMENT_TYPE: ELEMENT_TYPE}))
+    input_fields = get_input_fields({CONF_ELEMENT_TYPE: ELEMENT_TYPE})
     defaults = flow._build_partition_defaults(input_fields, dict(existing_config))
 
     assert defaults[SECTION_UNDERCHARGE][CONF_PARTITION_PERCENTAGE] == ["sensor.undercharge"]
@@ -529,7 +529,7 @@ async def test_reconfigure_partition_defaults_scalar_values(hass: HomeAssistant,
     }
     flow._get_reconfigure_subentry = Mock(return_value=existing_subentry)
 
-    input_fields = get_input_fields(cast("Any", {CONF_ELEMENT_TYPE: ELEMENT_TYPE}))
+    input_fields = get_input_fields({CONF_ELEMENT_TYPE: ELEMENT_TYPE})
     defaults = flow._build_partition_defaults(input_fields, dict(existing_config))
 
     assert defaults[SECTION_UNDERCHARGE][CONF_PARTITION_PERCENTAGE] == 5.0
@@ -540,7 +540,7 @@ async def test_build_partition_defaults_no_existing_data(hass: HomeAssistant, hu
     """_build_partition_defaults with no existing data uses field defaults."""
     flow = create_flow(hass, hub_entry, ELEMENT_TYPE)
 
-    input_fields = get_input_fields(cast("Any", {CONF_ELEMENT_TYPE: ELEMENT_TYPE}))
+    input_fields = get_input_fields({CONF_ELEMENT_TYPE: ELEMENT_TYPE})
     defaults = flow._build_partition_defaults(input_fields, None)
 
     # Partition fields have defaults (mode="value", value=0 or value=100)
@@ -641,7 +641,7 @@ async def test_reconfigure_defaults_handle_schema_values(
     assert result.get("type") == FlowResultType.FORM
     assert result.get("step_id") == "user"
 
-    input_fields = get_input_fields(cast("Any", {CONF_ELEMENT_TYPE: ELEMENT_TYPE}))
+    input_fields = get_input_fields({CONF_ELEMENT_TYPE: ELEMENT_TYPE})
     defaults = flow._build_defaults("Test Battery", input_fields, dict(existing_subentry.data))
 
     for section, values in expected_defaults.items():

--- a/custom_components/haeo/flows/elements/tests/test_battery_section_flow.py
+++ b/custom_components/haeo/flows/elements/tests/test_battery_section_flow.py
@@ -1,7 +1,7 @@
 """Tests for battery_section element config flow."""
 
 from types import MappingProxyType
-from typing import Any, cast
+from typing import Any
 from unittest.mock import Mock
 
 from homeassistant.config_entries import SOURCE_RECONFIGURE, ConfigSubentry
@@ -106,7 +106,7 @@ async def test_reconfigure_defaults_handle_schema_values(
     assert result.get("type") == FlowResultType.FORM
     assert result.get("step_id") == "user"
 
-    input_fields = get_input_fields(cast("Any", {CONF_ELEMENT_TYPE: ELEMENT_TYPE}))
+    input_fields = get_input_fields({CONF_ELEMENT_TYPE: ELEMENT_TYPE})
     defaults = flow._build_defaults("Test Battery Section", input_fields, dict(existing_subentry.data))
 
     for key, expected in expected_defaults.items():

--- a/custom_components/haeo/flows/elements/tests/test_connection_flow.py
+++ b/custom_components/haeo/flows/elements/tests/test_connection_flow.py
@@ -1,7 +1,7 @@
 """Tests for connection element config flow."""
 
 from types import MappingProxyType
-from typing import Any, cast
+from typing import Any
 from unittest.mock import Mock
 
 from homeassistant.config_entries import SOURCE_RECONFIGURE, ConfigSubentry
@@ -205,7 +205,7 @@ async def test_reconfigure_defaults_handle_schema_values(
     assert result.get("type") == FlowResultType.FORM
     assert result.get("step_id") == "user"
 
-    input_fields = get_input_fields(cast("Any", {CONF_ELEMENT_TYPE: ELEMENT_TYPE}))
+    input_fields = get_input_fields({CONF_ELEMENT_TYPE: ELEMENT_TYPE})
     defaults = flow._build_defaults("Test Connection", input_fields, dict(existing_subentry.data))
 
     for key, expected in expected_defaults.items():

--- a/custom_components/haeo/flows/elements/tests/test_grid_flow.py
+++ b/custom_components/haeo/flows/elements/tests/test_grid_flow.py
@@ -1,7 +1,7 @@
 """Tests for grid element config flow."""
 
 from types import MappingProxyType
-from typing import Any, cast
+from typing import Any
 from unittest.mock import Mock
 
 from homeassistant.config_entries import SOURCE_RECONFIGURE, ConfigSubentry
@@ -292,7 +292,7 @@ async def test_reconfigure_defaults_handle_schema_values(
     assert result.get("type") == FlowResultType.FORM
     assert result.get("step_id") == "user"
 
-    input_fields = get_input_fields(cast("Any", {CONF_ELEMENT_TYPE: ELEMENT_TYPE}))
+    input_fields = get_input_fields({CONF_ELEMENT_TYPE: ELEMENT_TYPE})
     defaults = flow._build_defaults("Test Grid", input_fields, dict(existing_subentry.data))
     assert defaults[SECTION_PRICING][CONF_IMPORT_PRICE] == expected_defaults[CONF_IMPORT_PRICE]
     assert defaults[SECTION_PRICING][CONF_EXPORT_PRICE] == expected_defaults[CONF_EXPORT_PRICE]

--- a/custom_components/haeo/flows/elements/tests/test_inverter_flow.py
+++ b/custom_components/haeo/flows/elements/tests/test_inverter_flow.py
@@ -1,7 +1,7 @@
 """Tests for inverter element config flow."""
 
 from types import MappingProxyType
-from typing import Any, cast
+from typing import Any
 from unittest.mock import Mock
 
 from homeassistant.config_entries import SOURCE_RECONFIGURE, ConfigSubentry
@@ -159,7 +159,7 @@ async def test_reconfigure_defaults_handle_schema_values(
     assert result.get("type") == FlowResultType.FORM
     assert result.get("step_id") == "user"
 
-    input_fields = get_input_fields(cast("Any", {CONF_ELEMENT_TYPE: ELEMENT_TYPE}))
+    input_fields = get_input_fields({CONF_ELEMENT_TYPE: ELEMENT_TYPE})
     defaults = flow._build_defaults("Test Inverter", input_fields, dict(existing_subentry.data))
     assert defaults[SECTION_LIMITS][CONF_MAX_POWER_DC_TO_AC] == expected_defaults[CONF_MAX_POWER_DC_TO_AC]
     assert defaults[SECTION_LIMITS][CONF_MAX_POWER_AC_TO_DC] == expected_defaults[CONF_MAX_POWER_AC_TO_DC]

--- a/custom_components/haeo/flows/elements/tests/test_load_flow.py
+++ b/custom_components/haeo/flows/elements/tests/test_load_flow.py
@@ -1,7 +1,7 @@
 """Tests for load element config flow."""
 
 from types import MappingProxyType
-from typing import Any, cast
+from typing import Any
 from unittest.mock import Mock
 
 from homeassistant.config_entries import SOURCE_RECONFIGURE, ConfigSubentry
@@ -134,7 +134,7 @@ async def test_reconfigure_defaults_handle_schema_values(
     assert result.get("type") == FlowResultType.FORM
     assert result.get("step_id") == "user"
 
-    input_fields = get_input_fields(cast("Any", {CONF_ELEMENT_TYPE: ELEMENT_TYPE}))
+    input_fields = get_input_fields({CONF_ELEMENT_TYPE: ELEMENT_TYPE})
     defaults = flow._build_defaults("Test Load", input_fields, dict(existing_subentry.data))
     assert defaults.get(SECTION_FORECAST, {}).get(CONF_FORECAST) == expected_forecast
 

--- a/custom_components/haeo/flows/elements/tests/test_solar_flow.py
+++ b/custom_components/haeo/flows/elements/tests/test_solar_flow.py
@@ -1,7 +1,7 @@
 """Tests for solar element config flow."""
 
 from types import MappingProxyType
-from typing import Any, cast
+from typing import Any
 from unittest.mock import Mock
 
 from homeassistant.config_entries import SOURCE_RECONFIGURE, ConfigSubentry
@@ -136,7 +136,7 @@ async def test_reconfigure_defaults_handle_schema_values(
     assert result.get("type") == FlowResultType.FORM
     assert result.get("step_id") == "user"
 
-    input_fields = get_input_fields(cast("Any", {CONF_ELEMENT_TYPE: ELEMENT_TYPE}))
+    input_fields = get_input_fields({CONF_ELEMENT_TYPE: ELEMENT_TYPE})
     defaults = flow._build_defaults("Test Solar", input_fields, dict(existing_subentry.data))
     assert defaults.get(SECTION_FORECAST, {}).get(CONF_FORECAST) == expected_forecast
 

--- a/custom_components/haeo/flows/tests/test_element_flows.py
+++ b/custom_components/haeo/flows/tests/test_element_flows.py
@@ -4,7 +4,7 @@ from collections.abc import Mapping
 from copy import deepcopy
 from dataclasses import dataclass
 from types import MappingProxyType
-from typing import Any, Literal, TypedDict, cast
+from typing import Any, Literal, TypedDict
 from unittest.mock import Mock
 
 from homeassistant.config_entries import ConfigSubentry, ConfigSubentryFlow, SubentryFlowResult
@@ -149,12 +149,15 @@ class FlowTestElementFactory:
 
     def create_subentry(self, *, name: str) -> ConfigSubentry:
         """Return a config subentry for the synthetic element."""
-        return _make_subentry(cast("ElementType", self.element_type), self.create_config(name=name))
+        return _make_subentry(
+            self.element_type,  # type: ignore[arg-type]  # synthetic id is not in ElementType; cannot register without monkeypatch
+            self.create_config(name=name),
+        )
 
     def element_type_for_flow(self) -> ElementType:
-        """Return the synthetic element type cast for flow construction."""
+        """Return the synthetic element type for flow construction."""
 
-        return cast("ElementType", self.element_type)
+        return self.element_type  # type: ignore[return-value]  # synthetic id is not in ElementType enum
 
 
 class FlowTestSubentryFlowHandler(ConfigSubentryFlow):
@@ -207,7 +210,11 @@ def flow_test_element_factory(monkeypatch: pytest.MonkeyPatch) -> FlowTestElemen
             return {}
 
     entry = FlowTestAdapter()
-    monkeypatch.setitem(ELEMENT_TYPES, cast("ElementType", TEST_ELEMENT_TYPE), entry)
+    monkeypatch.setitem(
+        ELEMENT_TYPES,
+        TEST_ELEMENT_TYPE,  # type: ignore[arg-type]  # synthetic id is not in ElementType; registry key type cannot be extended in tests
+        entry,
+    )
     return FlowTestElementFactory()
 
 

--- a/custom_components/haeo/flows/tests/test_options_flow.py
+++ b/custom_components/haeo/flows/tests/test_options_flow.py
@@ -1,6 +1,6 @@
 """Test hub options flow for network configuration."""
 
-from typing import Any, cast
+from typing import Any
 
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
@@ -87,7 +87,7 @@ async def test_options_flow_init(hass: HomeAssistant) -> None:
     )
     entry.add_to_hass(hass)
 
-    result = cast("FlowResultDict", await hass.config_entries.options.async_init(entry.entry_id))
+    result: FlowResultDict = await hass.config_entries.options.async_init(entry.entry_id)  # type: ignore[assignment]  # HA returns ConfigFlowResult; tests index as dict[str, Any]
 
     assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "init"
@@ -127,18 +127,15 @@ async def test_options_flow_select_preset(hass: HomeAssistant) -> None:
     )
     entry.add_to_hass(hass)
 
-    result = cast("FlowResultDict", await hass.config_entries.options.async_init(entry.entry_id))
+    result: FlowResultDict = await hass.config_entries.options.async_init(entry.entry_id)  # type: ignore[assignment]  # HA returns ConfigFlowResult; tests index as dict[str, Any]
     assert result["type"] == FlowResultType.FORM
 
     # Select 3 days preset
-    result = cast(
-        "FlowResultDict",
-        await hass.config_entries.options.async_configure(
-            result["flow_id"],
-            user_input=_wrap_options_input(
-                {CONF_HORIZON_PRESET: HORIZON_PRESET_3_DAYS},
-                {CONF_DEBOUNCE_SECONDS: DEFAULT_DEBOUNCE_SECONDS},
-            ),
+    result: FlowResultDict = await hass.config_entries.options.async_configure(  # type: ignore[assignment]  # HA returns ConfigFlowResult; tests index as dict[str, Any]
+        result["flow_id"],
+        user_input=_wrap_options_input(
+            {CONF_HORIZON_PRESET: HORIZON_PRESET_3_DAYS},
+            {CONF_DEBOUNCE_SECONDS: DEFAULT_DEBOUNCE_SECONDS},
         ),
     )
 
@@ -177,18 +174,15 @@ async def test_options_flow_custom_tiers(hass: HomeAssistant) -> None:
     )
     entry.add_to_hass(hass)
 
-    result = cast("FlowResultDict", await hass.config_entries.options.async_init(entry.entry_id))
+    result: FlowResultDict = await hass.config_entries.options.async_init(entry.entry_id)  # type: ignore[assignment]  # HA returns ConfigFlowResult; tests index as dict[str, Any]
     assert result["type"] == FlowResultType.FORM
 
     # Select custom preset - should go to custom_tiers step
-    result = cast(
-        "FlowResultDict",
-        await hass.config_entries.options.async_configure(
-            result["flow_id"],
-            user_input=_wrap_options_input(
-                {CONF_HORIZON_PRESET: HORIZON_PRESET_CUSTOM},
-                {CONF_DEBOUNCE_SECONDS: DEFAULT_DEBOUNCE_SECONDS},
-            ),
+    result: FlowResultDict = await hass.config_entries.options.async_configure(  # type: ignore[assignment]  # HA returns ConfigFlowResult; tests index as dict[str, Any]
+        result["flow_id"],
+        user_input=_wrap_options_input(
+            {CONF_HORIZON_PRESET: HORIZON_PRESET_CUSTOM},
+            {CONF_DEBOUNCE_SECONDS: DEFAULT_DEBOUNCE_SECONDS},
         ),
     )
 
@@ -196,21 +190,18 @@ async def test_options_flow_custom_tiers(hass: HomeAssistant) -> None:
     assert result["step_id"] == "custom_tiers"
 
     # Configure custom tier values
-    result = cast(
-        "FlowResultDict",
-        await hass.config_entries.options.async_configure(
-            result["flow_id"],
-            user_input={
-                CONF_TIER_1_COUNT: 10,
-                CONF_TIER_1_DURATION: 2,
-                CONF_TIER_2_COUNT: DEFAULT_TIER_2_COUNT,
-                CONF_TIER_2_DURATION: DEFAULT_TIER_2_DURATION,
-                CONF_TIER_3_COUNT: DEFAULT_TIER_3_COUNT,
-                CONF_TIER_3_DURATION: DEFAULT_TIER_3_DURATION,
-                CONF_TIER_4_COUNT: DEFAULT_TIER_4_COUNT,
-                CONF_TIER_4_DURATION: DEFAULT_TIER_4_DURATION,
-            },
-        ),
+    result: FlowResultDict = await hass.config_entries.options.async_configure(  # type: ignore[assignment]  # HA returns ConfigFlowResult; tests index as dict[str, Any]
+        result["flow_id"],
+        user_input={
+            CONF_TIER_1_COUNT: 10,
+            CONF_TIER_1_DURATION: 2,
+            CONF_TIER_2_COUNT: DEFAULT_TIER_2_COUNT,
+            CONF_TIER_2_DURATION: DEFAULT_TIER_2_DURATION,
+            CONF_TIER_3_COUNT: DEFAULT_TIER_3_COUNT,
+            CONF_TIER_3_DURATION: DEFAULT_TIER_3_DURATION,
+            CONF_TIER_4_COUNT: DEFAULT_TIER_4_COUNT,
+            CONF_TIER_4_DURATION: DEFAULT_TIER_4_DURATION,
+        },
     )
 
     assert result["type"] == FlowResultType.CREATE_ENTRY

--- a/custom_components/haeo/sensor_utils.py
+++ b/custom_components/haeo/sensor_utils.py
@@ -25,10 +25,11 @@ class ForecastItem(TypedDict):
 
 
 class SensorAttributes(TypedDict, total=False):
-    """Attributes dict for HAEO sensors.
+    """Subset of Home Assistant sensor attributes kept in output snapshots.
 
-    Uses total=False since not all attributes are always present.
-    Other Home Assistant attributes pass through as additional keys.
+    Only ``unit_of_measurement`` and ``forecast`` are copied from live state
+    attributes so diagnostics and snapshot comparisons stay stable. Other HA
+    attributes are omitted intentionally.
     """
 
     unit_of_measurement: str | None
@@ -44,7 +45,7 @@ class SensorStateDict(TypedDict):
 
 
 def _sensor_attributes(attributes: Mapping[str, Any]) -> SensorAttributes:
-    """Copy HA state attributes into the sensor snapshot shape."""
+    """Extract unit and forecast from HA state attributes for snapshots."""
     snapshot: SensorAttributes = {}
     unit = attributes.get("unit_of_measurement")
     if isinstance(unit, str):
@@ -174,11 +175,9 @@ def get_output_sensors(hass: HomeAssistant, config_entry: ConfigEntry) -> dict[s
     """Get all output sensors created by this config entry.
 
     Returns a dict mapping entity_id to a cleaned sensor state dict.
-    Uses State.as_dict() to get complete state information including:
-    - entity_id, state, attributes, last_changed, last_updated, context
-
-    Unstable fields that are removed:
-    - last_changed, last_updated, context (timestamp-based, not relevant for snapshot comparison)
+    Each entry includes entity_id, state, and a filtered attributes dict
+    (unit_of_measurement and forecast only). Timestamp and context fields from
+    live state are not included.
 
     Numeric values are rounded intelligently based on their unit's maximum absolute value
     to provide approximately 4 significant figures, reducing noise from floating-point precision.

--- a/custom_components/haeo/sensor_utils.py
+++ b/custom_components/haeo/sensor_utils.py
@@ -1,6 +1,6 @@
 """Utility functions for extracting and processing sensor data."""
 
-from collections.abc import Mapping
+from datetime import datetime
 import math
 from typing import Any, TypedDict
 
@@ -20,20 +20,16 @@ _TARGET_SIG_FIGS = 3
 class ForecastItem(TypedDict):
     """Single forecast point in sensor attributes."""
 
-    time: str  # ISO format after as_dict() serialization
+    time: datetime | str  # datetime in live state; ISO string once JSON-serialized
     value: float | str  # Numeric or status string (e.g., "success")
 
 
-class SensorAttributes(TypedDict, total=False):
-    """Subset of Home Assistant sensor attributes kept in output snapshots.
-
-    Only ``unit_of_measurement`` and ``forecast`` are copied from live state
-    attributes so diagnostics and snapshot comparisons stay stable. Other HA
-    attributes are omitted intentionally.
-    """
-
-    unit_of_measurement: str | None
-    forecast: list[ForecastItem]
+# Live Home Assistant state attributes pass through to snapshots as-is (minus
+# internal-only keys), so arbitrary keys appear alongside well-known entries
+# such as "unit_of_measurement" and "forecast". Downstream consumers (the
+# forecast card, scenario snapshots) rely on that full set, which a closed
+# TypedDict cannot describe.
+SensorAttributes = dict[str, Any]
 
 
 class SensorStateDict(TypedDict):
@@ -42,18 +38,6 @@ class SensorStateDict(TypedDict):
     entity_id: str
     state: str
     attributes: SensorAttributes
-
-
-def _sensor_attributes(attributes: Mapping[str, Any]) -> SensorAttributes:
-    """Extract unit and forecast from HA state attributes for snapshots."""
-    snapshot: SensorAttributes = {}
-    unit = attributes.get("unit_of_measurement")
-    if isinstance(unit, str):
-        snapshot["unit_of_measurement"] = unit
-    forecast = attributes.get("forecast")
-    if isinstance(forecast, list):
-        snapshot["forecast"] = forecast
-    return snapshot
 
 
 def _round_sig(value: float) -> float:
@@ -124,7 +108,8 @@ def _apply_smart_rounding(output_sensors: dict[str, SensorStateDict]) -> None:
             state_rounded = _round_sig(state_val)
 
         forecast_rounded: list[tuple[ForecastItem, float]] = []
-        for item in entity_data["attributes"].get("forecast", []):
+        forecast_items: list[ForecastItem] = entity_data["attributes"].get("forecast", [])
+        for item in forecast_items:
             val = _try_parse_float(item.get("value"))
             if val is not None:
                 forecast_rounded.append((item, _round_sig(val)))
@@ -175,12 +160,12 @@ def get_output_sensors(hass: HomeAssistant, config_entry: ConfigEntry) -> dict[s
     """Get all output sensors created by this config entry.
 
     Returns a dict mapping entity_id to a cleaned sensor state dict.
-    Each entry includes entity_id, state, and a filtered attributes dict
-    (unit_of_measurement and forecast only). Timestamp and context fields from
+    Each entry includes entity_id, state, and the live state attributes with
+    internal-only keys (field_path) removed. Timestamp and context fields from
     live state are not included.
 
     Numeric values are rounded intelligently based on their unit's maximum absolute value
-    to provide approximately 4 significant figures, reducing noise from floating-point precision.
+    to provide approximately 3 significant figures, reducing noise from floating-point precision.
     """
     entity_registry = er.async_get(hass)
 
@@ -197,13 +182,14 @@ def get_output_sensors(hass: HomeAssistant, config_entry: ConfigEntry) -> dict[s
         if state is None:
             continue
 
-        attributes = dict(state.attributes)
+        attributes: SensorAttributes = dict(state.attributes)
+        # Drop internal-only attributes to keep snapshots stable.
         attributes.pop("field_path", None)
 
         output_sensors[entity_entry.entity_id] = {
             "entity_id": state.entity_id,
             "state": state.state,
-            "attributes": _sensor_attributes(attributes),
+            "attributes": attributes,
         }
 
     # Apply smart rounding to all numeric values

--- a/custom_components/haeo/sensor_utils.py
+++ b/custom_components/haeo/sensor_utils.py
@@ -1,7 +1,8 @@
 """Utility functions for extracting and processing sensor data."""
 
+from collections.abc import Mapping
 import math
-from typing import Any, TypedDict, cast
+from typing import Any, TypedDict
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -40,6 +41,18 @@ class SensorStateDict(TypedDict):
     entity_id: str
     state: str
     attributes: SensorAttributes
+
+
+def _sensor_attributes(attributes: Mapping[str, Any]) -> SensorAttributes:
+    """Copy HA state attributes into the sensor snapshot shape."""
+    snapshot: SensorAttributes = {}
+    unit = attributes.get("unit_of_measurement")
+    if isinstance(unit, str):
+        snapshot["unit_of_measurement"] = unit
+    forecast = attributes.get("forecast")
+    if isinstance(forecast, list):
+        snapshot["forecast"] = forecast
+    return snapshot
 
 
 def _round_sig(value: float) -> float:
@@ -185,23 +198,14 @@ def get_output_sensors(hass: HomeAssistant, config_entry: ConfigEntry) -> dict[s
         if state is None:
             continue
 
-        # Get complete state as dict and create mutable copy
-        state_dict = dict(state.as_dict())
+        attributes = dict(state.attributes)
+        attributes.pop("field_path", None)
 
-        # Make attributes dict mutable and remove unstable fields
-        if "attributes" in state_dict and isinstance(state_dict["attributes"], dict):
-            state_dict["attributes"] = dict(state_dict["attributes"])
-            # Drop internal-only attributes to keep snapshots stable.
-            state_dict["attributes"].pop("field_path", None)
-
-        # Remove timestamp-based fields that aren't relevant for functional comparison
-        state_dict.pop("last_changed", None)
-        state_dict.pop("last_updated", None)
-        state_dict.pop("last_reported", None)
-        state_dict.pop("context", None)
-
-        # Cast to SensorStateDict after cleaning (state.as_dict() has extra fields we removed)
-        output_sensors[entity_entry.entity_id] = cast("SensorStateDict", state_dict)
+        output_sensors[entity_entry.entity_id] = {
+            "entity_id": state.entity_id,
+            "state": state.state,
+            "attributes": _sensor_attributes(attributes),
+        }
 
     # Apply smart rounding to all numeric values
     _apply_smart_rounding(output_sensors)

--- a/custom_components/haeo/sensors/tests/test_sensor.py
+++ b/custom_components/haeo/sensors/tests/test_sensor.py
@@ -2,7 +2,7 @@
 
 from datetime import UTC, datetime
 from types import MappingProxyType
-from typing import Any, Literal, cast
+from typing import Any, Literal
 from unittest.mock import Mock
 
 from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
@@ -185,7 +185,7 @@ def device_entry() -> DeviceEntry:
     """Return a mocked device entry instance."""
     device = Mock(spec=DeviceEntry)
     device.id = "mock-device"
-    return cast("DeviceEntry", device)
+    return device  # type: ignore[return-value]  # Mock(spec=DeviceEntry) is not a DeviceEntry for the type checker
 
 
 async def test_async_setup_entry_creates_sensors_with_metadata(

--- a/custom_components/haeo/tests/test_diagnostics.py
+++ b/custom_components/haeo/tests/test_diagnostics.py
@@ -938,7 +938,7 @@ async def test_historical_state_provider_get_states_sync(hass: HomeAssistant) ->
             return_value=mock_recorder,
         ),
         patch(
-            "custom_components.haeo.diagnostics.historical_state_provider.recorder_history.get_significant_states",
+            "custom_components.haeo.diagnostics.historical_state_provider.get_significant_states_full",
             return_value={"sensor.test": [mock_state]},
         ) as mock_get_states,
     ):
@@ -1081,7 +1081,7 @@ async def test_fetch_inputs_at_returns_states(hass: HomeAssistant) -> None:
             return_value=mock_recorder,
         ),
         patch(
-            "custom_components.haeo.diagnostics.collector.recorder_history.get_significant_states",
+            "custom_components.haeo.diagnostics.collector.get_significant_states_full",
             return_value={
                 "sensor.battery_capacity": [cap_state],
                 "sensor.battery_soc": [soc_state],
@@ -1133,7 +1133,7 @@ async def test_fetch_inputs_at_reports_missing_entities(hass: HomeAssistant) -> 
             return_value=mock_recorder,
         ),
         patch(
-            "custom_components.haeo.diagnostics.collector.recorder_history.get_significant_states",
+            "custom_components.haeo.diagnostics.collector.get_significant_states_full",
             return_value={"sensor.battery_capacity": [cap_state]},
         ),
     ):
@@ -1194,7 +1194,7 @@ async def test_get_last_run_before_finds_run(hass: HomeAssistant) -> None:
             return_value=mock_recorder,
         ),
         patch(
-            "custom_components.haeo.diagnostics.collector.recorder_history.get_significant_states",
+            "custom_components.haeo.diagnostics.collector.get_significant_states_full",
             return_value={
                 "sensor.haeo_optimization_duration": [duration_state],
                 "sensor.haeo_forecast_horizon": [horizon_state],
@@ -1278,7 +1278,7 @@ async def test_get_last_run_before_no_recorder_state(hass: HomeAssistant) -> Non
             return_value=mock_recorder,
         ),
         patch(
-            "custom_components.haeo.diagnostics.collector.recorder_history.get_significant_states",
+            "custom_components.haeo.diagnostics.collector.get_significant_states_full",
             return_value={},
         ),
     ):
@@ -1315,7 +1315,7 @@ async def test_get_last_run_before_invalid_duration_state(hass: HomeAssistant) -
             return_value=mock_recorder,
         ),
         patch(
-            "custom_components.haeo.diagnostics.collector.recorder_history.get_significant_states",
+            "custom_components.haeo.diagnostics.collector.get_significant_states_full",
             return_value={
                 "sensor.haeo_optimization_duration": [invalid_state],
                 "sensor.haeo_forecast_horizon": [State("sensor.haeo_forecast_horizon", "2024-01-01T00:00:00+00:00")],
@@ -1360,7 +1360,7 @@ async def test_get_last_run_before_no_horizon_state(hass: HomeAssistant) -> None
             return_value=mock_recorder,
         ),
         patch(
-            "custom_components.haeo.diagnostics.collector.recorder_history.get_significant_states",
+            "custom_components.haeo.diagnostics.collector.get_significant_states_full",
             return_value={
                 "sensor.haeo_optimization_duration": [duration_state],
             },

--- a/custom_components/haeo/tests/test_diagnostics.py
+++ b/custom_components/haeo/tests/test_diagnostics.py
@@ -3,7 +3,7 @@
 from datetime import UTC, datetime, timedelta, timezone
 import json
 from types import MappingProxyType
-from typing import Any, cast
+from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
 
 from homeassistant.config_entries import ConfigSubentry
@@ -204,7 +204,8 @@ def test_extract_entity_ids_from_config_collects_nested_entities() -> None:
         "ignored": {"type": "constant", "value": 2.0},
     }
 
-    entity_ids = _extract_entity_ids_from_config(cast("ElementConfigSchema", config))
+    # Fixture includes non-schema keys and invalid entity placeholders; structural guard would reject it.
+    entity_ids = _extract_entity_ids_from_config(config)  # type: ignore[arg-type]
 
     assert entity_ids == {"sensor.import", "sensor.export"}
 
@@ -317,21 +318,18 @@ async def test_diagnostics_uses_context_for_config_and_inputs(hass: HomeAssistan
     entry.add_to_hass(hass)
 
     context_participants = {
-        "Context Battery": cast(
-            "ElementConfigSchema",
-            _battery_config(
-                name="Context Battery",
-                connection="DC Bus",
-                capacity=20.0,
-                initial_charge_percentage=80.0,
-                max_power_source_target=10.0,
-                max_power_target_source=10.0,
-                min_charge_percentage=5.0,
-                max_charge_percentage=95.0,
-                efficiency_source_target=90.0,
-                efficiency_target_source=90.0,
-            ),
-        )
+        "Context Battery": _battery_config(
+            name="Context Battery",
+            connection="DC Bus",
+            capacity=20.0,
+            initial_charge_percentage=80.0,
+            max_power_source_target=10.0,
+            max_power_target_source=10.0,
+            min_charge_percentage=5.0,
+            max_charge_percentage=95.0,
+            efficiency_source_target=90.0,
+            efficiency_target_source=90.0,
+        ),
     }
     context_source_states = {
         "sensor.power": State("sensor.power", "100", {"unit_of_measurement": "W"}),
@@ -400,7 +398,7 @@ async def test_collect_diagnostics_unwraps_mappingproxy_participants(hass: HomeA
             initial_charge_percentage=50.0,
         )
     )
-    participants = cast("dict[str, ElementConfigSchema]", {"Grid": grid_config, "Battery": battery_config})
+    participants = {"Grid": grid_config, "Battery": battery_config}
 
     coordinator_data = _make_coordinator_data(participants=participants)
     coordinator = Mock(spec=HaeoDataUpdateCoordinator)
@@ -588,21 +586,18 @@ async def test_historical_diagnostics_ignores_context(hass: HomeAssistant) -> No
     entry.add_to_hass(hass)
 
     context_participants = {
-        "Context Battery": cast(
-            "ElementConfigSchema",
-            _battery_config(
-                name="Context Battery",
-                connection="DC Bus",
-                capacity=20.0,
-                initial_charge_percentage=80.0,
-                max_power_source_target=10.0,
-                max_power_target_source=10.0,
-                min_charge_percentage=5.0,
-                max_charge_percentage=95.0,
-                efficiency_source_target=90.0,
-                efficiency_target_source=90.0,
-            ),
-        )
+        "Context Battery": _battery_config(
+            name="Context Battery",
+            connection="DC Bus",
+            capacity=20.0,
+            initial_charge_percentage=80.0,
+            max_power_source_target=10.0,
+            max_power_target_source=10.0,
+            min_charge_percentage=5.0,
+            max_charge_percentage=95.0,
+            efficiency_source_target=90.0,
+            efficiency_target_source=90.0,
+        ),
     }
     coordinator_data = _make_coordinator_data(context_participants)
     coordinator = Mock(spec=HaeoDataUpdateCoordinator)
@@ -968,14 +963,11 @@ async def test_historical_state_provider_get_states_sync(hass: HomeAssistant) ->
 
 def test_extract_entity_ids_handles_non_dict_values() -> None:
     """_extract_entity_ids_from_config ignores non-dict/non-schema values."""
-    config = cast(
-        "ElementConfigSchema",
-        {
-            CONF_ELEMENT_TYPE: "grid",
-            "plain_string": "not_a_schema_value",
-            "plain_number": 42,
-        },
-    )
+    config: ElementConfigSchema = {  # type: ignore[typeddict-item]  # non-schema keys must reach runtime filtering under test
+        CONF_ELEMENT_TYPE: "grid",
+        "plain_string": "not_a_schema_value",
+        "plain_number": 42,
+    }
     entity_ids = _extract_entity_ids_from_config(config)
     assert entity_ids == set()
 

--- a/custom_components/haeo/tests/test_recorder_history.py
+++ b/custom_components/haeo/tests/test_recorder_history.py
@@ -1,0 +1,46 @@
+"""Tests for the recorder history helpers."""
+
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import patch
+
+from homeassistant.core import HomeAssistant, State
+
+from custom_components.haeo.diagnostics.recorder_history import get_significant_states_full
+
+
+async def test_get_significant_states_full_keeps_only_state_objects(hass: HomeAssistant) -> None:
+    """Minimal-response dict entries are dropped; full State objects are kept."""
+    start = datetime(2026, 1, 20, 14, 0, 0, tzinfo=UTC)
+    end = datetime(2026, 1, 20, 15, 0, 0, tzinfo=UTC)
+
+    full_state = State("sensor.full", "50", {"unit_of_measurement": "%"})
+    raw: dict[str, list[State | dict[str, Any]]] = {
+        "sensor.full": [full_state, {"state": "51", "last_changed": "2026-01-20T14:30:00+00:00"}],
+        "sensor.minimal_only": [{"state": "1"}],
+        "sensor.empty": [],
+    }
+
+    with patch(
+        "custom_components.haeo.diagnostics.recorder_history.recorder_history.get_significant_states",
+        return_value=raw,
+    ) as mock_get_states:
+        result = get_significant_states_full(
+            hass,
+            start_time=start,
+            end_time=end,
+            entity_ids=["sensor.full", "sensor.minimal_only", "sensor.empty"],
+        )
+
+    mock_get_states.assert_called_once_with(
+        hass,
+        start_time=start,
+        end_time=end,
+        entity_ids=["sensor.full", "sensor.minimal_only", "sensor.empty"],
+        include_start_time_state=True,
+        significant_changes_only=False,
+        no_attributes=False,
+    )
+
+    # Entities with no full State objects are omitted entirely.
+    assert result == {"sensor.full": [full_state]}

--- a/custom_components/haeo/tests/test_sensor_utils.py
+++ b/custom_components/haeo/tests/test_sensor_utils.py
@@ -93,6 +93,52 @@ async def test_get_output_sensors_filters_and_handles_forecasts(hass: HomeAssist
     assert "forecast" in attributes
 
 
+async def test_get_output_sensors_passes_attributes_through(hass: HomeAssistant) -> None:
+    """State attributes pass through to snapshots, minus internal-only keys.
+
+    The forecast card relies on attributes such as element_type to build its
+    series, so filtering them out breaks card rendering.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Test Hub",
+        data={
+            CONF_INTEGRATION_TYPE: INTEGRATION_TYPE_HUB,
+            CONF_NAME: "Test Hub",
+        },
+        entry_id="hub_entry_attrs",
+    )
+    entry.add_to_hass(hass)
+
+    entity_registry = er.async_get(hass)
+    haeo_entry = entity_registry.async_get_or_create(
+        domain="sensor",
+        platform=DOMAIN,
+        unique_id="haeo_attrs_unique",
+        config_entry=entry,
+    )
+    hass.states.async_set(
+        haeo_entry.entity_id,
+        "1.0",
+        {
+            "unit_of_measurement": "kW",
+            "element_type": "battery",
+            "config_mode": "driven",
+            "friendly_name": "Battery Power",
+            "field_path": "battery.power",
+        },
+    )
+
+    output_sensors = get_output_sensors(hass, entry)
+
+    attributes = output_sensors[haeo_entry.entity_id]["attributes"]
+    assert attributes["unit_of_measurement"] == "kW"
+    assert attributes["element_type"] == "battery"
+    assert attributes["config_mode"] == "driven"
+    assert attributes["friendly_name"] == "Battery Power"
+    assert "field_path" not in attributes
+
+
 async def test_get_output_sensors_handles_forecast_attributes(hass: HomeAssistant) -> None:
     """Sensors with forecast attributes have forecast values rounded."""
     entry = MockConfigEntry(

--- a/custom_components/haeo/translations/tests/test_translations.py
+++ b/custom_components/haeo/translations/tests/test_translations.py
@@ -4,7 +4,7 @@ from collections.abc import Mapping
 import json
 from pathlib import Path
 import types
-from typing import Any, Union, cast, get_args, get_origin, get_type_hints
+from typing import Any, Union, get_args, get_origin, get_type_hints
 
 import pytest
 
@@ -13,16 +13,16 @@ from custom_components.haeo.core.model.reactive import OutputMethod
 from custom_components.haeo.elements import ELEMENT_DEVICE_NAMES, ELEMENT_OUTPUT_NAMES
 
 
-def _is_mapping_type(annotation: object) -> bool:
+def _is_mapping_type(annotation: Any) -> bool:
     try:
-        alias_value = cast("Any", annotation).__value__
+        alias_value = annotation.__value__
     except AttributeError:
         alias_value = None
     if alias_value is not None:
         return _is_mapping_type(alias_value)
-    origin = get_origin(cast("Any", annotation))
+    origin = get_origin(annotation)
     if origin is None:
-        return cast("Any", annotation) in (Mapping, dict)
+        return annotation in (Mapping, dict)
     if origin in (Mapping, dict):
         return True
     if origin in (types.UnionType, Union):
@@ -50,7 +50,7 @@ def _mapping_output_names() -> set[str]:
 
 
 def _sensor_output_names() -> set[str]:
-    output_names = cast("set[str]", set(ELEMENT_OUTPUT_NAMES))
+    output_names = {str(name) for name in ELEMENT_OUTPUT_NAMES}
     return output_names - _mapping_output_names()
 
 

--- a/docs/developer-guide/typing.md
+++ b/docs/developer-guide/typing.md
@@ -173,8 +173,8 @@ typeCheckingMode = "strict"
 - All function parameters and return types must be annotated
 - All class attributes must have type annotations
 - Generic types must specify type parameters (`list[str]` not `list`)
-- Use `cast()` sparingly and only when type checker cannot infer
-- Prefer `assert` statements over `cast()` when narrowing types
+- Do not import `typing.cast` (banned by Ruff); prefer `TypeGuard`, boundary typing, or `assert` for narrowing
+- When the type checker cannot be satisfied otherwise, use `# type: ignore[...]` on the same line with a short comment explaining why a TypeGuard or other narrowing approach was not viable
 
 ## Assertion helpers
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,10 @@ ignore = [
     'PLR0911', # Too many return statements - something for code review not linting
 ]
 
+[tool.ruff.lint.flake8-tidy-imports.banned-api]
+"typing.cast" = { msg = "Fix the types properly, or use a TypeGuard if needed, as a last resort use # type: ignore[...] with an explanation as to why there was no other viable option." }
+"typing_extensions.cast" = { msg = "Fix the types properly, or use a TypeGuard if needed, as a last resort use # type: ignore[...] with an explanation as to why there was no other viable option." }
+
 [tool.ruff.lint.isort]
 known-first-party = ["haeo"]
 force-sort-within-sections = true

--- a/tests/scenarios/filter_states.py
+++ b/tests/scenarios/filter_states.py
@@ -12,7 +12,7 @@ import json
 from pathlib import Path
 import re
 import sys
-from typing import Any, cast
+from typing import Any
 from urllib import error as urllib_error
 from urllib import request as urllib_request
 from urllib.parse import quote, urljoin
@@ -56,7 +56,7 @@ def fetch_home_assistant_states(url: str, token: str) -> list[dict[str, Any]]:
             if not isinstance(item, dict):
                 msg = "Encountered non-object state entry"
                 raise TypeError(msg)
-            state_list.append(cast("dict[str, Any]", item))
+            state_list.append(item)
 
         return state_list
 

--- a/tests/test_diag_cli.py
+++ b/tests/test_diag_cli.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, cast
+from typing import Any
 
 import numpy as np
 import pytest
@@ -10,7 +10,9 @@ import pytest
 from custom_components.haeo.core.data.loader import config_loader as cl
 from custom_components.haeo.core.data.loader.config_loader import load_element_config
 from custom_components.haeo.core.schema import as_constant_value
-from custom_components.haeo.core.schema.elements import ElementConfigSchema, battery
+from custom_components.haeo.core.schema.elements import battery
+from custom_components.haeo.core.schema.elements.battery import is_battery_config_data
+from custom_components.haeo.elements import is_element_config_schema
 from tools import diag
 
 
@@ -31,6 +33,18 @@ def _base_battery_config() -> dict[str, Any]:
     }
 
 
+def _load_battery_config(
+    config: dict[str, Any],
+    provider: diag.DiagnosticsStateProvider,
+    forecast_times: tuple[float, ...],
+) -> battery.BatteryConfigData:
+    """Load a battery fixture after schema and result discriminators are verified."""
+    assert is_element_config_schema(config)
+    loaded = load_element_config("Battery", config, provider, forecast_times)
+    assert is_battery_config_data(loaded)
+    return loaded
+
+
 def test_load_element_config_unwraps_constant_wrappers() -> None:
     """Constant wrappers convert to loaded scalar/series values."""
     config = _base_battery_config()
@@ -39,15 +53,7 @@ def test_load_element_config_unwraps_constant_wrappers() -> None:
         "initial_charge_percentage": {"type": "constant", "value": 50.0},
     }
 
-    loaded = cast(
-        "battery.BatteryConfigData",
-        load_element_config(
-            "Battery",
-            cast("ElementConfigSchema", config),
-            diag.DiagnosticsStateProvider([]),
-            (0.0, 1800.0, 3600.0),
-        ),
-    )
+    loaded = _load_battery_config(config, diag.DiagnosticsStateProvider([]), (0.0, 1800.0, 3600.0))
 
     np.testing.assert_allclose(loaded["storage"]["capacity"], np.array([13.5, 13.5, 13.5]))
     assert loaded["storage"]["initial_charge_percentage"] == pytest.approx(0.5)
@@ -83,15 +89,7 @@ def test_load_element_config_uses_present_value_for_scalar_entities(monkeypatch:
         lambda *_args, **_kwargs: pytest.fail("fuse_to_intervals should not run for scalar fields"),
     )
 
-    loaded = cast(
-        "battery.BatteryConfigData",
-        load_element_config(
-            "Battery",
-            cast("ElementConfigSchema", config),
-            diag.DiagnosticsStateProvider([]),
-            (0.0, 1800.0, 3600.0),
-        ),
-    )
+    loaded = _load_battery_config(config, diag.DiagnosticsStateProvider([]), (0.0, 1800.0, 3600.0))
 
     assert loaded["storage"]["initial_charge_percentage"] == pytest.approx(0.75)
 
@@ -120,15 +118,7 @@ def test_load_element_config_unwraps_entity_wrappers_for_time_series(monkeypatch
         lambda *_args, **_kwargs: [13.5, 13.4, 13.3],
     )
 
-    loaded = cast(
-        "battery.BatteryConfigData",
-        load_element_config(
-            "Battery",
-            cast("ElementConfigSchema", config),
-            diag.DiagnosticsStateProvider([]),
-            (0.0, 1800.0, 3600.0),
-        ),
-    )
+    loaded = _load_battery_config(config, diag.DiagnosticsStateProvider([]), (0.0, 1800.0, 3600.0))
 
     np.testing.assert_allclose(loaded["storage"]["capacity"], np.array([13.5, 13.4, 13.3]))
 
@@ -144,15 +134,7 @@ def test_load_element_config_drops_none_wrappers() -> None:
         "salvage_value": {"type": "none"},
     }
 
-    loaded = cast(
-        "battery.BatteryConfigData",
-        load_element_config(
-            "Battery",
-            cast("ElementConfigSchema", config),
-            diag.DiagnosticsStateProvider([]),
-            (0.0, 1800.0, 3600.0),
-        ),
-    )
+    loaded = _load_battery_config(config, diag.DiagnosticsStateProvider([]), (0.0, 1800.0, 3600.0))
 
     assert "salvage_value" not in loaded["pricing"]
 


### PR DESCRIPTION
## Summary

- Ban `typing.cast` via Ruff TID251 and document the preferred alternatives in the typing guide
- Remove all `cast()` imports/usages across the codebase, using TypeGuards, runtime validation, annotations, or documented `# type: ignore` where appropriate
- Add `get_significant_states_full()` to validate recorder results are `State` objects instead of trusting HA stub types
- Introduce `FloatConstantLoader` so float coercion from `Real` values is typed without ignores
- Add `is_battery_config_data()` TypeGuard for diagnostics CLI tests

## Test plan

- [x] `uv run ruff check`
- [x] `uv run pyright`
- [x] `uv run pytest custom_components/haeo/core/data/loader/tests/test_constant_loader.py`
- [x] `uv run pytest custom_components/haeo/core/data/loader/tests/test_scalar_loader.py custom_components/haeo/flows/tests/test_options_flow.py`
- [x] `uv run pytest tests/test_diag_cli.py`


Made with [Cursor](https://cursor.com)