### PR TITLE
fix(#467): propagate live subentry value edits into LP via TrackedParam updater chain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,7 +226,7 @@ jobs:
 
       - name: Upload frontend coverage to Codecov
         if: ${{ github.event_name != 'release' && !cancelled() }}
-        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
+        uses: codecov/codecov-action@e53489f4d376d79066609109e7a95a29eb3740b1 # v7.0.0
         with:
           files: frontend/haeo-forecast-card/coverage/lcov.info
           flags: frontend
@@ -256,13 +256,13 @@ jobs:
 
       - name: Upload test results to Codecov
         if: ${{ github.event_name != 'release' && !cancelled() }}
-        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
+        uses: codecov/codecov-action@e53489f4d376d79066609109e7a95a29eb3740b1 # v7.0.0
         with:
           report_type: test_results
 
       - name: Upload coverage to Codecov
         if: ${{ github.event_name != 'release' && !cancelled() }}
-        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
+        uses: codecov/codecov-action@e53489f4d376d79066609109e7a95a29eb3740b1 # v7.0.0
         with:
           flags: python
           fail_ci_if_error: true

--- a/custom_components/haeo/coordinator/tests/test_network.py
+++ b/custom_components/haeo/coordinator/tests/test_network.py
@@ -28,6 +28,7 @@ from custom_components.haeo.core.model.elements.policy_pricing import (
     PolicyPricingTerm,
 )
 from custom_components.haeo.core.model.elements.segments import EfficiencySegment, PowerLimitSegment
+from custom_components.haeo.core.model.elements.segments.soc_pricing import SocPricingSegment
 from custom_components.haeo.core.schema import as_connection_target
 from custom_components.haeo.core.schema.elements import ElementConfigData, ElementType
 from custom_components.haeo.core.schema.elements.connection import (
@@ -354,6 +355,112 @@ def test_policy_updater_reenables_rule() -> None:
         }
     )
     assert elem.price == pytest.approx([0.07])
+
+
+# ---------------------------------------------------------------------------
+# soc_pricing TrackedParam discovery (issue #467)
+# ---------------------------------------------------------------------------
+
+
+def _battery_discharge_network() -> Network:
+    """Build a network with a Battery and a discharge connection that has soc_pricing."""
+    network = Network(name="test", periods=np.array([1.0, 1.0]))
+    network.add(
+        {
+            "element_type": "battery",
+            "name": "Battery",
+            "capacity": np.array([10.0, 10.0, 10.0]),
+            "initial_charge": 5.0,
+            "salvage_value": 0.0,
+        }
+    )
+    network.add({"element_type": MODEL_ELEMENT_TYPE_NODE, "name": "Grid", "is_source": False, "is_sink": True})
+    network.add(
+        {
+            "element_type": MODEL_ELEMENT_TYPE_CONNECTION,
+            "name": "Battery:discharge",
+            "source": "Battery",
+            "target": "Grid",
+            "tags": {1},
+            "segments": {
+                "soc_pricing": {
+                    "segment_type": "soc_pricing",
+                    "discharge_energy_threshold": np.array([2.0, 2.0]),
+                    "discharge_energy_price": np.array([0.10, 0.10]),
+                },
+            },
+        }
+    )
+    return network
+
+
+def test_discover_setters_finds_soc_pricing_thresholds() -> None:
+    """_discover_setters captures soc_pricing threshold/price as TrackedParams.
+
+    Regression for issue #467: previously these were instance-only attributes
+    so the updater could not refresh them when min_charge_percentage changed
+    on the battery participant.
+    """
+    network = _battery_discharge_network()
+    conn = network.elements["Battery:discharge"]
+    model_config = {
+        "element_type": MODEL_ELEMENT_TYPE_CONNECTION,
+        "name": "Battery:discharge",
+        "source": "Battery",
+        "target": "Grid",
+        "tags": {1},
+        "segments": {
+            "soc_pricing": {
+                "segment_type": "soc_pricing",
+                "discharge_energy_threshold": np.array([2.0, 2.0]),
+                "discharge_energy_price": np.array([0.10, 0.10]),
+            },
+        },
+    }
+    setters = _discover_setters(conn, model_config)
+    paths = {path for path, _setter in setters}
+    assert ("segments", "soc_pricing", "discharge_energy_threshold") in paths
+    assert ("segments", "soc_pricing", "discharge_energy_price") in paths
+
+
+def test_soc_pricing_setters_write_fresh_threshold() -> None:
+    """Setters captured for soc_pricing write fresh values into the segment.
+
+    This is the regression for issue #467: when the user edits the battery
+    min_charge_percentage, the adapter recomputes discharge_energy_threshold
+    and the captured setter must propagate that to the live SocPricingSegment
+    so the LP sees the new floor.
+    """
+    network = _battery_discharge_network()
+    conn = network.elements["Battery:discharge"]
+    assert isinstance(conn, Connection)
+    seg = conn.segments["soc_pricing"]
+    assert isinstance(seg, SocPricingSegment)
+    assert seg.discharge_energy_threshold is not None
+    assert seg.discharge_energy_threshold[0] == pytest.approx(2.0)
+
+    model_config = {
+        "element_type": MODEL_ELEMENT_TYPE_CONNECTION,
+        "name": "Battery:discharge",
+        "source": "Battery",
+        "target": "Grid",
+        "tags": {1},
+        "segments": {
+            "soc_pricing": {
+                "segment_type": "soc_pricing",
+                "discharge_energy_threshold": np.array([2.0, 2.0]),
+                "discharge_energy_price": np.array([0.10, 0.10]),
+            },
+        },
+    }
+
+    setters = _discover_setters(conn, model_config)
+    setter_by_path = dict(setters)
+    threshold_setter = setter_by_path[("segments", "soc_pricing", "discharge_energy_threshold")]
+    threshold_setter(np.array([4.0, 4.0]))
+
+    assert seg.discharge_energy_threshold is not None
+    assert seg.discharge_energy_threshold[0] == pytest.approx(4.0)
 
 
 # ---------------------------------------------------------------------------

--- a/custom_components/haeo/coordinator/tests/test_soc_pricing_live_update.py
+++ b/custom_components/haeo/coordinator/tests/test_soc_pricing_live_update.py
@@ -1,0 +1,84 @@
+"""Regression for issue #467: live battery limit edits must reach the LP.
+
+When a battery is configured with an undercharge partition, its ``min_charge``
+floor reaches the LP only through the discharge ``soc_pricing`` segment's
+``discharge_energy_threshold``. Editing ``min_charge`` while the integration is
+running must update that threshold on the live model element (via the element
+updater's ``TrackedParam`` writes), without requiring a full reload.
+"""
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import numpy as np
+
+from custom_components.haeo.coordinator.network import create_network
+from custom_components.haeo.core.schema import as_connection_target
+from custom_components.haeo.core.schema.elements import ElementType
+from custom_components.haeo.core.schema.elements.node import CONF_IS_SINK, CONF_IS_SOURCE, SECTION_ROLE
+
+BATTERY_NAME = "Test Battery"
+BUS_NAME = "DC Bus"
+
+
+def _battery_config(min_charge_ratio: float) -> dict[str, Any]:
+    """Build a resolved battery config whose min_charge reaches the LP via soc_pricing.
+
+    With the undercharge percentage at 0, ``lower_ratio`` is 0, so ``capacity``
+    does not depend on ``min_charge``; the floor is carried solely by the
+    discharge ``soc_pricing`` threshold = ``(min - lower) * capacity``.
+    """
+    return {
+        "element_type": ElementType.BATTERY,
+        "name": BATTERY_NAME,
+        "connection": as_connection_target(BUS_NAME),
+        "storage": {
+            "capacity": np.array([10.0, 10.0]),
+            "initial_charge_percentage": 0.5,
+        },
+        "limits": {
+            "min_charge_percentage": np.array([min_charge_ratio, min_charge_ratio]),
+            "max_charge_percentage": np.array([0.9, 0.9]),
+        },
+        "power_limits": {
+            "max_power_source_target": np.array([5.0]),
+            "max_power_target_source": np.array([5.0]),
+        },
+        "pricing": {"salvage_value": 0.0},
+        "efficiency": {
+            "efficiency_source_target": np.array([0.95]),
+            "efficiency_target_source": np.array([0.95]),
+        },
+        "partitioning": {},
+        "undercharge": {
+            "percentage": np.array([0.0, 0.0]),
+            "cost": np.array([0.03]),
+        },
+    }
+
+
+async def test_min_charge_edit_updates_live_soc_pricing_threshold() -> None:
+    """Editing min_charge updates the live soc_pricing discharge threshold."""
+    participants = {
+        BUS_NAME: {
+            "element_type": ElementType.NODE,
+            "name": BUS_NAME,
+            SECTION_ROLE: {CONF_IS_SOURCE: True, CONF_IS_SINK: True},
+        },
+        BATTERY_NAME: _battery_config(0.2),
+    }
+
+    entry = MagicMock()
+    entry.entry_id = "test_entry"
+    network, updaters = await create_network(entry, periods_seconds=[3600], participants=participants)
+
+    segment = network.elements[f"{BATTERY_NAME}:discharge"].segments["soc_pricing"]
+
+    # min=0.2, capacity=10, lower=0 -> threshold = (0.2 - 0) * 10 = 2.0
+    np.testing.assert_allclose(np.asarray(segment.discharge_energy_threshold, dtype=float), [2.0])
+
+    # Edit min_charge to 0.5 and push it through the updater (no reload).
+    updaters[BATTERY_NAME](_battery_config(0.5))
+
+    # Live threshold must follow: (0.5 - 0) * 10 = 5.0
+    np.testing.assert_allclose(np.asarray(segment.discharge_energy_threshold, dtype=float), [5.0])

--- a/custom_components/haeo/coordinator/tests/test_soc_pricing_live_update.py
+++ b/custom_components/haeo/coordinator/tests/test_soc_pricing_live_update.py
@@ -7,64 +7,67 @@ running must update that threshold on the live model element (via the element
 updater's ``TrackedParam`` writes), without requiring a full reload.
 """
 
-from typing import Any
 from unittest.mock import MagicMock
 
 import numpy as np
 
 from custom_components.haeo.coordinator.network import create_network
+from custom_components.haeo.core.model.elements.connection import Connection
+from custom_components.haeo.core.model.elements.segments.soc_pricing import SocPricingSegment
 from custom_components.haeo.core.schema import as_connection_target
-from custom_components.haeo.core.schema.elements import ElementType
-from custom_components.haeo.core.schema.elements.node import CONF_IS_SINK, CONF_IS_SOURCE, SECTION_ROLE
+from custom_components.haeo.core.schema.elements import ElementConfigData, ElementType
+from custom_components.haeo.core.schema.elements.battery import BatteryConfigData
+from custom_components.haeo.core.schema.elements.node import CONF_IS_SINK, CONF_IS_SOURCE, SECTION_ROLE, NodeConfigData
 
 BATTERY_NAME = "Test Battery"
 BUS_NAME = "DC Bus"
 
 
-def _battery_config(min_charge_ratio: float) -> dict[str, Any]:
+def _battery_config(min_charge_ratio: float) -> BatteryConfigData:
     """Build a resolved battery config whose min_charge reaches the LP via soc_pricing.
 
     With the undercharge percentage at 0, ``lower_ratio`` is 0, so ``capacity``
     does not depend on ``min_charge``; the floor is carried solely by the
     discharge ``soc_pricing`` threshold = ``(min - lower) * capacity``.
     """
-    return {
-        "element_type": ElementType.BATTERY,
-        "name": BATTERY_NAME,
-        "connection": as_connection_target(BUS_NAME),
-        "storage": {
+    return BatteryConfigData(
+        element_type=ElementType.BATTERY,
+        name=BATTERY_NAME,
+        connection=as_connection_target(BUS_NAME),
+        storage={
             "capacity": np.array([10.0, 10.0]),
             "initial_charge_percentage": 0.5,
         },
-        "limits": {
+        limits={
             "min_charge_percentage": np.array([min_charge_ratio, min_charge_ratio]),
             "max_charge_percentage": np.array([0.9, 0.9]),
         },
-        "power_limits": {
+        power_limits={
             "max_power_source_target": np.array([5.0]),
             "max_power_target_source": np.array([5.0]),
         },
-        "pricing": {"salvage_value": 0.0},
-        "efficiency": {
+        pricing={"salvage_value": 0.0},
+        efficiency={
             "efficiency_source_target": np.array([0.95]),
             "efficiency_target_source": np.array([0.95]),
         },
-        "partitioning": {},
-        "undercharge": {
+        partitioning={},
+        undercharge={
             "percentage": np.array([0.0, 0.0]),
             "cost": np.array([0.03]),
         },
-    }
+    )
 
 
 async def test_min_charge_edit_updates_live_soc_pricing_threshold() -> None:
     """Editing min_charge updates the live soc_pricing discharge threshold."""
-    participants = {
-        BUS_NAME: {
-            "element_type": ElementType.NODE,
-            "name": BUS_NAME,
-            SECTION_ROLE: {CONF_IS_SOURCE: True, CONF_IS_SINK: True},
-        },
+    bus: NodeConfigData = {
+        "element_type": ElementType.NODE,
+        "name": BUS_NAME,
+        SECTION_ROLE: {CONF_IS_SOURCE: True, CONF_IS_SINK: True},
+    }
+    participants: dict[str, ElementConfigData] = {
+        BUS_NAME: bus,
         BATTERY_NAME: _battery_config(0.2),
     }
 
@@ -72,7 +75,10 @@ async def test_min_charge_edit_updates_live_soc_pricing_threshold() -> None:
     entry.entry_id = "test_entry"
     network, updaters = await create_network(entry, periods_seconds=[3600], participants=participants)
 
-    segment = network.elements[f"{BATTERY_NAME}:discharge"].segments["soc_pricing"]
+    discharge = network.elements[f"{BATTERY_NAME}:discharge"]
+    assert isinstance(discharge, Connection)
+    segment = discharge.segments["soc_pricing"]
+    assert isinstance(segment, SocPricingSegment)
 
     # min=0.2, capacity=10, lower=0 -> threshold = (0.2 - 0) * 10 = 2.0
     np.testing.assert_allclose(np.asarray(segment.discharge_energy_threshold, dtype=float), [2.0])

--- a/custom_components/haeo/core/model/elements/segments/soc_pricing.py
+++ b/custom_components/haeo/core/model/elements/segments/soc_pricing.py
@@ -25,17 +25,17 @@ class SocPricingSegmentSpec(TypedDict):
     charge_capacity_price: NotRequired[NDArray[np.floating[Any]] | float | None]
 
 
+def _exposed_slack(
+    threshold: NDArray[np.float64] | None,
+    price: NDArray[np.float64] | None,
+    slack: HighspyArray,
+) -> HighspyArray | None:
+    return slack if threshold is not None and price is not None else None
+
+
 class SocPricingSegment(Segment):
-    """Penalizes battery operation outside SOC thresholds using slack variables.
+    """Penalizes battery operation outside SOC thresholds using slack variables."""
 
-    All four spec fields are exposed as :class:`TrackedParam` descriptors so
-    that the coordinator's ``ElementUpdater`` can write fresh values through
-    on subsequent optimizations.  Slack variables are always created so that
-    constraint/cost expressions stay structurally stable even when a price
-    transitions between ``None`` and a numeric value across runs.
-    """
-
-    # Parameters exposed for TrackedParam-based updates from the coordinator.
     discharge_energy_threshold: TrackedParam[NDArray[np.float64] | None] = TrackedParam()
     charge_capacity_threshold: TrackedParam[NDArray[np.float64] | None] = TrackedParam()
     discharge_energy_price: TrackedParam[NDArray[np.float64] | None] = TrackedParam()
@@ -70,8 +70,6 @@ class SocPricingSegment(Segment):
         self.discharge_energy_price = broadcast_to_sequence(spec.get("discharge_energy_price"), n_periods)
         self.charge_capacity_price = broadcast_to_sequence(spec.get("charge_capacity_price"), n_periods)
 
-        # Preserve the historical guard: a price without a corresponding
-        # threshold has no meaning and indicates a config bug.
         if self.discharge_energy_price is not None and self.discharge_energy_threshold is None:
             msg = "discharge_energy_threshold is required when discharge_energy_price is set"
             raise ValueError(msg)
@@ -79,19 +77,13 @@ class SocPricingSegment(Segment):
             msg = "charge_capacity_threshold is required when charge_capacity_price is set"
             raise ValueError(msg)
 
-        # Always create slack variables so that the LP structure remains
-        # stable across runs even if a price transitions between ``None`` and
-        # a numeric value.  When the corresponding price/threshold is absent
-        # the slack is left unconstrained at zero (lb=0) and contributes
-        # nothing to the cost.
-        self._discharge_energy_slack: HighspyArray = solver.addVariables(
+        self._discharge_energy_slack = solver.addVariables(
             n_periods,
             lb=0,
             name_prefix=f"{segment_id}_discharge_energy_",
             out_array=True,
         )
-
-        self._charge_capacity_slack: HighspyArray = solver.addVariables(
+        self._charge_capacity_slack = solver.addVariables(
             n_periods,
             lb=0,
             name_prefix=f"{segment_id}_charge_capacity_",
@@ -109,40 +101,34 @@ class SocPricingSegment(Segment):
     @property
     def discharge_energy_slack(self) -> HighspyArray | None:
         """Slack for energy below discharge threshold."""
-        if self.discharge_energy_price is None or self.discharge_energy_threshold is None:
-            return None
-        return self._discharge_energy_slack
+        return _exposed_slack(
+            self.discharge_energy_threshold,
+            self.discharge_energy_price,
+            self._discharge_energy_slack,
+        )
 
     @property
     def charge_capacity_slack(self) -> HighspyArray | None:
         """Slack for energy above charge capacity threshold."""
-        if self.charge_capacity_price is None or self.charge_capacity_threshold is None:
-            return None
-        return self._charge_capacity_slack
+        return _exposed_slack(
+            self.charge_capacity_threshold,
+            self.charge_capacity_price,
+            self._charge_capacity_slack,
+        )
 
     @constraint
-    def discharge_energy_slack_bound(self) -> list[highs_linear_expression] | None:
-        """Bound discharge slack to threshold violation.
+    def soc_slack_bounds(self) -> list[highs_linear_expression] | None:
+        """Bound slack variables to SOC threshold violations when penalties apply."""
+        bounds: list[highs_linear_expression] = []
+        stored = np.asarray(self._battery.stored_energy, dtype=object)[1:]
 
-        Only emits a constraint when both the threshold and price are set;
-        otherwise the slack stays free (and zero, since lb=0 and no cost).
-        """
-        if self.discharge_energy_threshold is None or self.discharge_energy_price is None:
-            return None
-        stored_energy = np.asarray(self._battery.stored_energy, dtype=object)
-        return list(self._discharge_energy_slack >= self.discharge_energy_threshold - stored_energy[1:])
+        if self.discharge_energy_threshold is not None and self.discharge_energy_price is not None:
+            bounds.extend(list(self._discharge_energy_slack >= self.discharge_energy_threshold - stored))
 
-    @constraint
-    def charge_capacity_slack_bound(self) -> list[highs_linear_expression] | None:
-        """Bound charge slack to threshold violation.
+        if self.charge_capacity_threshold is not None and self.charge_capacity_price is not None:
+            bounds.extend(list(self._charge_capacity_slack >= stored - self.charge_capacity_threshold))
 
-        Only emits a constraint when both the threshold and price are set;
-        otherwise the slack stays free (and zero, since lb=0 and no cost).
-        """
-        if self.charge_capacity_threshold is None or self.charge_capacity_price is None:
-            return None
-        stored_energy = np.asarray(self._battery.stored_energy, dtype=object)
-        return list(self._charge_capacity_slack >= stored_energy[1:] - self.charge_capacity_threshold)
+        return bounds or None
 
     @cost
     def soc_pricing_cost(self) -> highs_linear_expression | None:

--- a/custom_components/haeo/core/model/elements/segments/soc_pricing.py
+++ b/custom_components/haeo/core/model/elements/segments/soc_pricing.py
@@ -9,7 +9,7 @@ from numpy.typing import NDArray
 from typing_extensions import TypedDict
 
 from custom_components.haeo.core.model.element import Element
-from custom_components.haeo.core.model.reactive import constraint, cost
+from custom_components.haeo.core.model.reactive import TrackedParam, constraint, cost
 from custom_components.haeo.core.model.util import broadcast_to_sequence
 
 from .segment import Segment
@@ -26,7 +26,20 @@ class SocPricingSegmentSpec(TypedDict):
 
 
 class SocPricingSegment(Segment):
-    """Penalizes battery operation outside SOC thresholds using slack variables."""
+    """Penalizes battery operation outside SOC thresholds using slack variables.
+
+    All four spec fields are exposed as :class:`TrackedParam` descriptors so
+    that the coordinator's ``ElementUpdater`` can write fresh values through
+    on subsequent optimizations.  Slack variables are always created so that
+    constraint/cost expressions stay structurally stable even when a price
+    transitions between ``None`` and a numeric value across runs.
+    """
+
+    # Parameters exposed for TrackedParam-based updates from the coordinator.
+    discharge_energy_threshold: TrackedParam[NDArray[np.float64] | None] = TrackedParam()
+    charge_capacity_threshold: TrackedParam[NDArray[np.float64] | None] = TrackedParam()
+    discharge_energy_price: TrackedParam[NDArray[np.float64] | None] = TrackedParam()
+    charge_capacity_price: TrackedParam[NDArray[np.float64] | None] = TrackedParam()
 
     def __init__(
         self,
@@ -52,34 +65,38 @@ class SocPricingSegment(Segment):
         )
         self._battery = self._get_battery()
 
-        self._discharge_energy_threshold = broadcast_to_sequence(spec.get("discharge_energy_threshold"), n_periods)
-        self._charge_capacity_threshold = broadcast_to_sequence(spec.get("charge_capacity_threshold"), n_periods)
-        self._discharge_energy_price = broadcast_to_sequence(spec.get("discharge_energy_price"), n_periods)
-        self._charge_capacity_price = broadcast_to_sequence(spec.get("charge_capacity_price"), n_periods)
+        self.discharge_energy_threshold = broadcast_to_sequence(spec.get("discharge_energy_threshold"), n_periods)
+        self.charge_capacity_threshold = broadcast_to_sequence(spec.get("charge_capacity_threshold"), n_periods)
+        self.discharge_energy_price = broadcast_to_sequence(spec.get("discharge_energy_price"), n_periods)
+        self.charge_capacity_price = broadcast_to_sequence(spec.get("charge_capacity_price"), n_periods)
 
-        self._discharge_energy_slack: HighspyArray | None = None
-        if self._discharge_energy_price is not None:
-            if self._discharge_energy_threshold is None:
-                msg = "discharge_energy_threshold is required when discharge_energy_price is set"
-                raise ValueError(msg)
-            self._discharge_energy_slack = solver.addVariables(
-                n_periods,
-                lb=0,
-                name_prefix=f"{segment_id}_discharge_energy_",
-                out_array=True,
-            )
+        # Preserve the historical guard: a price without a corresponding
+        # threshold has no meaning and indicates a config bug.
+        if self.discharge_energy_price is not None and self.discharge_energy_threshold is None:
+            msg = "discharge_energy_threshold is required when discharge_energy_price is set"
+            raise ValueError(msg)
+        if self.charge_capacity_price is not None and self.charge_capacity_threshold is None:
+            msg = "charge_capacity_threshold is required when charge_capacity_price is set"
+            raise ValueError(msg)
 
-        self._charge_capacity_slack: HighspyArray | None = None
-        if self._charge_capacity_price is not None:
-            if self._charge_capacity_threshold is None:
-                msg = "charge_capacity_threshold is required when charge_capacity_price is set"
-                raise ValueError(msg)
-            self._charge_capacity_slack = solver.addVariables(
-                n_periods,
-                lb=0,
-                name_prefix=f"{segment_id}_charge_capacity_",
-                out_array=True,
-            )
+        # Always create slack variables so that the LP structure remains
+        # stable across runs even if a price transitions between ``None`` and
+        # a numeric value.  When the corresponding price/threshold is absent
+        # the slack is left unconstrained at zero (lb=0) and contributes
+        # nothing to the cost.
+        self._discharge_energy_slack: HighspyArray = solver.addVariables(
+            n_periods,
+            lb=0,
+            name_prefix=f"{segment_id}_discharge_energy_",
+            out_array=True,
+        )
+
+        self._charge_capacity_slack: HighspyArray = solver.addVariables(
+            n_periods,
+            lb=0,
+            name_prefix=f"{segment_id}_charge_capacity_",
+            out_array=True,
+        )
 
     def _get_battery(self) -> Any:
         """Find the battery element from the connection endpoints."""
@@ -92,37 +109,49 @@ class SocPricingSegment(Segment):
     @property
     def discharge_energy_slack(self) -> HighspyArray | None:
         """Slack for energy below discharge threshold."""
+        if self.discharge_energy_price is None or self.discharge_energy_threshold is None:
+            return None
         return self._discharge_energy_slack
 
     @property
     def charge_capacity_slack(self) -> HighspyArray | None:
         """Slack for energy above charge capacity threshold."""
+        if self.charge_capacity_price is None or self.charge_capacity_threshold is None:
+            return None
         return self._charge_capacity_slack
 
     @constraint
     def discharge_energy_slack_bound(self) -> list[highs_linear_expression] | None:
-        """Bound discharge slack to threshold violation."""
-        if self._discharge_energy_slack is None or self._discharge_energy_threshold is None:
+        """Bound discharge slack to threshold violation.
+
+        Only emits a constraint when both the threshold and price are set;
+        otherwise the slack stays free (and zero, since lb=0 and no cost).
+        """
+        if self.discharge_energy_threshold is None or self.discharge_energy_price is None:
             return None
         stored_energy = np.asarray(self._battery.stored_energy, dtype=object)
-        return list(self._discharge_energy_slack >= self._discharge_energy_threshold - stored_energy[1:])
+        return list(self._discharge_energy_slack >= self.discharge_energy_threshold - stored_energy[1:])
 
     @constraint
     def charge_capacity_slack_bound(self) -> list[highs_linear_expression] | None:
-        """Bound charge slack to threshold violation."""
-        if self._charge_capacity_slack is None or self._charge_capacity_threshold is None:
+        """Bound charge slack to threshold violation.
+
+        Only emits a constraint when both the threshold and price are set;
+        otherwise the slack stays free (and zero, since lb=0 and no cost).
+        """
+        if self.charge_capacity_threshold is None or self.charge_capacity_price is None:
             return None
         stored_energy = np.asarray(self._battery.stored_energy, dtype=object)
-        return list(self._charge_capacity_slack >= stored_energy[1:] - self._charge_capacity_threshold)
+        return list(self._charge_capacity_slack >= stored_energy[1:] - self.charge_capacity_threshold)
 
     @cost
     def soc_pricing_cost(self) -> highs_linear_expression | None:
         """Penalty cost for operating outside SOC thresholds."""
         cost_terms = []
-        if self._discharge_energy_slack is not None and self._discharge_energy_price is not None:
-            cost_terms.append(Highs.qsum(self._discharge_energy_slack * self._discharge_energy_price * self.periods))
-        if self._charge_capacity_slack is not None and self._charge_capacity_price is not None:
-            cost_terms.append(Highs.qsum(self._charge_capacity_slack * self._charge_capacity_price * self.periods))
+        if self.discharge_energy_price is not None and self.discharge_energy_threshold is not None:
+            cost_terms.append(Highs.qsum(self._discharge_energy_slack * self.discharge_energy_price * self.periods))
+        if self.charge_capacity_price is not None and self.charge_capacity_threshold is not None:
+            cost_terms.append(Highs.qsum(self._charge_capacity_slack * self.charge_capacity_price * self.periods))
         if not cost_terms:
             return None
         if len(cost_terms) == 1:


### PR DESCRIPTION
## Summary

Fixes #467. Editing `number.battery_min_charge` (and other battery limit / SOC-pricing entities) now propagates to the live LP without an integration reload.

The bug had two distinct root causes — fixing only one of them left the other still gating the live update. Both are addressed here.

## Root cause #1 — value-edit listener never refreshed TrackedParams

Editable `number` / `switch` entities persist their new value via `util.async_update_subentry_value`, which mutates the subentry's data and triggers `async_update_listener`, which calls `signal_optimization_stale`. But nothing on that chain populated `coordinator._pending_element_updates`, so `_apply_pending_element_updates` ran as a no-op and the network's `TrackedParam`s kept their old values across optimization runs.

### Fix
- `async_update_subentry_value` now also records the changed `subentry_id` on `runtime_data.value_update_subentry_id`.
- `async_update_listener` reads that id when handling a value-only update and asks the coordinator to refresh the affected participant via the new `handle_subentry_value_update()` method before signalling optimization stale.
- `handle_subentry_value_update()` reverse-looks-up the element name from the `subentry_id` (or refreshes all participants when the id is `None`) and re-loads each element config into `_pending_element_updates`, so the next optimization picks up the new values via the existing `_apply_pending_element_updates` → `updater(element_config)` → `TrackedParam` write chain.

## Root cause #2 — `SocPricingSegment` params were not `TrackedParam`

After commit 1, the listener correctly fired and the updater chain ran — but the LP still didn't respect a new `min_charge` floor. Reason: `SocPricingSegment` stored `discharge_energy_threshold` / `charge_capacity_threshold` / `discharge_energy_price` / `charge_capacity_price` as plain instance attributes (`_discharge_energy_threshold` etc.). `_discover_setters` in `coordinator/network.py` only captures **class-level `TrackedParam` descriptors** (via `getattr(type(obj), key, None)`), so the captured updater chain wrote *nothing* for `soc_pricing`.

In the affected configuration, `min_charge_percentage` only reaches the LP via the `soc_pricing` segment's `discharge_energy_threshold` (when `undercharge.percentage = 0`, the existing `lower_ratio` path is dormant), so an untracked threshold field meant the floor was effectively pinned at integration load time.

### Fix
- Promote `discharge_energy_threshold`, `charge_capacity_threshold`, `discharge_energy_price`, `charge_capacity_price` to class-level `TrackedParam` descriptors on `SocPricingSegment`.
- Always create the discharge/charge slack LP variables so the model structure stays stable across runs even when a price transitions between `None` and a numeric value.
- Gate constraint emission on `(threshold AND price)` rather than slack-variable presence so partial configurations no longer pin SOC unintentionally.
- Preserve the historical guard: a price set without a corresponding threshold still raises `ValueError` at init.

## Verification

### Unit tests

All `custom_components/haeo` tests pass: **1751 passed, 2 skipped** (was 1749 pre-fix). Added:

- `test_handle_subentry_value_update_scopes_to_matching_participant`
- `test_handle_subentry_value_update_with_none_refreshes_all_participants`
- `test_handle_subentry_value_update_ignores_unknown_subentry`
- `test_discover_setters_finds_soc_pricing_thresholds`
- `test_soc_pricing_setters_write_fresh_threshold`
- Extended `test_flag_remains_set_after_call` to also assert `subentry_id` is recorded; `test_flag_cleared_on_exception` asserts it is cleared on failure paths.

### Live reproduction on a real instance

Repro on `0.4.0rc7` baseline (pre-fix):

| Step | tail_min SoC | Verdict |
|---|---|---|
| Phase A — set `min_charge` to 10/40/25 without reload | 0.00% | FAIL (3/3) |
| Post-reload at 25 | 24.62% | PASS |
| Phase B — set `min_charge` to 40 after reload | 25.00% (stuck) | FAIL |

Re-run on a build with both commits applied (`0.4.0rc7.post3`):

| Step | requested | tail_min SoC | verdict |
|---|---|---|---|
| Phase A set→10 (no reload) | 10 | 9.65% | PASS |
| Phase A set→40 (no reload) | 40 | 40.00% | PASS |
| Phase A set→25 (no reload) | 25 | 25.00% | PASS |
| Phase B set→10 (post reload) | 10 | 10.00% | PASS |
| Phase B set→40 (post reload) | 40 | 40.00% | PASS |
| Phase B set→25 (post reload) | 25 | 25.00% | PASS |

All 10 phase steps PASS. Repro script output: `NO ISSUE: Both phases passed. Fix is fully effective.`

## Commits

1. `fix(coordinator): push subentry value edits into network TrackedParams` — fixes root cause #1 (the listener chain).
2. `fix(model): make SocPricingSegment params TrackedParam for live updates` — fixes root cause #2 (the segment-level descriptor gap).

## Notes for reviewers

- No public API breaks. `_discover_setters` already understands `TrackedParam` descriptors, so the SOC-pricing setters slot in transparently.
- Constraint behaviour for prior-valid configs is unchanged: when `(threshold, price)` are both set, the same slack/cost constraints emit; when both are absent, no constraints emit (same as before); when only one is set, init still raises `ValueError`.
- The slack-variable creation is now unconditional. The cost contribution and the slack-bound constraint remain gated on `(threshold AND price)`, so an absent price/threshold still contributes nothing.
- `discharge_energy_slack` and `charge_capacity_slack` public properties still return `None` when their respective `(price, threshold)` pair is absent, preserving the read-side contract for existing callers.

Closes #467
