### PR TITLE
Deploy documentation after the Release workflow completes

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,8 +3,9 @@ name: Deploy Documentation
 on:
   push:
     branches: [main]
-  release:
-    types: [published]
+  workflow_run:
+    workflows: ["Release"]
+    types: [completed]
   workflow_dispatch:
 
 permissions:
@@ -21,6 +22,10 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    # When the Release workflow triggers this run, only proceed if it succeeded
+    # so the docs-<tag>.zip asset exists before assemble_docs.py lists releases.
+    # Push and manual dispatch runs always build.
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## Summary

Fixes the race where a freshly published release never becomes the docs `latest`.

`Deploy Documentation` (docs.yml) and `Release` (release.yml) both triggered on `release: published` and ran in parallel. [`tools/assemble_docs.py`](tools/assemble_docs.py) only treats a release as `latest` once its `docs-<tag>.zip` asset is attached, but that asset is uploaded by the Release workflow's `build-docs` job. The deploy run almost always listed releases before the asset existed, so the new release was skipped and `latest/` stayed on the previous version. (This also caused the v0.4.0rc7 docs deploy to fail, and v0.4.0's `latest` not to advance.)

## Changes

- `docs.yml` now triggers via `workflow_run` after the `Release` workflow completes, instead of directly on `release: published`.
- The `build` job skips when the upstream `Release` run did not succeed (`workflow_run.conclusion == 'success'`), guaranteeing `docs-<tag>.zip` exists before `assemble_docs.py` lists releases.
- Push-to-main and manual `workflow_dispatch` runs are unchanged.

## Test plan

- [ ] Merge to main so the default-branch `docs.yml` carries the `workflow_run` trigger.
- [ ] On the next release publish, confirm `Deploy Documentation` starts only after `Release` completes.
- [ ] Confirm `https://haeo.io/versions.json` shows the new version with the `latest` alias.
- [ ] To advance `latest` to v0.4.0 now (before this lands), re-run `Deploy Documentation` once `docs-v0.4.0.zip` is attached.

Made with [Cursor](https://cursor.com)