### PR TITLE
fix(#478): report bus-side flow and cap charging on bus side

### DIFF
--- a/custom_components/haeo/core/adapters/elements/battery.py
+++ b/custom_components/haeo/core/adapters/elements/battery.py
@@ -6,7 +6,7 @@ from typing import Any, Final, Literal
 
 import numpy as np
 
-from custom_components.haeo.core.adapters.output_utils import connection_power, expect_output_data
+from custom_components.haeo.core.adapters.output_utils import connection_power, connection_power_out, expect_output_data
 from custom_components.haeo.core.const import ConnectivityLevel
 from custom_components.haeo.core.model import ModelElementConfig, ModelOutputName, ModelOutputValue
 from custom_components.haeo.core.model import battery as model_battery
@@ -194,6 +194,13 @@ class BatteryAdapter:
             }
         )
         # Charge: network -> battery
+        # Segment order [power_limit, efficiency] places the cap on the bus side
+        # (source-end of the connection, pre-efficiency), matching how
+        # OEM hybrid-inverter charging limits are specified
+        # (e.g. SigEnergy ``max_charging_limit``, Sungrow charging power limit
+        # — these are AC/bus-side caps, not electrochemical-side caps).
+        # Mirrors the discharge connection where [efficiency, power_limit]
+        # also lands the cap on the bus side per upstream PR #297.
         elements.append(
             {
                 "element_type": MODEL_ELEMENT_TYPE_CONNECTION,
@@ -201,8 +208,8 @@ class BatteryAdapter:
                 "source": extract_connection_target(config[CONF_CONNECTION]),
                 "target": name,
                 "segments": {
-                    "efficiency": {"segment_type": "efficiency", "efficiency": efficiency_target_source},
                     "power_limit": {"segment_type": "power_limit", "max_power": max_charge},
+                    "efficiency": {"segment_type": "efficiency", "efficiency": efficiency_target_source},
                 },
             }
         )
@@ -221,8 +228,30 @@ class BatteryAdapter:
         charge_conn = model_outputs.get(f"{name}:charge")
         period_count = len(expect_output_data(model_outputs[name][model_battery.BATTERY_POWER_CHARGE]).values)
 
-        power_discharge = replace(connection_power(discharge_conn, period_count), type=OutputType.POWER)
-        power_charge = replace(connection_power(charge_conn, period_count), type=OutputType.POWER, direction="-")
+        # Discharge/charge sensors report the electrochemical-side flow, i.e.
+        # the rate the cells are drawn down / refilled at. This is what the LP
+        # primal variable for stored-energy delta tracks, and it reconciles
+        # with SOC changes.
+        #
+        # Discharge connection: source = battery, target = bus, segments =
+        # [efficiency, power_limit]. So total_power_in is the battery-side
+        # (electrochemical) flow, and total_power_out is the bus-side flow.
+        #
+        # Charge connection: source = bus, target = battery, segments =
+        # [efficiency, power_limit]. So total_power_out is the battery-side
+        # (electrochemical) flow, and total_power_in is the bus-side flow.
+        power_discharge_electro = replace(connection_power(discharge_conn, period_count), type=OutputType.POWER)
+        power_charge_electro = replace(
+            connection_power_out(charge_conn, period_count), type=OutputType.POWER, direction="-"
+        )
+
+        # Active power is the bus-side net flow, matching what hybrid-inverter
+        # OEM monitoring sensors (Sungrow, SigEnergy, Victron) report and the
+        # bus-side max_active_power control surfaces (aligned with PR #297,
+        # which placed power_limit on the post-efficiency side).
+        # Signed: positive = battery exporting to bus (discharging).
+        discharge_bus = connection_power_out(discharge_conn, period_count)
+        charge_bus = connection_power(charge_conn, period_count)
 
         # Battery-internal outputs (energy, SOC, shadow prices)
         battery_outputs = {key: expect_output_data(value) for key, value in model_outputs[name].items()}
@@ -232,15 +261,15 @@ class BatteryAdapter:
         aggregate_soc = _calculate_soc(total_energy_stored, config)
 
         aggregate_outputs: dict[BatteryOutputName, OutputData] = {
-            BATTERY_POWER_CHARGE: power_charge,
-            BATTERY_POWER_DISCHARGE: power_discharge,
+            BATTERY_POWER_CHARGE: power_charge_electro,
+            BATTERY_POWER_DISCHARGE: power_discharge_electro,
             BATTERY_ENERGY_STORED: total_energy_stored,
             BATTERY_STATE_OF_CHARGE: aggregate_soc,
         }
 
         aggregate_outputs[BATTERY_POWER_ACTIVE] = replace(
-            power_discharge,
-            values=[d - c for d, c in zip(power_discharge.values, power_charge.values, strict=True)],
+            discharge_bus,
+            values=[d - c for d, c in zip(discharge_bus.values, charge_bus.values, strict=True)],
             direction=None,
             type=OutputType.POWER,
         )

--- a/custom_components/haeo/core/adapters/elements/inverter.py
+++ b/custom_components/haeo/core/adapters/elements/inverter.py
@@ -4,7 +4,7 @@ from collections.abc import Mapping
 from dataclasses import replace
 from typing import Any, Final, Literal
 
-from custom_components.haeo.core.adapters.output_utils import connection_power, expect_output_data
+from custom_components.haeo.core.adapters.output_utils import connection_power, connection_power_out, expect_output_data
 from custom_components.haeo.core.const import ConnectivityLevel
 from custom_components.haeo.core.model import ModelElementConfig, ModelOutputName, ModelOutputValue
 from custom_components.haeo.core.model.const import OutputType
@@ -88,19 +88,25 @@ class InverterAdapter:
                     },
                 },
             },
+            # ac_to_dc (rectifying): source = AC bus, target = DC bus.
+            # Segment order [power_limit, efficiency] places the cap on the AC
+            # (source) side, matching how OEM hybrid-inverter rectifier limits
+            # are specified (AC-side ``max_active_power`` style caps).
+            # Mirrors dc_to_ac where [efficiency, power_limit] also lands the
+            # cap on the AC (target) side per upstream PR #297.
             {
                 "element_type": MODEL_ELEMENT_TYPE_CONNECTION,
                 "name": f"{config['name']}:ac_to_dc",
                 "source": extract_connection_target(config[CONF_CONNECTION]),
                 "target": config["name"],
                 "segments": {
-                    "efficiency": {
-                        "segment_type": "efficiency",
-                        "efficiency": config[SECTION_EFFICIENCY].get(CONF_EFFICIENCY_TARGET_SOURCE),
-                    },
                     "power_limit": {
                         "segment_type": "power_limit",
                         "max_power": config[SECTION_POWER_LIMITS].get(CONF_MAX_POWER_TARGET_SOURCE),
+                    },
+                    "efficiency": {
+                        "segment_type": "efficiency",
+                        "efficiency": config[SECTION_EFFICIENCY].get(CONF_EFFICIENCY_TARGET_SOURCE),
                     },
                 },
             },
@@ -117,24 +123,40 @@ class InverterAdapter:
         reverse_conn = model_outputs.get(f"{name}:ac_to_dc")
         dc_bus = model_outputs[name]
         period_count = len(expect_output_data(dc_bus[ELEMENT_POWER_BALANCE]).values)
-        power_forward = connection_power(forward_conn, period_count)
-        power_reverse = connection_power(reverse_conn, period_count)
+
+        # DC-side flows for the per-direction sensors (matches the existing
+        # convention that *_dc_to_ac / *_ac_to_dc describe what the LP draws
+        # from / pushes onto the DC bus). For the forward (inverting)
+        # connection source = DC bus, so total_power_in is the DC-side flow.
+        # For the reverse (rectifying) connection target = DC bus, so
+        # total_power_out is the DC-side flow.
+        power_forward_dc = connection_power(forward_conn, period_count)
+        power_reverse_dc = connection_power_out(reverse_conn, period_count)
+
+        # AC-side flows for the active sensor (matches OEM inverter monitoring
+        # which reports AC-side power). Forward target = AC, so
+        # total_power_out is AC-side; reverse source = AC, so total_power_in
+        # is AC-side.
+        power_forward_ac = connection_power_out(forward_conn, period_count)
+        power_reverse_ac = connection_power(reverse_conn, period_count)
 
         inverter_outputs: dict[InverterOutputName, OutputData] = {}
 
         # source_target = DC to AC (inverting)
         # target_source = AC to DC (rectifying)
-        inverter_outputs[INVERTER_POWER_DC_TO_AC] = replace(power_forward, direction="+")
-        inverter_outputs[INVERTER_POWER_AC_TO_DC] = replace(power_reverse, direction="-")
+        inverter_outputs[INVERTER_POWER_DC_TO_AC] = replace(power_forward_dc, direction="+")
+        inverter_outputs[INVERTER_POWER_AC_TO_DC] = replace(power_reverse_dc, direction="-")
 
-        # Active inverter power (DC to AC - AC to DC)
+        # Active inverter power (AC-side net: DC to AC - AC to DC, both AC-side)
+        # Matches what an OEM inverter's "Active Power" sensor reports.
+        # Signed: positive = net DC to AC (exporting to AC grid).
         inverter_outputs[INVERTER_POWER_ACTIVE] = replace(
-            power_forward,
+            power_forward_ac,
             values=[
                 dc_to_ac - ac_to_dc
                 for dc_to_ac, ac_to_dc in zip(
-                    power_forward.values,
-                    power_reverse.values,
+                    power_forward_ac.values,
+                    power_reverse_ac.values,
                     strict=True,
                 )
             ],

--- a/custom_components/haeo/core/adapters/elements/tests/test_battery.py
+++ b/custom_components/haeo/core/adapters/elements/tests/test_battery.py
@@ -4,7 +4,9 @@ from collections.abc import Sequence
 
 from homeassistant.core import HomeAssistant
 import numpy as np
+import pytest
 
+from custom_components.haeo.core.adapters.elements.battery import BATTERY_DEVICE_BATTERY, BATTERY_POWER_ACTIVE
 from custom_components.haeo.core.adapters.elements.battery import adapter as battery_adapter
 from custom_components.haeo.core.model import Network
 from custom_components.haeo.core.model.elements import (
@@ -18,6 +20,7 @@ from custom_components.haeo.core.model.elements.connection import ConnectionElem
 from custom_components.haeo.core.model.elements.segments import is_efficiency_spec
 from custom_components.haeo.core.schema import as_connection_target, as_constant_value, as_entity_value, as_none_value
 from custom_components.haeo.core.schema.elements import battery
+from custom_components.haeo.core.schema.elements.battery import BatteryConfigData
 from custom_components.haeo.elements.availability import schema_config_available
 
 
@@ -598,3 +601,354 @@ def test_charge_respects_power_limit_with_efficiency() -> None:
     )
     # Should charge since it's profitable (exact amount depends on efficiency interaction)
     assert battery_charge > 0, "Expected battery to charge since it's profitable"
+
+
+# ---------------------------------------------------------------------------
+# Sensor-output side selection (electrochemical vs bus)
+# ---------------------------------------------------------------------------
+#
+# The battery adapter exposes three power sensors with intentionally
+# different sides of the post-efficiency boundary:
+#
+#   * ``BATTERY_POWER_DISCHARGE`` — electrochemical (battery-cell) draw rate
+#   * ``BATTERY_POWER_CHARGE``    — electrochemical (battery-cell) refill rate
+#   * ``BATTERY_POWER_ACTIVE``    — bus-side net flow, signed
+#                                   (positive = battery exporting to bus)
+#
+# This split matches the OEM hybrid-inverter sensor convention
+# (Sungrow, SigEnergy, Victron) and is the follow-on to upstream PR #297,
+# which placed ``power_limit`` on the post-efficiency side of the chain.
+# Energy/SOC reconciliation needs the electrochemical figures; downstream
+# integrations binding to ``max_active_power`` need the bus figure.
+#
+# The two helpers below build a network with the production adapter's
+# segment order (``efficiency`` then ``power_limit``), so the LP exhibits
+# the post-efficiency cap behaviour the sensors are designed to surface.
+
+
+def _make_battery_config_for_adapter() -> BatteryConfigData:
+    """Return a minimal BatteryConfigData accepted by ``BatteryAdapter.outputs``.
+
+    Only the storage/efficiency/power_limits sections are exercised here;
+    the rest are filled with no-op defaults so the outputs path does not
+    raise on missing keys.
+    """
+    return BatteryConfigData(
+        element_type="battery",
+        name="battery",
+        connection=as_connection_target("bus"),
+        storage={
+            "capacity": np.array([100.0, 100.0]),
+            "initial_charge_percentage": as_constant_value(0.5),
+        },
+        limits={
+            "min_charge_percentage": np.array([0.0]),
+            "max_charge_percentage": np.array([1.0]),
+        },
+        power_limits={
+            "max_power_source_target": np.array([10.0]),
+            "max_power_target_source": np.array([10.0]),
+        },
+        pricing={"salvage_value": as_constant_value(0.0)},
+        efficiency={
+            "efficiency_source_target": np.array([0.9]),
+            "efficiency_target_source": np.array([0.9]),
+        },
+        partitioning={},
+        undercharge={},
+        overcharge={},
+    )
+
+
+def _build_battery_bus_network(
+    *,
+    efficiency: float,
+    discharge_cap_kw: float,
+    charge_cap_kw: float,
+    discharge_price: float,
+    charge_price: float,
+) -> Network:
+    """Build a single-period battery↔bus network using the production segment order.
+
+    Discharge connection: battery → bus, segments = [efficiency, power_limit, pricing]
+        ⇒ power_limit caps the bus-side (post-efficiency) flow.
+    Charge connection:    bus → battery, segments = [power_limit, efficiency, pricing]
+        ⇒ power_limit caps the bus-side (pre-efficiency, source-end) flow.
+
+    Both directions cap on the bus side, matching how OEM hybrid-inverter
+    control surfaces (SigEnergy ``max_charging_limit``, Sungrow charging
+    power limit, etc.) are specified, and aligned with PR #297's intent.
+
+    Battery is sized large (100 kWh, 50% SOC) so the binding constraint in
+    the resulting LP is the connection power_limit, not the stored-energy
+    headroom.
+    """
+    network = Network(name="test_efficiency_sensors", periods=np.array([1.0]))
+    network.add(
+        {
+            "element_type": MODEL_ELEMENT_TYPE_BATTERY,
+            "name": "battery",
+            "capacity": np.array([100.0, 100.0]),
+            "initial_charge": 50.0,
+        }
+    )
+    network.add({"element_type": MODEL_ELEMENT_TYPE_NODE, "name": "bus", "is_source": True, "is_sink": True})
+    network.add(
+        {
+            "element_type": MODEL_ELEMENT_TYPE_CONNECTION,
+            "name": "battery:discharge",
+            "source": "battery",
+            "target": "bus",
+            "tags": {1},
+            "segments": {
+                "efficiency": {"segment_type": "efficiency", "efficiency": np.array([efficiency])},
+                "power_limit": {"segment_type": "power_limit", "max_power": np.array([discharge_cap_kw])},
+                "pricing": {"segment_type": "pricing", "price": np.array([discharge_price])},
+            },
+        }
+    )
+    network.add(
+        {
+            "element_type": MODEL_ELEMENT_TYPE_CONNECTION,
+            "name": "battery:charge",
+            "source": "bus",
+            "target": "battery",
+            "tags": {1},
+            "segments": {
+                "power_limit": {"segment_type": "power_limit", "max_power": np.array([charge_cap_kw])},
+                "efficiency": {"segment_type": "efficiency", "efficiency": np.array([efficiency])},
+                "pricing": {"segment_type": "pricing", "price": np.array([charge_price])},
+            },
+        }
+    )
+    return network
+
+
+def _collect_model_outputs(network: Network) -> dict[str, dict[str, object]]:
+    """Snapshot per-element outputs after ``network.optimize`` has run."""
+    return {name: dict(element.outputs()) for name, element in network.elements.items()}
+
+
+def test_sensors_report_correct_sides_on_discharge() -> None:
+    """During pure discharge the three sensors should each report their declared side.
+
+    With η=0.9 and a 10 kW post-efficiency cap on the discharge connection:
+
+    * ``BATTERY_POWER_DISCHARGE`` reads the electrochemical-side flow
+      (source-end of the discharge connection, pre-efficiency).
+    * ``BATTERY_POWER_CHARGE`` is zero (no charge happening).
+    * ``BATTERY_POWER_ACTIVE`` reads the bus-side net flow (post-efficiency)
+      and is positive (discharging).
+    """
+    efficiency = 0.9
+    cap_kw = 10.0
+
+    network = _build_battery_bus_network(
+        efficiency=efficiency,
+        discharge_cap_kw=cap_kw,
+        charge_cap_kw=cap_kw,
+        discharge_price=-1.0,  # exporting to bus is profitable
+        charge_price=100.0,  # charging is heavily penalised
+    )
+    network.optimize()
+
+    sensors = battery_adapter.outputs(
+        "battery", _collect_model_outputs(network), config=_make_battery_config_for_adapter()
+    )[BATTERY_DEVICE_BATTERY]
+
+    discharge_conn = network.elements["battery:discharge"]
+    source_end_electro = discharge_conn.extract_values(discharge_conn.total_power_in)[0]
+    target_end_bus = discharge_conn.extract_values(discharge_conn.total_power_out)[0]
+
+    # Electrochemical-side draw matches the connection's source-end (pre-efficiency)
+    assert sensors[BATTERY_POWER_DISCHARGE].values[0] == pytest.approx(source_end_electro)
+    # No charging happening
+    assert sensors[BATTERY_POWER_CHARGE].values[0] == pytest.approx(0.0)
+    # Bus-side active matches the connection's target-end (post-efficiency)
+    assert sensors[BATTERY_POWER_ACTIVE].values[0] == pytest.approx(target_end_bus)
+    # And bus-side is strictly less than electrochemical-side because of η=0.9 loss
+    assert sensors[BATTERY_POWER_ACTIVE].values[0] < sensors[BATTERY_POWER_DISCHARGE].values[0]
+    assert sensors[BATTERY_POWER_ACTIVE].values[0] == pytest.approx(
+        sensors[BATTERY_POWER_DISCHARGE].values[0] * efficiency
+    )
+
+
+def test_sensors_report_correct_sides_on_charge() -> None:
+    """During pure charge the three sensors should each report their declared side.
+
+    With η=0.9 on the charge connection:
+
+    * ``BATTERY_POWER_DISCHARGE`` is zero (no discharge happening).
+    * ``BATTERY_POWER_CHARGE`` reads the electrochemical-side flow
+      (target-end of the charge connection, post-efficiency = battery cells).
+    * ``BATTERY_POWER_ACTIVE`` reads the bus-side net flow (source-end of
+      the charge connection, pre-efficiency) and is negative (charging).
+    """
+    efficiency = 0.9
+    cap_kw = 10.0
+
+    network = _build_battery_bus_network(
+        efficiency=efficiency,
+        discharge_cap_kw=cap_kw,
+        charge_cap_kw=cap_kw,
+        discharge_price=100.0,  # discharging is heavily penalised
+        charge_price=-1.0,  # importing from bus is profitable
+    )
+    network.optimize()
+
+    sensors = battery_adapter.outputs(
+        "battery", _collect_model_outputs(network), config=_make_battery_config_for_adapter()
+    )[BATTERY_DEVICE_BATTERY]
+
+    charge_conn = network.elements["battery:charge"]
+    source_end_bus = charge_conn.extract_values(charge_conn.total_power_in)[0]
+    target_end_electro = charge_conn.extract_values(charge_conn.total_power_out)[0]
+
+    assert sensors[BATTERY_POWER_DISCHARGE].values[0] == pytest.approx(0.0)
+    # Electrochemical-side refill matches the charge connection's target-end (post-efficiency)
+    assert sensors[BATTERY_POWER_CHARGE].values[0] == pytest.approx(target_end_electro)
+    # Active is bus-side and negative (charging) — equals -source-end of charge connection
+    assert sensors[BATTERY_POWER_ACTIVE].values[0] == pytest.approx(-source_end_bus)
+    assert sensors[BATTERY_POWER_ACTIVE].values[0] < 0.0
+    # Bus-side magnitude is strictly greater than electrochemical-side because of η=0.9 loss
+    assert abs(sensors[BATTERY_POWER_ACTIVE].values[0]) > sensors[BATTERY_POWER_CHARGE].values[0]
+    assert abs(sensors[BATTERY_POWER_ACTIVE].values[0]) == pytest.approx(
+        sensors[BATTERY_POWER_CHARGE].values[0] / efficiency
+    )
+
+
+def test_sensor_sides_with_no_efficiency_loss() -> None:
+    """With η=1.0, electrochemical and bus sides coincide.
+
+    All three sensors agree on magnitude regardless of direction.
+    """
+    efficiency = 1.0
+    cap_kw = 10.0
+
+    # Discharge case
+    network = _build_battery_bus_network(
+        efficiency=efficiency,
+        discharge_cap_kw=cap_kw,
+        charge_cap_kw=cap_kw,
+        discharge_price=-1.0,
+        charge_price=100.0,
+    )
+    network.optimize()
+    sensors = battery_adapter.outputs(
+        "battery", _collect_model_outputs(network), config=_make_battery_config_for_adapter()
+    )[BATTERY_DEVICE_BATTERY]
+    assert sensors[BATTERY_POWER_ACTIVE].values[0] == pytest.approx(sensors[BATTERY_POWER_DISCHARGE].values[0])
+
+    # Charge case
+    network = _build_battery_bus_network(
+        efficiency=efficiency,
+        discharge_cap_kw=cap_kw,
+        charge_cap_kw=cap_kw,
+        discharge_price=100.0,
+        charge_price=-1.0,
+    )
+    network.optimize()
+    sensors = battery_adapter.outputs(
+        "battery", _collect_model_outputs(network), config=_make_battery_config_for_adapter()
+    )[BATTERY_DEVICE_BATTERY]
+    assert sensors[BATTERY_POWER_ACTIVE].values[0] == pytest.approx(-sensors[BATTERY_POWER_CHARGE].values[0])
+
+
+# ---------------------------------------------------------------------------
+# Adapter-level cap-side regression (issue #478 follow-on)
+# ---------------------------------------------------------------------------
+#
+# Prior to the segment-order fix, the charge connection used
+# [efficiency, power_limit] which placed ``max_power_target_source`` on
+# the electrochemical (cell, target-end) side. With η<1 this caused the
+# bus-side draw to exceed the OEM-declared charging-power limit by a
+# factor of 1/η — e.g. a 21 kW cap on a 90%-efficient battery produced
+# ~23.3 kW of AC draw, contradicting the OEM ``max_charging_limit``
+# semantics on SigEnergy, Sungrow, and Victron hybrid inverters.
+#
+# The adapter now emits charge segments as [power_limit, efficiency] so
+# the cap binds the bus (source-end) flow, mirroring the discharge
+# connection where [efficiency, power_limit] also binds the bus
+# (target-end) per PR #297. Both directions are now bus-side-capped.
+
+
+def test_adapter_charge_cap_binds_bus_side() -> None:
+    """Charge cap from the adapter binds the bus (source-end), not cells.
+
+    Builds the production adapter for a battery with η=0.9 and a 10 kW
+    charge cap, then optimises a network where charging is heavily
+    profitable. Expects bus draw at exactly the cap, cells at cap x η.
+    """
+    efficiency = 0.9
+    charge_cap_kw = 10.0
+
+    config = BatteryConfigData(
+        element_type="battery",
+        name="battery",
+        connection=as_connection_target("bus"),
+        storage={
+            "capacity": np.array([100.0, 100.0]),
+            "initial_charge_percentage": 0.5,
+        },
+        limits={
+            "min_charge_percentage": np.array([0.0]),
+            "max_charge_percentage": np.array([1.0]),
+        },
+        power_limits={
+            "max_power_source_target": np.array([charge_cap_kw]),
+            "max_power_target_source": np.array([charge_cap_kw]),
+        },
+        pricing={"salvage_value": 0.0},
+        efficiency={
+            "efficiency_source_target": np.array([efficiency]),
+            "efficiency_target_source": np.array([efficiency]),
+        },
+        partitioning={},
+        undercharge={},
+        overcharge={},
+    )
+
+    elements = battery_adapter.model_elements(config)
+
+    # The production pipeline normally tags connections in a separate policy
+    # compilation step (see ``adapters/policy_compilation.py``). For this
+    # adapter-only unit test, assign a single shared tag and inject a
+    # pricing segment into the charge connection BEFORE it's added to the
+    # network, so charging is heavily profitable and the LP drives the
+    # charge connection all the way to its cap. Preserves the adapter's
+    # production segment order (power_limit before efficiency).
+    for element in elements:
+        if element.get("element_type") == MODEL_ELEMENT_TYPE_CONNECTION:
+            element["tags"] = {1}
+        if element.get("name") == "battery:charge":
+            element["segments"]["pricing"] = {
+                "segment_type": "pricing",
+                "price": np.array([-1.0]),
+            }
+        if element.get("name") == "battery:discharge":
+            # Heavily penalise discharging so the LP doesn't cycle.
+            element["segments"]["pricing"] = {
+                "segment_type": "pricing",
+                "price": np.array([100.0]),
+            }
+
+    network = Network(name="test_charge_cap_bus_side", periods=np.array([1.0]))
+    network.add({"element_type": MODEL_ELEMENT_TYPE_NODE, "name": "bus", "is_source": True, "is_sink": True})
+    for element in elements:
+        network.add(element)
+
+    network.optimize()
+
+    sensors = battery_adapter.outputs("battery", _collect_model_outputs(network), config=config)[BATTERY_DEVICE_BATTERY]
+
+    bus_draw = abs(sensors[BATTERY_POWER_ACTIVE].values[0])
+    cell_intake = sensors[BATTERY_POWER_CHARGE].values[0]
+
+    # Bus-side AC draw is capped at the OEM-declared limit.
+    assert bus_draw == pytest.approx(charge_cap_kw, abs=1e-3), (
+        f"Bus draw {bus_draw:.3f} kW should equal cap {charge_cap_kw} kW (was the bug)"
+    )
+    # Cell-side intake is cap x efficiency, not cap.
+    assert cell_intake == pytest.approx(charge_cap_kw * efficiency, abs=1e-3), (
+        f"Cell intake {cell_intake:.3f} kW should equal cap x η = {charge_cap_kw * efficiency} kW"
+    )

--- a/custom_components/haeo/core/adapters/elements/tests/test_battery_model.py
+++ b/custom_components/haeo/core/adapters/elements/tests/test_battery_model.py
@@ -120,8 +120,8 @@ CREATE_CASES: Sequence[CreateCase] = [
                 "source": "network",
                 "target": "battery_main",
                 "segments": {
-                    "efficiency": {"segment_type": "efficiency", "efficiency": [0.95]},
                     "power_limit": {"segment_type": "power_limit", "max_power": [5.0]},
+                    "efficiency": {"segment_type": "efficiency", "efficiency": [0.95]},
                 },
             },
         ],
@@ -179,8 +179,8 @@ CREATE_CASES: Sequence[CreateCase] = [
                 "source": "network",
                 "target": "battery_normal",
                 "segments": {
-                    "efficiency": {"segment_type": "efficiency", "efficiency": [0.95]},
                     "power_limit": {"segment_type": "power_limit", "max_power": [5.0]},
+                    "efficiency": {"segment_type": "efficiency", "efficiency": [0.95]},
                 },
             },
         ],
@@ -238,8 +238,8 @@ CREATE_CASES: Sequence[CreateCase] = [
                 "source": "network",
                 "target": "battery_salvage",
                 "segments": {
-                    "efficiency": {"segment_type": "efficiency", "efficiency": [0.95]},
                     "power_limit": {"segment_type": "power_limit", "max_power": [4.0]},
+                    "efficiency": {"segment_type": "efficiency", "efficiency": [0.95]},
                 },
             },
         ],
@@ -303,9 +303,15 @@ OUTPUTS_CASES: Sequence[OutputsCase] = [
                 connection.CONNECTION_POWER: OutputData(
                     type=OutputType.POWER_FLOW, unit="kW", values=(0.5,), direction="+"
                 ),
+                connection.CONNECTION_POWER_OUT: OutputData(
+                    type=OutputType.POWER_FLOW, unit="kW", values=(0.5,), direction="+"
+                ),
             },
             "battery_no_balance:charge": {
                 connection.CONNECTION_POWER: OutputData(
+                    type=OutputType.POWER_FLOW, unit="kW", values=(1.0,), direction="-"
+                ),
+                connection.CONNECTION_POWER_OUT: OutputData(
                     type=OutputType.POWER_FLOW, unit="kW", values=(1.0,), direction="-"
                 ),
             },
@@ -382,6 +388,9 @@ OUTPUTS_CASES: Sequence[OutputsCase] = [
             },
             "battery_no_balance:discharge": {
                 connection.CONNECTION_POWER: OutputData(
+                    type=OutputType.POWER_FLOW, unit="kW", values=(0.5,), direction="+"
+                ),
+                connection.CONNECTION_POWER_OUT: OutputData(
                     type=OutputType.POWER_FLOW, unit="kW", values=(0.5,), direction="+"
                 ),
             },
@@ -466,9 +475,15 @@ OUTPUTS_CASES: Sequence[OutputsCase] = [
                 connection.CONNECTION_POWER: OutputData(
                     type=OutputType.POWER_FLOW, unit="kW", values=(0.5,), direction="+"
                 ),
+                connection.CONNECTION_POWER_OUT: OutputData(
+                    type=OutputType.POWER_FLOW, unit="kW", values=(0.5,), direction="+"
+                ),
             },
             "battery_with_thresholds:charge": {
                 connection.CONNECTION_POWER: OutputData(
+                    type=OutputType.POWER_FLOW, unit="kW", values=(1.0,), direction="-"
+                ),
+                connection.CONNECTION_POWER_OUT: OutputData(
                     type=OutputType.POWER_FLOW, unit="kW", values=(1.0,), direction="-"
                 ),
             },

--- a/custom_components/haeo/core/adapters/elements/tests/test_inverter_model.py
+++ b/custom_components/haeo/core/adapters/elements/tests/test_inverter_model.py
@@ -82,8 +82,8 @@ CREATE_CASES: Sequence[CreateCase] = [
                 "source": "network",
                 "target": "inverter_main",
                 "segments": {
-                    "efficiency": {"segment_type": "efficiency", "efficiency": 1.0},
                     "power_limit": {"segment_type": "power_limit", "max_power": [8.0]},
+                    "efficiency": {"segment_type": "efficiency", "efficiency": 1.0},
                 },
             },
         ],
@@ -121,8 +121,8 @@ CREATE_CASES: Sequence[CreateCase] = [
                 "source": "network",
                 "target": "inverter_simple",
                 "segments": {
-                    "efficiency": {"segment_type": "efficiency", "efficiency": 1.0},
                     "power_limit": {"segment_type": "power_limit", "max_power": [10.0]},
+                    "efficiency": {"segment_type": "efficiency", "efficiency": 1.0},
                 },
             },
         ],
@@ -142,6 +142,9 @@ OUTPUTS_CASES: Sequence[OutputsCase] = [
                 connection.CONNECTION_POWER: OutputData(
                     type=OutputType.POWER_FLOW, unit="kW", values=(5.0,), direction="+"
                 ),
+                connection.CONNECTION_POWER_OUT: OutputData(
+                    type=OutputType.POWER_FLOW, unit="kW", values=(5.0,), direction="+"
+                ),
                 connection.CONNECTION_SEGMENTS: {
                     "power_limit": {
                         "power_limit": OutputData(type=OutputType.SHADOW_PRICE, unit="$/kWh", values=(0.01,)),
@@ -150,6 +153,9 @@ OUTPUTS_CASES: Sequence[OutputsCase] = [
             },
             "inverter_main:ac_to_dc": {
                 connection.CONNECTION_POWER: OutputData(
+                    type=OutputType.POWER_FLOW, unit="kW", values=(3.0,), direction="-"
+                ),
+                connection.CONNECTION_POWER_OUT: OutputData(
                     type=OutputType.POWER_FLOW, unit="kW", values=(3.0,), direction="-"
                 ),
                 connection.CONNECTION_SEGMENTS: {
@@ -187,6 +193,9 @@ OUTPUTS_CASES: Sequence[OutputsCase] = [
             },
             "inverter_main:dc_to_ac": {
                 connection.CONNECTION_POWER: OutputData(
+                    type=OutputType.POWER_FLOW, unit="kW", values=(5.0,), direction="+"
+                ),
+                connection.CONNECTION_POWER_OUT: OutputData(
                     type=OutputType.POWER_FLOW, unit="kW", values=(5.0,), direction="+"
                 ),
                 connection.CONNECTION_SEGMENTS: {

--- a/custom_components/haeo/core/adapters/output_utils.py
+++ b/custom_components/haeo/core/adapters/output_utils.py
@@ -5,7 +5,7 @@ from typing import overload
 
 from custom_components.haeo.core.model import ModelOutputName, ModelOutputValue
 from custom_components.haeo.core.model.const import OutputType
-from custom_components.haeo.core.model.elements.connection import CONNECTION_POWER
+from custom_components.haeo.core.model.elements.connection import CONNECTION_POWER, CONNECTION_POWER_OUT
 from custom_components.haeo.core.model.output_data import OutputData
 
 
@@ -34,7 +34,11 @@ def connection_power(
     connection_outputs: Mapping[ModelOutputName, ModelOutputValue] | None,
     period_count: int,
 ) -> OutputData:
-    """Return a connection's power output, or zeros when the connection is absent.
+    """Return a connection's source-end (pre-segment) power output.
+
+    For a connection with an efficiency segment, this is the flow *before*
+    efficiency is applied. Use :func:`connection_power_out` for the post-
+    efficiency, target-end flow.
 
     Policy compilation drops connections that no tagged source can reach. Adapters
     still run for the configured element, so a pruned connection is treated as
@@ -45,4 +49,23 @@ def connection_power(
     return expect_output_data(connection_outputs[CONNECTION_POWER])
 
 
-__all__ = ["connection_power", "expect_output_data"]
+def connection_power_out(
+    connection_outputs: Mapping[ModelOutputName, ModelOutputValue] | None,
+    period_count: int,
+) -> OutputData:
+    """Return a connection's target-end (post-segment) power output.
+
+    For a connection with an efficiency segment, this is the flow *after*
+    efficiency is applied. Use :func:`connection_power` for the pre-
+    efficiency, source-end flow.
+
+    Policy compilation drops connections that no tagged source can reach. Adapters
+    still run for the configured element, so a pruned connection is treated as
+    carrying no flow rather than failing output extraction.
+    """
+    if connection_outputs is None:
+        return OutputData(type=OutputType.POWER_FLOW, unit="kW", values=[0.0] * period_count, direction="+")
+    return expect_output_data(connection_outputs[CONNECTION_POWER_OUT])
+
+
+__all__ = ["connection_power", "connection_power_out", "expect_output_data"]

--- a/custom_components/haeo/core/model/elements/connection.py
+++ b/custom_components/haeo/core/model/elements/connection.py
@@ -30,13 +30,17 @@ ELEMENT_TYPE: Final[ConnectionElementTypeName] = "connection"
 
 type ConnectionOutputName = Literal[
     "connection_power",
+    "connection_power_out",
     "segments",
 ]
 
 CONNECTION_POWER: Final = "connection_power"
+CONNECTION_POWER_OUT: Final = "connection_power_out"
 CONNECTION_SEGMENTS: Final = "segments"
 
-CONNECTION_OUTPUT_NAMES: Final[frozenset[ConnectionOutputName]] = frozenset((CONNECTION_POWER, CONNECTION_SEGMENTS))
+CONNECTION_OUTPUT_NAMES: Final[frozenset[ConnectionOutputName]] = frozenset(
+    (CONNECTION_POWER, CONNECTION_POWER_OUT, CONNECTION_SEGMENTS)
+)
 
 
 class ConnectionElementConfig(TypedDict):
@@ -257,11 +261,32 @@ class Connection[TOutputName: str](Element[TOutputName]):
 
     @output(name=CONNECTION_POWER)
     def _connection_power_output(self) -> OutputData:
-        """Power flow through this connection."""
+        """Power flow at the source end of the connection (pre-segment-transforms).
+
+        For a connection with an efficiency segment, this is the flow before
+        efficiency is applied. Adapters that need the post-efficiency,
+        target-end flow should use ``CONNECTION_POWER_OUT`` instead.
+        """
         return OutputData(
             type=OutputType.POWER_FLOW,
             unit="kW",
             values=self.extract_values(self.total_power_in),
+            direction="+",
+            priority=self.priority,
+        )
+
+    @output(name=CONNECTION_POWER_OUT)
+    def _connection_power_out_output(self) -> OutputData:
+        """Power flow at the target end of the connection (post-segment-transforms).
+
+        For a connection with an efficiency segment, this is the flow after
+        efficiency has been applied. Equals ``CONNECTION_POWER`` when the
+        chain has no transforming segments (passthrough only).
+        """
+        return OutputData(
+            type=OutputType.POWER_FLOW,
+            unit="kW",
+            values=self.extract_values(self.total_power_out),
             direction="+",
             priority=self.priority,
         )
@@ -288,6 +313,7 @@ class Connection[TOutputName: str](Element[TOutputName]):
 __all__ = [
     "CONNECTION_OUTPUT_NAMES",
     "CONNECTION_POWER",
+    "CONNECTION_POWER_OUT",
     "CONNECTION_SEGMENTS",
     "ELEMENT_TYPE",
     "Connection",


### PR DESCRIPTION
Fixes #478.

> Targeted against `v0.4.x`, not `main`: main is currently carrying the LP-ranging branch which has performance regressions on my horizon. Branched off the `v0.4.1` tag (`cfecb98`).

## Summary

Two related defects in how battery/inverter power was reported and constrained, both stemming from the same root cause: the model layer treated the electrochemical (cell) side and the bus side of a connection asymmetrically. OEM hybrid-inverter control surfaces (SigEnergy, Sungrow, Victron) specify both their max-power limits and their live monitoring on the bus side.

(Bus-side here means the source/target end of a connection that sits on the shared DC/AC bus the element is wired to — not the cell side. For a battery connected directly to the DC bus, "bus side" is the DC-bus end of its charge/discharge connections; for an inverter, the DC-bus end and AC-bus end as appropriate.)

## Part 1 — sensor side reporting

The `battery_power_active` sensor (and the inverter equivalent) previously mixed sides: discharge power was read from the electrochemical side of the discharge connection, while charge power was read from the bus side of the charge connection. The resulting signed `active = discharge − charge` was therefore neither cleanly electrochemical nor cleanly bus-side, and disagreed with the values reported by OEM live sensors.

A new model-layer output, `CONNECTION_POWER_OUT`, exposes the post-segment-transform target-end flow of a connection; `CONNECTION_POWER` continues to expose the pre-transform source-end flow. The battery and inverter adapters wire the three power sensors as follows:

  * `BATTERY_POWER_DISCHARGE` — electrochemical-side cell discharge rate
  * `BATTERY_POWER_CHARGE`    — electrochemical-side cell refill rate
  * `BATTERY_POWER_ACTIVE`    — bus-side net flow, signed (positive = exporting to bus)

  * `INVERTER_POWER_DC_TO_AC` — DC-side forward flow
  * `INVERTER_POWER_AC_TO_DC` — DC-side reverse flow
  * `INVERTER_POWER_ACTIVE`   — AC-side net flow, signed

## Part 2 — bus-side power cap on charge / ac_to_dc

Prior to this change, the charge connection used segment order `[efficiency, power_limit]`, which placed `max_power_target_source` on the electrochemical (post-efficiency) side. With η<1 this allowed the bus-side draw to exceed the OEM-declared charging limit by a factor of 1/η — e.g. a 21 kW SigEnergy `max_charging_limit` on a 90%-efficient battery produced ~23.3 kW of bus-side draw, contradicting OEM semantics.

Battery charge connection segments are now `[power_limit, efficiency]`, landing the cap on the bus (source-end) side. The discharge connection already capped bus-side via `[efficiency, power_limit]` per PR #297, so both directions now consistently bind the OEM control surface. The inverter `ac_to_dc` connection receives the symmetric treatment so its bus-side cap holds against the declared rating.

Sensor wiring is unaffected: source-end and target-end semantics of a connection are independent of internal segment ordering — `power_limit` adds a constraint without changing flow propagation — so the three sensors continue to report their declared sides correctly.

## Live validation

Captured from my deployment running this branch — SigEnergy hybrid inverter, battery wired to the DC bus, EV1 wired to the DC bus via a DC charger module.

### Battery charge — early scenario before SOC topped out

η_battery = 0.9, `max_charging_limit = 21 kW`. Earlier snapshot when the LP was driving the battery to its cap:

| | Before fix | After fix | OEM `sensor.sigen_inverter_battery_power` |
|---|---|---|---|
| `sensor.battery_active_power` | −23.33 kW | **−21.0 kW** | 20.85 kW |
| `sensor.battery_charge_power`  | 21.0 kW  | **18.9 kW** | n/a (cell-side not exposed by OEM) |

Before the fix, `battery_active_power` reported −23.33 kW (= cap / η), 12% above the OEM-declared limit. After the fix, both `active` and the OEM agree at ~21 kW, and `charge` (cells) lands at cap × η = 18.9 kW.

### EV1 DC-charger module saturated, battery idle at 99 % SOC

Latest snapshot (this branch live):

DC-charger module (bus → EV1, cap = 25 kW, η = 0.98):

| Sensor | Value | Side |
|---|---|---|
| `sensor.dcev_inverter_active_power`     | **−25.0 kW** | DC-bus side (cap binds here) |
| `sensor.dcev_inverter_ac_to_dc_power`   | 24.5 kW       | downstream of η (= 25 × 0.98) |
| OEM `sensor.sigen_inverter_dc_charger_output_power` | 24.946 kW | OEM-reported downstream flow |

EV1 charge connection (cap = 25 kW, η = 0.95):

| Sensor | Value | Side |
|---|---|---|
| `sensor.ev1_active_power`          | **−24.5 kW** | EV1-bus source-end (upstream cap is the binding one here, not this 25 kW) |
| `sensor.ev1_charge_power`          | **23.3 kW**  | EV1 cells (= 24.5 × 0.95) |
| `sensor.ev1_state_of_charge`       | 20.0 %       | — |

Battery sitting idle (SOC = 99 %, LP correctly holds):

| Sensor | Value |
|---|---|
| `sensor.battery_active_power`      | 0.0 kW |
| `sensor.battery_charge_power`      | 0.0 kW |
| `sensor.battery_state_of_charge`   | 99.0 % |
| OEM `sensor.sigen_inverter_battery_power` | 0.003 kW |

Pre-fix, the DC-charger module's 25 kW cap would have sat on the downstream side, allowing the DC-bus draw to climb to 25 / 0.98 ≈ 25.5 kW and exceeding the OEM-declared rating. Live values now agree with OEM telemetry to within sensor resolution.

## Tests

  * `test_sensors_report_correct_sides_on_discharge` — η=0.9 LP scenario, asserts `BATTERY_POWER_DISCHARGE` equals discharge-connection source-end and `BATTERY_POWER_ACTIVE` equals discharge-connection target-end.
  * `test_sensors_report_correct_sides_on_charge` — η=0.9 LP scenario, asserts `BATTERY_POWER_CHARGE` equals charge-connection target-end and `BATTERY_POWER_ACTIVE` equals `−source-end` of charge connection.
  * `test_sensor_sides_with_no_efficiency_loss` — η=1.0 sanity check.
  * `test_adapter_charge_cap_binds_bus_side` (new in this PR) — builds the production battery adapter with η=0.9 and a 10 kW charge cap, optimises a charge-profitable LP, and asserts the bus-side draw is exactly the cap and the electrochemical-side intake is `cap × η`.

Existing `test_battery_model` and `test_inverter_model` fixtures are extended to include the `CONNECTION_POWER_OUT` mirror of `CONNECTION_POWER`, and the charge / `ac_to_dc` segment-order fixtures are flipped to match the production order.

```
1748 passed, 2 skipped in 38.98s
```

`ruff check` and `ruff format` both clean.

## Refs
- Fixes hass-energy/haeo#478
- Builds on the precedent set by hass-energy/haeo#297 (discharge `power_limit` on post-efficiency side)

## Notes for review

I do not have admin on this repo so I cannot self-assign reviewers. Happy to rebase onto another branch if `v0.4.x` is not the right target.
