### PR TITLE
fix: read system health coordinator from runtime data

### DIFF
--- a/custom_components/haeo/system_health.py
+++ b/custom_components/haeo/system_health.py
@@ -43,11 +43,13 @@ async def async_system_health_info(hass: HomeAssistant) -> dict[str, Any]:
         hub_key = entry_name
 
         # Get coordinator from runtime data
-        coordinator = entry.runtime_data
+        runtime_data = entry.runtime_data
 
-        if coordinator is None:
+        if runtime_data is None or runtime_data.coordinator is None:
             health_info[f"{prefix}status"] = "coordinator_not_initialized"
             continue
+
+        coordinator = runtime_data.coordinator
 
         # Coordinator status
         health_info[f"{prefix}status"] = "ok" if coordinator.last_update_success else "update_failed"

--- a/custom_components/haeo/tests/test_system_health.py
+++ b/custom_components/haeo/tests/test_system_health.py
@@ -9,6 +9,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util
 import pytest
 
+from custom_components.haeo import HaeoRuntimeData
 from custom_components.haeo.const import (
     OUTPUT_NAME_OPTIMIZATION_COST,
     OUTPUT_NAME_OPTIMIZATION_DURATION,
@@ -58,6 +59,11 @@ def _make_coordinator_data(outputs: dict[str, Any]) -> CoordinatorData:
     )
 
 
+def _make_runtime_data(coordinator: HaeoDataUpdateCoordinator | None) -> HaeoRuntimeData:
+    """Create runtime data for system health tests."""
+    return HaeoRuntimeData(horizon_manager=Mock(), coordinator=coordinator)
+
+
 async def test_async_register_callback(hass: HomeAssistant) -> None:
     """The system health callback is registered."""
 
@@ -79,6 +85,20 @@ async def test_system_health_coordinator_not_initialized(hass: HomeAssistant) ->
     entry = MagicMock()
     entry.title = "HAEO Hub"
     entry.runtime_data = None
+
+    with patch.object(hass.config_entries, "async_entries", return_value=[entry]):
+        info = await async_system_health_info(hass)
+    assert info["HAEO Hub_status"] == "coordinator_not_initialized"
+
+
+async def test_system_health_runtime_data_without_coordinator(
+    hass: HomeAssistant,
+) -> None:
+    """Runtime data without a coordinator is identified explicitly."""
+
+    entry = MagicMock()
+    entry.title = "HAEO Hub"
+    entry.runtime_data = _make_runtime_data(coordinator=None)
 
     with patch.object(hass.config_entries, "async_entries", return_value=[entry]):
         info = await async_system_health_info(hass)
@@ -120,7 +140,7 @@ async def test_system_health_reports_coordinator_state(hass: HomeAssistant) -> N
         CONF_TIER_4_DURATION: DEFAULT_TIER_4_DURATION,
         CONF_TIER_4_COUNT: DEFAULT_TIER_4_COUNT,
     }
-    entry.runtime_data = coordinator
+    entry.runtime_data = _make_runtime_data(coordinator)
 
     with patch.object(hass.config_entries, "async_entries", return_value=[entry]):
         info = await async_system_health_info(hass)
@@ -155,7 +175,7 @@ async def test_system_health_detects_failed_updates(hass: HomeAssistant) -> None
         CONF_TIER_4_DURATION: DEFAULT_TIER_4_DURATION,
         CONF_TIER_4_COUNT: DEFAULT_TIER_4_COUNT,
     }
-    entry.runtime_data = coordinator
+    entry.runtime_data = _make_runtime_data(coordinator)
 
     with patch.object(hass.config_entries, "async_entries", return_value=[entry]):
         info = await async_system_health_info(hass)


### PR DESCRIPTION
## Summary
- read the system health coordinator from `entry.runtime_data.coordinator` instead of treating runtime data as the coordinator
- keep the existing `coordinator_not_initialized` status when runtime data or the coordinator is missing
- update system health tests to use `HaeoRuntimeData` and cover the missing-coordinator case

Fixes #471.

## Tests
- `uv run pytest custom_components/haeo/tests/test_system_health.py`
- `uv run ruff check custom_components/haeo/system_health.py custom_components/haeo/tests/test_system_health.py`
- `uv run ruff format --check custom_components/haeo/system_health.py custom_components/haeo/tests/test_system_health.py`