### PR TITLE
Defer config-entry reload during element flows so batteries get devices

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,7 +226,7 @@ jobs:
 
       - name: Upload frontend coverage to Codecov
         if: ${{ github.event_name != 'release' && !cancelled() }}
-        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
+        uses: codecov/codecov-action@e53489f4d376d79066609109e7a95a29eb3740b1 # v7.0.0
         with:
           files: frontend/haeo-forecast-card/coverage/lcov.info
           flags: frontend
@@ -256,13 +256,13 @@ jobs:
 
       - name: Upload test results to Codecov
         if: ${{ github.event_name != 'release' && !cancelled() }}
-        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
+        uses: codecov/codecov-action@e53489f4d376d79066609109e7a95a29eb3740b1 # v7.0.0
         with:
           report_type: test_results
 
       - name: Upload coverage to Codecov
         if: ${{ github.event_name != 'release' && !cancelled() }}
-        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
+        uses: codecov/codecov-action@e53489f4d376d79066609109e7a95a29eb3740b1 # v7.0.0
         with:
           flags: python
           fail_ci_if_error: true

--- a/custom_components/haeo/__init__.py
+++ b/custom_components/haeo/__init__.py
@@ -120,6 +120,7 @@ class HaeoRuntimeData:
     auto_optimize_switch: AutoOptimizeSwitch | None = field(default=None)
     coordinator: HaeoDataUpdateCoordinator | None = field(default=None)
     value_update_in_progress: bool = field(default=False)
+    reload_pending: bool = field(default=False)
 
 
 type HaeoConfigEntry = ConfigEntry[HaeoRuntimeData | None]
@@ -219,11 +220,41 @@ async def async_update_listener(hass: HomeAssistant, entry: HaeoConfigEntry) -> 
     # writes the element's surfaced policy rules before that. Skip cleanup while
     # a subentry flow for this entry is active so those rules are not mistaken
     # for orphans; element deletions do not run a flow, so they still clean up.
-    if not _element_flow_in_progress(hass, entry):
+    flow_in_progress = _element_flow_in_progress(hass, entry)
+    if not flow_in_progress:
         _cleanup_policy_rules(hass, entry)
 
     _LOGGER.info("HAEO configuration changed, reloading integration")
-    hass.config_entries.async_schedule_reload(entry.entry_id)
+
+    if not flow_in_progress:
+        hass.config_entries.async_schedule_reload(entry.entry_id)
+        return
+
+    # A subentry flow may still be committing further subentries in the same
+    # synchronous step: the battery flow writes its surfaced policy rules before
+    # creating its own subentry. Home Assistant fires update listeners and runs
+    # reloads eagerly, so scheduling the reload now runs the unload phase
+    # synchronously from within this change callback, which removes this update
+    # listener before the later subentry commit fires it; that commit then never
+    # schedules a reload and the new element is left without a device or
+    # entities. Defer to the next event loop iteration so every commit in this
+    # step lands first, and coalesce the deferred reloads so the flow rebuilds
+    # the entry exactly once with all subentries present.
+    if runtime_data is None:
+        hass.loop.call_soon(hass.config_entries.async_schedule_reload, entry.entry_id)
+        return
+
+    if runtime_data.reload_pending:
+        return
+    runtime_data.reload_pending = True
+
+    def _deferred_reload() -> None:
+        # Clear the coalescing flag before scheduling so it cannot stick across
+        # synchronous steps; the reload recreates runtime_data regardless.
+        runtime_data.reload_pending = False
+        hass.config_entries.async_schedule_reload(entry.entry_id)
+
+    hass.loop.call_soon(_deferred_reload)
 
 
 def _element_flow_in_progress(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/haeo/__init__.py
+++ b/custom_components/haeo/__init__.py
@@ -112,6 +112,7 @@ class HaeoRuntimeData:
         auto_optimize_switch: Switch controlling automatic optimization.
         coordinator: Coordinator for network-level optimization (set after input platforms).
         value_update_in_progress: Flag to skip reload when updating entity values.
+        reload_pending: Flag to coalesce deferred reloads during an element config flow.
 
     """
 

--- a/custom_components/haeo/tests/test_init.py
+++ b/custom_components/haeo/tests/test_init.py
@@ -18,6 +18,7 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 from custom_components.haeo import (
     HaeoRuntimeData,
     _async_register_static_frontend_resources,
+    _element_flow_in_progress,
     _ensure_required_subentries,
     async_remove_config_entry_device,
     async_setup,
@@ -456,6 +457,89 @@ async def test_async_update_listener_value_update_in_progress(
     if expect_signal:
         assert mock_coordinator is not None
         mock_coordinator.signal_optimization_stale.assert_called_once()
+
+
+def _mock_element_flow_in_progress(hass: HomeAssistant, entry: MockConfigEntry) -> None:
+    """Mark a subentry config flow as in progress for *entry*."""
+    hass.config_entries.subentries.async_progress = Mock(
+        return_value=[{"handler": (entry.entry_id, "battery")}],
+    )
+
+
+async def test_async_update_listener_defers_reload_during_element_flow(
+    hass: HomeAssistant,
+    mock_hub_entry: MockConfigEntry,
+) -> None:
+    """Reload is deferred to the next loop iteration while an element flow commits subentries."""
+    mock_hub_entry.runtime_data = _create_mock_runtime_data(Mock())
+    _mock_element_flow_in_progress(hass, mock_hub_entry)
+
+    schedule_reload_calls: list[str] = []
+    hass.config_entries.async_schedule_reload = lambda entry_id: schedule_reload_calls.append(entry_id)
+
+    await async_update_listener(hass, mock_hub_entry)
+
+    assert schedule_reload_calls == []
+    assert mock_hub_entry.runtime_data.reload_pending is True
+
+    await hass.async_block_till_done()
+
+    assert mock_hub_entry.runtime_data.reload_pending is False
+    assert schedule_reload_calls == [mock_hub_entry.entry_id]
+
+
+async def test_async_update_listener_coalesces_deferred_reload(
+    hass: HomeAssistant,
+    mock_hub_entry: MockConfigEntry,
+) -> None:
+    """Further update events during a flow only schedule one deferred reload."""
+    mock_hub_entry.runtime_data = _create_mock_runtime_data(Mock())
+    mock_hub_entry.runtime_data.reload_pending = True
+    _mock_element_flow_in_progress(hass, mock_hub_entry)
+
+    schedule_reload = Mock()
+    hass.config_entries.async_schedule_reload = schedule_reload
+
+    await async_update_listener(hass, mock_hub_entry)
+    await hass.async_block_till_done()
+
+    schedule_reload.assert_not_called()
+    assert mock_hub_entry.runtime_data.reload_pending is True
+
+
+async def test_async_update_listener_defers_reload_without_runtime_data(
+    hass: HomeAssistant,
+    mock_hub_entry: MockConfigEntry,
+) -> None:
+    """Deferred reload still runs when runtime_data is not yet populated."""
+    mock_hub_entry.runtime_data = None
+    _mock_element_flow_in_progress(hass, mock_hub_entry)
+
+    schedule_reload_calls: list[str] = []
+    hass.config_entries.async_schedule_reload = lambda entry_id: schedule_reload_calls.append(entry_id)
+
+    await async_update_listener(hass, mock_hub_entry)
+
+    assert schedule_reload_calls == []
+
+    await hass.async_block_till_done()
+
+    assert schedule_reload_calls == [mock_hub_entry.entry_id]
+
+
+async def test_element_flow_in_progress(
+    hass: HomeAssistant,
+    mock_hub_entry: MockConfigEntry,
+) -> None:
+    """Element flow detection matches subentry flows owned by the config entry."""
+    hass.config_entries.subentries.async_progress = Mock(
+        return_value=[{"handler": (mock_hub_entry.entry_id, "battery")}],
+    )
+
+    assert _element_flow_in_progress(hass, mock_hub_entry) is True
+
+    hass.config_entries.subentries.async_progress = Mock(return_value=[])
+    assert _element_flow_in_progress(hass, mock_hub_entry) is False
 
 
 async def test_async_setup_entry_raises_config_entry_not_ready_on_timeout(

--- a/tests/guides/test_battery_device_repro.py
+++ b/tests/guides/test_battery_device_repro.py
@@ -1,0 +1,162 @@
+"""Live reproduction for the missing battery device/entities bug.
+
+Drives the real Home Assistant UI config flow (via Playwright against a live
+in-process instance) to create an inverter, a grid, and a battery, then
+inspects the backend device and entity registries to confirm that a device
+and entities are created for the battery as they are for the grid.
+
+The battery is added last on purpose: it is the only element whose flow writes
+surfaced policy rules to the policy subentry before creating its own subentry,
+and that policy write triggers an eager reload that tears the entry down before
+the battery subentry commits. If another element were created afterwards, its
+reload would rebuild the entry and mask the bug, so the battery must be the
+final commit for the reproduction to be deterministic.
+
+Run with:
+    uv run pytest tests/guides/test_battery_device_repro.py -m guide -v
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import entity_registry as er
+from playwright.sync_api import sync_playwright
+import pytest
+
+from custom_components.haeo.const import DOMAIN
+from tests.guides.primitives import (
+    ConstantInput,
+    EntityInput,
+    HAPage,
+    add_battery,
+    add_grid,
+    add_integration,
+    add_inverter,
+    login,
+)
+from tools.guide_runner import INPUTS_FILE, load_scenario_environment
+from tools.live_hass import LiveHomeAssistant, live_home_assistant
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def _registry_summary(live: LiveHomeAssistant) -> dict[str, Any]:
+    """Summarize, per element subentry, how many devices and entities exist."""
+
+    async def _collect() -> dict[str, Any]:
+        entries = live.hass.config_entries.async_entries(DOMAIN)
+        entry = entries[0]
+        device_registry = dr.async_get(live.hass)
+        entity_registry = er.async_get(live.hass)
+
+        devices = dr.async_entries_for_config_entry(device_registry, entry.entry_id)
+
+        per_subentry: dict[str, dict[str, Any]] = {}
+        for subentry_id, subentry in entry.subentries.items():
+            subentry_devices = [
+                device
+                for device in devices
+                if subentry_id in device.config_entries_subentries.get(entry.entry_id, set())
+            ]
+            entity_count = 0
+            entity_ids: list[str] = []
+            for device in subentry_devices:
+                device_entities = er.async_entries_for_device(
+                    entity_registry, device.id, include_disabled_entities=True
+                )
+                entity_count += len(device_entities)
+                entity_ids.extend(ent.entity_id for ent in device_entities)
+            per_subentry[subentry.title] = {
+                "type": str(subentry.subentry_type),
+                "devices": len(subentry_devices),
+                "entities": entity_count,
+                "entity_ids": entity_ids,
+            }
+        return {
+            "state": str(entry.state),
+            "reason": entry.reason,
+            "subentries": per_subentry,
+        }
+
+    return live.run_coro(_collect())
+
+
+@pytest.mark.guide
+@pytest.mark.enable_socket
+@pytest.mark.timeout(300)
+def test_battery_gets_device_and_entities_like_grid() -> None:
+    """A battery created via the real UI flow must register a device + entities."""
+    environment = load_scenario_environment()
+
+    with live_home_assistant(timeout=120, environment=environment) as live:
+        live.load_states_from_file(INPUTS_FILE)
+
+        with (
+            sync_playwright() as playwright,
+            playwright.firefox.launch(headless=True) as browser,
+            browser.new_context(
+                viewport={"width": 1280, "height": 800},
+                reduced_motion="reduce",
+            ) as context,
+        ):
+            live.configure_context(context, dark_mode=False)
+            with context.new_page() as page_obj:
+                page_obj.set_default_timeout(5000)
+                page = HAPage(page=page_obj, url=live.url, ha=live)
+
+                login(page)
+                add_integration(page, network_name="Sigenergy System")
+                add_inverter(
+                    page,
+                    name="Inverter",
+                    connection="Switchboard",
+                    max_power_source_target=EntityInput("max active power", "Sigen Plant Max Active Power"),
+                    max_power_target_source=EntityInput("max active power", "Sigen Plant Max Active Power"),
+                )
+                add_grid(
+                    page,
+                    name="Grid",
+                    connection="Switchboard",
+                    price_source_target=[
+                        EntityInput("general price", "Home - General Price"),
+                        EntityInput("general forecast", "Home - General Forecast"),
+                    ],
+                    price_target_source=[
+                        EntityInput("feed in price", "Home - Feed In Price"),
+                        EntityInput("feed in forecast", "Home - Feed In Forecast"),
+                    ],
+                    max_power_source_target=ConstantInput(55),
+                    max_power_target_source=ConstantInput(30),
+                )
+                add_battery(
+                    page,
+                    name="Battery",
+                    connection="Inverter",
+                    capacity=EntityInput("rated energy", "Rated Energy Capacity"),
+                    initial_charge_percentage=EntityInput("state of charge", "Battery State of Charge"),
+                    max_power_target_source=EntityInput("rated charging", "Rated Charging Power"),
+                    max_power_source_target=EntityInput("rated discharging", "Rated Discharging Power"),
+                    min_charge_percentage=ConstantInput(10),
+                    max_charge_percentage=ConstantInput(100),
+                )
+
+        live.run_coro(live.hass.async_block_till_done())
+        summary = _registry_summary(live)
+
+    _LOGGER.info("Registry summary: %s", summary)
+
+    subentries = summary["subentries"]
+    assert "Grid" in subentries, f"Grid subentry missing: {summary}"
+    assert "Battery" in subentries, f"Battery subentry missing: {summary}"
+
+    grid = subentries["Grid"]
+    battery = subentries["Battery"]
+
+    assert grid["devices"] >= 1, f"Grid should have a device: {summary}"
+    assert grid["entities"] >= 1, f"Grid should have entities: {summary}"
+
+    assert battery["devices"] >= 1, f"Battery should have a device like grid does: {summary}"
+    assert battery["entities"] >= 1, f"Battery should have entities like grid does: {summary}"


### PR DESCRIPTION
## Summary

Fixes a bug where creating a **battery** element via the UI left it with **no device and no entities** until a manual reload, while other elements (grid, inverter, etc.) worked fine.

### Root cause

When an element config flow commits, Home Assistant fires the config-entry update listener and runs the resulting reload **eagerly**. The battery flow is the only element flow that writes its *surfaced policy rules* (mutating the policy subentry) **before** committing its own subentry. The reload triggered by that policy write runs the unload phase synchronously from inside the change callback, which removes the update listener **before** the battery subentry commit fires it. That commit then never schedules a reload, so the battery is left without a device or entities.

This is battery-specific because it's the only element whose flow performs a cross-subentry write before its own commit in the same synchronous step.

### Fix

In `async_update_listener`, while a subentry flow is in progress, defer the reload to the next event loop iteration (`hass.loop.call_soon`) so every commit in the step lands first, and coalesce deferred reloads via a `reload_pending` flag so the entry rebuilds exactly once with all subentries present. The flag is cleared when the deferred reload fires so it can't stick across steps.

## Test plan

- [x] New live guide test `tests/guides/test_battery_device_repro.py` drives the real UI config flow (Playwright + in-process HA) to create an inverter, grid, and battery, then asserts the battery registers a device + entities like the grid does.
- [x] Red/green verified: the test **fails on `main`** (battery has no device/entities) and **passes with this fix**.
- [x] `ruff check` / `ruff format` clean.

Run the test with:

```
uv run pytest tests/guides/test_battery_device_repro.py -m guide -v
```

Made with [Cursor](https://cursor.com)