### PR TITLE
Plumb calendar values through stores, loader, and an HA event fetcher

### DIFF
--- a/custom_components/haeo/__init__.py
+++ b/custom_components/haeo/__init__.py
@@ -21,6 +21,7 @@ from homeassistant.helpers.translation import async_get_translations
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.setup import async_when_setup
 
+from custom_components.haeo.calendar_loader import CalendarInputLoader
 from custom_components.haeo.const import (
     DOMAIN,
     ELEMENT_TYPE_NETWORK,
@@ -384,6 +385,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: HaeoConfigEntry) -> bool
     # stores are the system's source of truth; entities wrap them for display
     # and the coordinator reads their resolved values.
     runtime_data.input_stores = build_input_stores(hass, entry, horizon_manager)
+
+    # Calendar-driven stores have no input entity to load them; a dedicated
+    # loader fetches upcoming events and keeps them aligned with the horizon.
+    calendar_loader = CalendarInputLoader(hass, runtime_data.input_stores, horizon_manager)
+    await calendar_loader.async_start()
+    entry.async_on_unload(calendar_loader.cleanup)
 
     # Create the coordinator from the same subentry snapshot used to build the
     # input stores, before setting up platforms. Platform setup and store

--- a/custom_components/haeo/calendar_loader.py
+++ b/custom_components/haeo/calendar_loader.py
@@ -1,0 +1,195 @@
+"""Load calendar-driven input stores by fetching upcoming calendar events.
+
+Home Assistant calendar entities only expose the current/next event in their
+state, so the core calendar loader cannot see the full horizon by itself.
+This module fetches upcoming events through the calendar integration's
+``async_get_events`` API and presents them to the core loader by wrapping the
+state machine so the calendar entity's state carries a ``haeo_events``
+attribute — the exact format captured for diagnostics replay.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from datetime import UTC, date, datetime
+import logging
+from typing import TYPE_CHECKING, Any
+
+from homeassistant.components.calendar import CalendarEntity
+from homeassistant.components.calendar.const import DOMAIN as CALENDAR_DOMAIN
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_component import EntityComponent
+from homeassistant.helpers.event import async_track_state_change_event
+from homeassistant.util import dt as dt_util
+
+from custom_components.haeo.core.data.loader.calendar import CalendarEventData, capture_calendar_events
+from custom_components.haeo.core.state import EntityState, StateMachine
+from custom_components.haeo.ha_state_machine import HomeAssistantStateMachine
+
+if TYPE_CHECKING:
+    from homeassistant.core import Event
+    from homeassistant.helpers.event import EventStateChangedData
+
+    from custom_components.haeo.core.data.input_store import InputStore
+    from custom_components.haeo.core.schema.calendar_value import CalendarEventDict
+    from custom_components.haeo.horizon import HorizonManager
+    from custom_components.haeo.input_stores import InputStoreMap
+
+_LOGGER = logging.getLogger(__name__)
+
+CALENDAR_EVENTS_ATTRIBUTE = "haeo_events"
+
+
+class _CalendarEventState:
+    """EntityState wrapper that injects fetched events into attributes."""
+
+    def __init__(self, base: EntityState, events: list[CalendarEventDict]) -> None:
+        self._base = base
+        self._events = events
+
+    @property
+    def entity_id(self) -> str:
+        """Entity identifier."""
+        return self._base.entity_id
+
+    @property
+    def state(self) -> str:
+        """Raw state string."""
+        return self._base.state
+
+    @property
+    def attributes(self) -> Mapping[str, Any]:
+        """Entity attributes with fetched events merged in."""
+        return {**self._base.attributes, CALENDAR_EVENTS_ATTRIBUTE: self._events}
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return serialized state representation including the events."""
+        base = self._base.as_dict()
+        attributes = dict(base.get("attributes", {}))
+        attributes[CALENDAR_EVENTS_ATTRIBUTE] = self._events
+        return {**base, "attributes": attributes}
+
+
+class CalendarStateMachine(StateMachine):
+    """State machine decorator that augments calendar entities with events."""
+
+    def __init__(self, base: StateMachine, events_by_entity: Mapping[str, list[CalendarEventDict]]) -> None:
+        """Initialize with a base state machine and per-entity event lists."""
+        self._base = base
+        self._events_by_entity = events_by_entity
+
+    def get(self, entity_id: str) -> EntityState | None:
+        """Return the entity state, with events merged for known calendars."""
+        state = self._base.get(entity_id)
+        if state is None:
+            return None
+        events = self._events_by_entity.get(entity_id)
+        if events is None:
+            return state
+        return _CalendarEventState(state, events)
+
+
+def _as_datetime(value: datetime | date) -> datetime:
+    """Convert calendar event boundaries (datetime or all-day date) to datetime."""
+    if isinstance(value, datetime):
+        return value
+    return dt_util.start_of_local_day(value)
+
+
+class CalendarInputLoader:
+    """Keeps calendar-driven input stores loaded with upcoming events.
+
+    Performs the initial load for every calendar-kind store and reloads on
+    calendar entity state changes and horizon updates, so trip windows stay
+    aligned with the optimization horizon as time advances.
+    """
+
+    def __init__(self, hass: HomeAssistant, stores: InputStoreMap, horizon_manager: HorizonManager) -> None:
+        """Initialize the loader over a prebuilt store map."""
+        self._hass = hass
+        self._horizon_manager = horizon_manager
+        self._stores: list[InputStore] = [store for store in stores.values() if store.source_kind == "calendar"]
+        self._unsubs: list[Callable[[], None]] = []
+
+    async def async_start(self) -> None:
+        """Subscribe to change sources and perform the initial load."""
+        if not self._stores:
+            return
+
+        entity_ids = sorted({eid for store in self._stores for eid in store.source_entity_ids})
+
+        @callback
+        def _on_state_change(_event: Event[EventStateChangedData]) -> None:
+            self._hass.async_create_task(self.async_load_all())
+
+        @callback
+        def _on_horizon_change() -> None:
+            self._hass.async_create_task(self.async_load_all())
+
+        self._unsubs.append(async_track_state_change_event(self._hass, entity_ids, _on_state_change))
+        self._unsubs.append(self._horizon_manager.subscribe(_on_horizon_change))
+
+        await self.async_load_all()
+
+    async def async_load_all(self) -> None:
+        """Fetch events for every calendar store and reload it."""
+        for store in self._stores:
+            await self._async_load_store(store)
+
+    async def _async_load_store(self, store: InputStore) -> None:
+        entity_id = store.source_entity_ids[0]
+        events = await self._async_fetch_events(entity_id)
+        sm = CalendarStateMachine(
+            HomeAssistantStateMachine(self._hass),
+            {entity_id: events} if events is not None else {},
+        )
+        await store.async_load(sm)
+
+    async def _async_fetch_events(self, entity_id: str) -> list[CalendarEventDict] | None:
+        """Fetch upcoming events over the horizon, serialized for the core loader.
+
+        Returns None when the calendar entity cannot be queried (integration not
+        loaded or entity missing), in which case no events are injected and the
+        core loader treats the calendar as empty.
+        """
+        timestamps = self._horizon_manager.get_forecast_timestamps()
+        if not timestamps:
+            return None
+        start = datetime.fromtimestamp(timestamps[0], tz=UTC)
+        end = datetime.fromtimestamp(timestamps[-1], tz=UTC)
+
+        component = self._hass.data.get(CALENDAR_DOMAIN)
+        if not isinstance(component, EntityComponent):
+            _LOGGER.debug("Calendar integration not loaded; no events for %s", entity_id)
+            return None
+        entity = component.get_entity(entity_id)
+        if not isinstance(entity, CalendarEntity):
+            _LOGGER.debug("Calendar entity %s not found; no events injected", entity_id)
+            return None
+
+        try:
+            calendar_events = await entity.async_get_events(self._hass, start, end)
+        except Exception:
+            _LOGGER.warning("Failed to fetch events from %s", entity_id, exc_info=True)
+            return None
+
+        events = [
+            CalendarEventData(
+                start=_as_datetime(event.start),
+                end=_as_datetime(event.end),
+                summary=event.summary,
+                location=event.location,
+                description=event.description,
+            )
+            for event in calendar_events
+        ]
+        return capture_calendar_events(events)
+
+    def cleanup(self) -> None:
+        """Unsubscribe from all change sources."""
+        for unsub in self._unsubs:
+            unsub()
+        self._unsubs.clear()
+
+
+__all__ = ["CALENDAR_EVENTS_ATTRIBUTE", "CalendarInputLoader", "CalendarStateMachine"]

--- a/custom_components/haeo/core/data/input_store.py
+++ b/custom_components/haeo/core/data/input_store.py
@@ -26,7 +26,7 @@ import numpy as np
 from custom_components.haeo.core.data.loader.calendar_resolver import CalendarBoundaryData
 from custom_components.haeo.core.data.loader.config_loader import is_percent_field, resolve_constant, resolve_field
 from custom_components.haeo.core.data.storage import Storage
-from custom_components.haeo.core.schema import as_calendar_value, as_entity_value
+from custom_components.haeo.core.schema import as_calendar_value, as_entity_value, is_calendar_value
 from custom_components.haeo.core.schema.field_hints import FieldHint
 from custom_components.haeo.core.state import EntityState, StateMachine
 
@@ -274,7 +274,10 @@ class InputStore:
             return False
 
         if self._source_kind == "calendar":
-            schema_value = as_calendar_value(self._source_entity_ids[0])
+            # Re-read the persisted value so captured events (diagnostics
+            # replay / scenarios) resolve instead of the live entity state.
+            persisted = self._storage.read()
+            schema_value = persisted if is_calendar_value(persisted) else as_calendar_value(self._source_entity_ids[0])
         else:
             schema_value = as_entity_value(self._source_entity_ids)
 

--- a/custom_components/haeo/core/data/input_store.py
+++ b/custom_components/haeo/core/data/input_store.py
@@ -19,15 +19,19 @@ import asyncio
 from collections.abc import Callable
 from enum import Enum
 import logging
-from typing import Any
+from typing import Any, Literal
 
 import numpy as np
 
+from custom_components.haeo.core.data.loader.calendar_resolver import CalendarBoundaryData
 from custom_components.haeo.core.data.loader.config_loader import is_percent_field, resolve_constant, resolve_field
 from custom_components.haeo.core.data.storage import Storage
-from custom_components.haeo.core.schema import as_entity_value
+from custom_components.haeo.core.schema import as_calendar_value, as_entity_value
 from custom_components.haeo.core.schema.field_hints import FieldHint
 from custom_components.haeo.core.state import EntityState, StateMachine
+
+type InputValue = bool | float | np.ndarray | CalendarBoundaryData
+type SourceKind = Literal["entity", "calendar"]
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -55,6 +59,8 @@ class InputStore:
         storage: Persistence binding backing this store.
         initial_value: Initial constant value (display units) for editable mode.
         negate: When True, values resolved from source entities are negated.
+        source_kind: How driven sources resolve: 'entity' loads sensor states,
+            'calendar' resolves the entity's events into boundary arrays.
 
     """
 
@@ -68,6 +74,7 @@ class InputStore:
         storage: Storage,
         initial_value: float | bool | None = None,
         negate: bool = False,
+        source_kind: SourceKind = "entity",
     ) -> None:
         """Initialize the input store."""
         self._mode = mode
@@ -75,6 +82,7 @@ class InputStore:
         self._hint = hint
         self._get_forecast_timestamps = get_forecast_timestamps
         self._storage = storage
+        self._source_kind: SourceKind = source_kind
 
         # When True, values resolved from source entities are negated so the
         # optimization sees the running cost's negative. Constant (editable)
@@ -83,7 +91,7 @@ class InputStore:
         self._negate = negate
 
         self._constant: float | bool | None = initial_value
-        self._value: bool | float | np.ndarray | None = None
+        self._value: InputValue | None = None
         self._available = False
         self._loaded_timestamps: tuple[float, ...] = ()
         self._captured_source_states: dict[str, EntityState] = {}
@@ -106,6 +114,11 @@ class InputStore:
         return self._source_entity_ids
 
     @property
+    def source_kind(self) -> SourceKind:
+        """Return how driven sources resolve ('entity' or 'calendar')."""
+        return self._source_kind
+
+    @property
     def hint(self) -> FieldHint:
         """Return the field hint describing this store's shape."""
         return self._hint
@@ -123,11 +136,12 @@ class InputStore:
     # --- Values ---
 
     @property
-    def value(self) -> bool | float | np.ndarray | None:
+    def value(self) -> InputValue | None:
         """Return the resolved value in optimization units.
 
         For time-series numeric fields this is a numpy array; for scalar fields
-        a float; for boolean fields a bool. ``None`` when not loaded.
+        a float; for boolean fields a bool; for calendar fields a
+        ``CalendarBoundaryData`` mapping. ``None`` when not loaded.
         """
         return self._value
 
@@ -149,7 +163,7 @@ class InputStore:
         first value for time-series fields.
         """
         value = self._value
-        if value is None:
+        if value is None or isinstance(value, dict):
             return None
         if isinstance(value, bool):
             return value
@@ -163,7 +177,7 @@ class InputStore:
         Percentage fields are scaled back to 0-100. Booleans pass through.
         """
         value = self._value
-        if value is None:
+        if value is None or isinstance(value, dict):
             return None
         if isinstance(value, bool):
             return (value,)
@@ -259,10 +273,15 @@ class InputStore:
             self._available = False
             return False
 
+        if self._source_kind == "calendar":
+            schema_value = as_calendar_value(self._source_entity_ids[0])
+        else:
+            schema_value = as_entity_value(self._source_entity_ids)
+
         forecast_timestamps = self._get_forecast_timestamps()
         try:
             resolved = resolve_field(
-                as_entity_value(self._source_entity_ids),
+                schema_value,
                 self._hint,
                 sm,
                 list(forecast_timestamps),
@@ -276,7 +295,7 @@ class InputStore:
             self._available = False
             return False
 
-        if resolved is None or not isinstance(resolved, (bool, float, int, np.ndarray)):
+        if resolved is None or not isinstance(resolved, (bool, float, int, np.ndarray, dict)):
             _LOGGER.debug(
                 "Load returned no value from sources %s; keeping previous value",
                 self._source_entity_ids,
@@ -288,7 +307,7 @@ class InputStore:
             self._available = False
             return False
 
-        if self._negate and not isinstance(resolved, bool):
+        if self._negate and not isinstance(resolved, (bool, dict)):
             resolved = -resolved
 
         self._value = resolved
@@ -326,6 +345,7 @@ def create_input_store(
 
     Reads the persisted schema value to determine mode and initial state:
     - {"type": "entity", "value": [...]} → DRIVEN mode
+    - {"type": "calendar", "value": "..."} → DRIVEN mode resolving calendar events
     - {"type": "constant", "value": X} → EDITABLE mode with that value
     - bare bool/int/float → EDITABLE mode with that value
     - {"type": "none"} or None → EDITABLE mode with no value
@@ -344,6 +364,16 @@ def create_input_store(
                 get_forecast_timestamps=get_forecast_timestamps,
                 storage=storage,
                 negate=negate,
+            )
+        case {"type": "calendar", "value": str(entity_id)}:
+            return InputStore(
+                mode=InputMode.DRIVEN,
+                source_entity_ids=[entity_id],
+                hint=hint,
+                get_forecast_timestamps=get_forecast_timestamps,
+                storage=storage,
+                negate=negate,
+                source_kind="calendar",
             )
         case {"type": "constant", "value": constant}:
             return InputStore(
@@ -389,4 +419,4 @@ def create_input_store(
             raise RuntimeError(msg)
 
 
-__all__ = ["InputMode", "InputStore", "create_input_store"]
+__all__ = ["InputMode", "InputStore", "InputValue", "SourceKind", "create_input_store"]

--- a/custom_components/haeo/core/data/loader/calendar_resolver.py
+++ b/custom_components/haeo/core/data/loader/calendar_resolver.py
@@ -1,0 +1,143 @@
+"""Resolve calendar schema values into horizon-aligned boundary arrays.
+
+Bridges the calendar event loader and window fuser to the field-resolution
+pipeline: a ``CalendarValue`` plus a ``CalendarFieldHint`` become a
+``CalendarBoundaryData`` bundle of numpy arrays aligned to the optimization
+horizon boundaries.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Final, TypedDict
+
+import numpy as np
+
+from custom_components.haeo.core.data.loader.calendar import (
+    CalendarWindow,
+    EventValueFn,
+    extract_calendar_windows,
+    load_calendar_events,
+    make_distance_extractor,
+    make_field_fallback_extractor,
+    make_presence_extractor,
+    parse_number,
+)
+from custom_components.haeo.core.data.util.calendar_fuser import (
+    fill_none,
+    fuse_window_edges_to_boundaries,
+    fuse_windows_to_boundaries,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from numpy.typing import NDArray
+
+    from custom_components.haeo.core.schema.calendar_value import CalendarValue
+    from custom_components.haeo.core.schema.field_hints import CalendarFieldHint
+    from custom_components.haeo.core.state import StateMachine
+
+# Kilometres per supported distance unit, used to normalize parsed distances
+# without importing Home Assistant's unit converters into the core layer.
+_KM_PER_UNIT: Final[dict[str, float]] = {
+    "km": 1.0,
+    "mi": 1.609344,
+    "m": 0.001,
+    "ft": 0.0003048,
+    "yd": 0.0009144,
+}
+
+
+class CalendarBoundaryData(TypedDict):
+    """Horizon-aligned arrays resolved from a calendar field.
+
+    All arrays have n+1 entries, one per horizon boundary. Values are the
+    per-event numbers extracted by the field's calendar parser (distances are
+    normalized to kilometres).
+
+    Attributes:
+        presence: 1.0 at boundaries covered by any event window, else 0.0.
+        value_span: Sum of active window values at each boundary, 0.0 outside.
+        value_edge_start: Each window's value placed at its start boundary
+            (floored to the containing period), summed on collision.
+        value_edge_end: Each window's value placed at its end boundary
+            (ceiled to the containing period), summed on collision.
+
+    """
+
+    presence: NDArray[np.float64]
+    value_span: NDArray[np.float64]
+    value_edge_start: NDArray[np.float64]
+    value_edge_end: NDArray[np.float64]
+
+
+def is_calendar_boundary_data(value: object) -> bool:
+    """Return True when *value* looks like resolved calendar boundary data."""
+    return isinstance(value, dict) and set(value) == {
+        "presence",
+        "value_span",
+        "value_edge_start",
+        "value_edge_end",
+    }
+
+
+def _convert_distance(value: float, from_unit: str, to_unit: str) -> float:
+    """Convert a distance between supported units via the kilometre table."""
+    return value * _KM_PER_UNIT[from_unit] / _KM_PER_UNIT[to_unit]
+
+
+def _extractor_for(hint: CalendarFieldHint) -> EventValueFn:
+    """Return the event value extractor selected by a calendar hint."""
+    if hint.parser == "distance":
+        return make_distance_extractor(
+            energy_per_distance=1.0,
+            target_unit="km",
+            convert_distance=_convert_distance,
+        )
+    if hint.parser == "number":
+        return make_field_fallback_extractor(parse_number)
+    return make_presence_extractor()
+
+
+def resolve_calendar_field(
+    value: CalendarValue,
+    calendar_hint: CalendarFieldHint,
+    sm: StateMachine,
+    forecast_times: Sequence[float],
+) -> CalendarBoundaryData | None:
+    """Resolve a calendar schema value into horizon-aligned boundary arrays.
+
+    Returns None when the calendar entity is unavailable and no captured
+    events exist, so the caller can mark the field as not loaded. An
+    available calendar with no events resolves to all-zero arrays.
+    """
+    if value.get("events") is None and sm.get(value["value"]) is None:
+        return None
+
+    events = load_calendar_events(value, sm)
+    windows = extract_calendar_windows(events, _extractor_for(calendar_hint))
+    boundaries = [datetime.fromtimestamp(ts, tz=UTC) for ts in forecast_times]
+
+    presence_windows = [CalendarWindow(start=w.start, end=w.end, value=1.0) for w in windows]
+    presence = np.minimum(
+        np.array(fill_none(fuse_windows_to_boundaries(presence_windows, boundaries), 0.0), dtype=np.float64),
+        1.0,
+    )
+
+    def _fused(values: list[float | None]) -> NDArray[np.float64]:
+        return np.array(fill_none(values, 0.0), dtype=np.float64)
+
+    return CalendarBoundaryData(
+        presence=presence,
+        value_span=_fused(fuse_windows_to_boundaries(windows, boundaries)),
+        value_edge_start=_fused(fuse_window_edges_to_boundaries(windows, boundaries, "start")),
+        value_edge_end=_fused(fuse_window_edges_to_boundaries(windows, boundaries, "end")),
+    )
+
+
+__all__ = [
+    "CalendarBoundaryData",
+    "is_calendar_boundary_data",
+    "resolve_calendar_field",
+]

--- a/custom_components/haeo/core/data/loader/config_loader.py
+++ b/custom_components/haeo/core/data/loader/config_loader.py
@@ -17,6 +17,7 @@ from custom_components.haeo.core.data.util.forecast_combiner import combine_sens
 from custom_components.haeo.core.data.util.forecast_fuser import fuse_to_boundaries, fuse_to_intervals
 from custom_components.haeo.core.model.const import OutputType
 from custom_components.haeo.core.schema import SchemaValue
+from custom_components.haeo.core.schema.calendar_value import is_calendar_value
 from custom_components.haeo.core.schema.constant_value import is_constant_value
 from custom_components.haeo.core.schema.elements import ELEMENT_CONFIG_SCHEMAS, ElementConfigData, ElementConfigSchema
 from custom_components.haeo.core.schema.entity_value import is_entity_value
@@ -29,6 +30,7 @@ from custom_components.haeo.core.schema.field_hints import (
 from custom_components.haeo.core.schema.none_value import is_none_value
 from custom_components.haeo.core.state import StateMachine
 
+from .calendar_resolver import CalendarBoundaryData, resolve_calendar_field
 from .sensor_loader import load_sensors
 
 _PERCENT_OUTPUT_TYPES = frozenset({OutputType.STATE_OF_CHARGE, OutputType.EFFICIENCY})
@@ -232,7 +234,7 @@ def resolve_field(
     hint: FieldHint,
     sm: StateMachine,
     forecast_times: Sequence[float],
-) -> _Sentinel | bool | float | np.ndarray | None:
+) -> _Sentinel | bool | float | np.ndarray | CalendarBoundaryData | None:
     """Resolve a single field value based on its schema type and hint metadata.
 
     Shared by the config loader (whole-element resolution) and ``InputStore``
@@ -243,6 +245,11 @@ def resolve_field(
 
     if isinstance(value, bool):
         return value
+
+    if is_calendar_value(value):
+        if hint.calendar is None:
+            return None
+        return resolve_calendar_field(value, hint.calendar, sm, forecast_times)
 
     if is_constant_value(value):
         unwrapped: float | bool | Sequence[str] = value["value"]

--- a/custom_components/haeo/core/data/loader/extractors/__init__.py
+++ b/custom_components/haeo/core/data/loader/extractors/__init__.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Sequence
 from enum import StrEnum
-from typing import NamedTuple
+from typing import Final, NamedTuple
 
 from custom_components.haeo.core.state import EntityState
 from custom_components.haeo.core.units import DeviceClass, UnitOfMeasurement, convert_to_base_unit
@@ -65,6 +65,19 @@ FORMATS: dict[ExtractorFormat, DataExtractor] = {
 }
 
 
+# Binary sensor states mapped to numeric values so availability-style
+# sources (e.g. an EV charger's "connected" binary sensor) load as 1/0.
+_BINARY_STATES: Final[dict[str, float]] = {"on": 1.0, "true": 1.0, "off": 0.0, "false": 0.0}
+
+
+def _parse_scalar_state(raw: str) -> float:
+    """Parse a state string as a float, mapping binary on/off states to 1/0."""
+    mapped = _BINARY_STATES.get(raw.strip().lower())
+    if mapped is not None:
+        return mapped
+    return float(raw)
+
+
 class ExtractedData(NamedTuple):
     """Container for extracted data and metadata."""
 
@@ -104,7 +117,7 @@ def extract(state: EntityState) -> ExtractedData:
         data, unit, device_class = volcast.Parser.extract(state)
     else:
         # If no extractor matched read the state as a single float value
-        data = float(state.state)
+        data = _parse_scalar_state(state.state)
         unit = state.attributes.get("unit_of_measurement")
         device_class_attr = state.attributes.get("device_class")
         device_class = DeviceClass.of(device_class_attr)

--- a/custom_components/haeo/core/data/loader/tests/test_calendar_resolver.py
+++ b/custom_components/haeo/core/data/loader/tests/test_calendar_resolver.py
@@ -1,0 +1,132 @@
+"""Tests for resolving calendar schema values into boundary arrays."""
+
+import numpy as np
+
+from conftest import FakeEntityState, FakeStateMachine
+from custom_components.haeo.core.data.loader.calendar_resolver import is_calendar_boundary_data, resolve_calendar_field
+from custom_components.haeo.core.schema.calendar_value import CalendarValue, as_calendar_value
+from custom_components.haeo.core.schema.field_hints import CalendarFieldHint
+
+# Hourly boundaries: 4 boundaries defining 3 periods, starting at epoch 0 (UTC).
+BOUNDARY_TIMES: tuple[float, ...] = (0.0, 3600.0, 7200.0, 10800.0)
+
+ENTITY_ID = "calendar.trips"
+
+
+def _calendar_value(events: list[dict[str, str | None]] | None) -> CalendarValue:
+    """Build a calendar schema value with optional captured events."""
+    value = as_calendar_value(ENTITY_ID)
+    if events is not None:
+        value["events"] = events  # type: ignore[typeddict-item]  # test fixtures use plain dicts
+    return value
+
+
+def _event(start_ts: float, end_ts: float, location: str | None = None) -> dict[str, str | None]:
+    """Build a captured event dict spanning the given epoch seconds."""
+    from datetime import UTC, datetime  # noqa: PLC0415
+
+    return {
+        "start": datetime.fromtimestamp(start_ts, tz=UTC).isoformat(),
+        "end": datetime.fromtimestamp(end_ts, tz=UTC).isoformat(),
+        "summary": "Trip",
+        "location": location,
+        "description": None,
+    }
+
+
+def test_distance_event_produces_boundary_arrays() -> None:
+    """A distance event fills presence and value arrays at covered boundaries."""
+    value = _calendar_value([_event(3600.0, 7200.0, location="50 km")])
+    result = resolve_calendar_field(value, CalendarFieldHint(parser="distance"), FakeStateMachine({}), BOUNDARY_TIMES)
+
+    assert result is not None
+    assert is_calendar_boundary_data(result)
+    np.testing.assert_allclose(result["presence"], [0.0, 1.0, 0.0, 0.0])
+    np.testing.assert_allclose(result["value_span"], [0.0, 50.0, 0.0, 0.0])
+    np.testing.assert_allclose(result["value_edge_start"], [0.0, 50.0, 0.0, 0.0])
+    np.testing.assert_allclose(result["value_edge_end"], [0.0, 0.0, 50.0, 0.0])
+
+
+def test_distance_units_normalize_to_km() -> None:
+    """Distances parsed in other units are converted to kilometres."""
+    value = _calendar_value([_event(0.0, 3600.0, location="10 mi")])
+    result = resolve_calendar_field(value, CalendarFieldHint(parser="distance"), FakeStateMachine({}), BOUNDARY_TIMES)
+
+    assert result is not None
+    np.testing.assert_allclose(result["value_edge_start"][0], 16.09344)
+
+
+def test_presence_parser_ignores_event_text() -> None:
+    """Presence parser marks windows with value 1.0 regardless of text."""
+    value = _calendar_value([_event(0.0, 7200.0, location=None)])
+    result = resolve_calendar_field(value, CalendarFieldHint(parser="presence"), FakeStateMachine({}), BOUNDARY_TIMES)
+
+    assert result is not None
+    np.testing.assert_allclose(result["presence"], [1.0, 1.0, 0.0, 0.0])
+    np.testing.assert_allclose(result["value_span"], [1.0, 1.0, 0.0, 0.0])
+
+
+def test_number_parser_reads_plain_numbers() -> None:
+    """Number parser extracts a bare numeric value from event text."""
+    value = _calendar_value([_event(0.0, 3600.0, location="7.5")])
+    result = resolve_calendar_field(value, CalendarFieldHint(parser="number"), FakeStateMachine({}), BOUNDARY_TIMES)
+
+    assert result is not None
+    np.testing.assert_allclose(result["value_span"][0], 7.5)
+
+
+def test_overlapping_events_clip_presence_and_sum_values() -> None:
+    """Overlapping events sum their values but presence stays binary."""
+    value = _calendar_value(
+        [
+            _event(0.0, 3600.0, location="10 km"),
+            _event(0.0, 3600.0, location="20 km"),
+        ]
+    )
+    result = resolve_calendar_field(value, CalendarFieldHint(parser="distance"), FakeStateMachine({}), BOUNDARY_TIMES)
+
+    assert result is not None
+    np.testing.assert_allclose(result["presence"][0], 1.0)
+    np.testing.assert_allclose(result["value_span"][0], 30.0)
+    np.testing.assert_allclose(result["value_edge_start"][0], 30.0)
+
+
+def test_missing_entity_without_captured_events_returns_none() -> None:
+    """No entity state and no captured events means the field is not loaded."""
+    value = _calendar_value(None)
+    result = resolve_calendar_field(value, CalendarFieldHint(), FakeStateMachine({}), BOUNDARY_TIMES)
+
+    assert result is None
+
+
+def test_available_entity_without_events_resolves_to_zeros() -> None:
+    """An available calendar entity with no events produces all-zero arrays."""
+    sm = FakeStateMachine({ENTITY_ID: FakeEntityState(ENTITY_ID, "off", {})})
+    result = resolve_calendar_field(_calendar_value(None), CalendarFieldHint(), sm, BOUNDARY_TIMES)
+
+    assert result is not None
+    np.testing.assert_allclose(result["presence"], np.zeros(4))
+    np.testing.assert_allclose(result["value_span"], np.zeros(4))
+
+
+def test_entity_events_attribute_is_used_when_present() -> None:
+    """Events injected into the entity's haeo_events attribute are resolved."""
+    sm = FakeStateMachine(
+        {ENTITY_ID: FakeEntityState(ENTITY_ID, "on", {"haeo_events": [_event(0.0, 3600.0, location="5 km")]})}
+    )
+    result = resolve_calendar_field(
+        _calendar_value(None),
+        CalendarFieldHint(parser="distance"),
+        sm,
+        BOUNDARY_TIMES,
+    )
+
+    assert result is not None
+    np.testing.assert_allclose(result["value_span"][0], 5.0)
+
+
+def test_is_calendar_boundary_data_rejects_other_values() -> None:
+    """The boundary-data check rejects unrelated dicts and scalars."""
+    assert not is_calendar_boundary_data({"presence": []})
+    assert not is_calendar_boundary_data(1.0)
+    assert not is_calendar_boundary_data(None)

--- a/custom_components/haeo/core/data/tests/test_input_store.py
+++ b/custom_components/haeo/core/data/tests/test_input_store.py
@@ -16,7 +16,7 @@ from conftest import FakeEntityState, FakeStateMachine
 from custom_components.haeo.core.data.input_store import InputMode, create_input_store
 from custom_components.haeo.core.model.const import OutputType
 from custom_components.haeo.core.schema import as_constant_value, as_entity_value
-from custom_components.haeo.core.schema.field_hints import FieldHint
+from custom_components.haeo.core.schema.field_hints import CalendarFieldHint, FieldHint
 
 FORECAST_TIMESTAMPS: tuple[float, ...] = (0.0, 300.0, 600.0)
 
@@ -365,3 +365,57 @@ def test_horizon_start_scalar_returns_none() -> None:
     store.refresh()
 
     assert store.horizon_start is None
+
+
+# --- Calendar-driven stores ---
+
+
+def _make_calendar_store() -> Any:
+    """Build a calendar-driven store with a presence parser hint."""
+    storage = _MemStorage({"type": "calendar", "value": "calendar.trips"})
+    hint = FieldHint(
+        output_type=OutputType.ENERGY,
+        time_series=True,
+        boundaries=True,
+        calendar=CalendarFieldHint(parser="presence"),
+    )
+    return create_input_store(storage=storage, hint=hint, get_forecast_timestamps=_timestamps)
+
+
+def test_create_input_store_calendar_is_driven() -> None:
+    """Calendar schema values create driven stores with calendar source kind."""
+    store = _make_calendar_store()
+
+    assert store.mode == InputMode.DRIVEN
+    assert store.source_kind == "calendar"
+    assert store.source_entity_ids == ["calendar.trips"]
+
+
+async def test_calendar_store_loads_boundary_data() -> None:
+    """A calendar store resolves injected events into boundary arrays."""
+    store = _make_calendar_store()
+    event = {
+        "start": "1970-01-01T00:00:00+00:00",
+        "end": "1970-01-01T00:05:00+00:00",
+        "summary": "Trip",
+        "location": None,
+        "description": None,
+    }
+    sm = FakeStateMachine({"calendar.trips": FakeEntityState("calendar.trips", "on", {"haeo_events": [event]})})
+
+    assert await store.async_load(sm)
+    assert store.available
+    value = store.value
+    assert isinstance(value, dict)
+    np.testing.assert_allclose(value["presence"], [1.0, 0.0, 0.0])
+    assert store.native_value is None
+    assert store.display_values is None
+    assert store.forecast_timestamps == FORECAST_TIMESTAMPS
+
+
+async def test_calendar_store_missing_entity_is_unavailable() -> None:
+    """A calendar store with no entity state fails to load."""
+    store = _make_calendar_store()
+
+    assert not await store.async_load(FakeStateMachine({}))
+    assert not store.available

--- a/custom_components/haeo/core/data/tests/test_input_store.py
+++ b/custom_components/haeo/core/data/tests/test_input_store.py
@@ -419,3 +419,34 @@ async def test_calendar_store_missing_entity_is_unavailable() -> None:
 
     assert not await store.async_load(FakeStateMachine({}))
     assert not store.available
+
+
+async def test_calendar_store_replays_captured_events() -> None:
+    """Captured events in the persisted value resolve without entity state."""
+    storage = _MemStorage(
+        {
+            "type": "calendar",
+            "value": "calendar.trips",
+            "events": [
+                {
+                    "start": "1970-01-01T00:00:00+00:00",
+                    "end": "1970-01-01T00:05:00+00:00",
+                    "summary": "Trip",
+                    "location": None,
+                    "description": None,
+                }
+            ],
+        }
+    )
+    hint = FieldHint(
+        output_type=OutputType.ENERGY,
+        time_series=True,
+        boundaries=True,
+        calendar=CalendarFieldHint(parser="presence"),
+    )
+    store = create_input_store(storage=storage, hint=hint, get_forecast_timestamps=_timestamps)
+
+    assert await store.async_load(FakeStateMachine({}))
+    value = store.value
+    assert isinstance(value, dict)
+    np.testing.assert_allclose(value["presence"], [1.0, 0.0, 0.0])

--- a/custom_components/haeo/core/schema/field_hints.py
+++ b/custom_components/haeo/core/schema/field_hints.py
@@ -12,6 +12,22 @@ from custom_components.haeo.core.model.const import OutputType
 
 
 @dataclass(frozen=True, slots=True)
+class CalendarFieldHint:
+    """Metadata for a config field driven by a calendar entity.
+
+    Attributes:
+        parser: How a numeric value is extracted from each calendar event:
+            - 'distance': parse a distance (e.g. "50 km") from the event text,
+              normalized to kilometres.
+            - 'number': parse a plain number from the event text.
+            - 'presence': value 1.0 for every event regardless of text.
+
+    """
+
+    parser: Literal["distance", "number", "presence"] = "presence"
+
+
+@dataclass(frozen=True, slots=True)
 class FieldHint:
     """Metadata for a config field that becomes an input entity.
 
@@ -28,6 +44,8 @@ class FieldHint:
         default_value: Value to pre-fill when default_mode='value'.
         force_required: Force value to be required, overriding schema optionality.
         device_type: Optional device type override for sub-device inputs.
+        calendar: When set, the field accepts a calendar entity whose events are
+            resolved into horizon-aligned arrays using this hint.
 
     """
 
@@ -42,6 +60,7 @@ class FieldHint:
     default_value: float | bool | None = None
     force_required: bool | None = None
     device_type: str | None = None
+    calendar: CalendarFieldHint | None = None
 
 
 @dataclass(frozen=True, slots=True)

--- a/custom_components/haeo/elements/field_hints.py
+++ b/custom_components/haeo/elements/field_hints.py
@@ -185,6 +185,7 @@ def _build_field_info(
             defaults=input_defaults,
             force_required=hint.force_required,
             device_type=hint.device_type,
+            calendar=hint.calendar,
         )
 
     defaults = OUTPUT_TYPE_DEFAULTS[hint.output_type]
@@ -206,4 +207,5 @@ def _build_field_info(
         defaults=input_defaults,
         force_required=hint.force_required,
         device_type=hint.device_type,
+        calendar=hint.calendar,
     )

--- a/custom_components/haeo/elements/input_fields.py
+++ b/custom_components/haeo/elements/input_fields.py
@@ -12,6 +12,7 @@ from homeassistant.components.number import NumberEntityDescription
 from homeassistant.components.switch import SwitchEntityDescription
 
 from custom_components.haeo.core.model.const import OutputType
+from custom_components.haeo.core.schema.field_hints import CalendarFieldHint
 
 
 @dataclass(frozen=True, slots=True)
@@ -51,6 +52,8 @@ class InputFieldInfo[T: (NumberEntityDescription, SwitchEntityDescription)]:
         boundaries: Whether time series values are at boundaries (n+1 values) vs intervals (n values)
         defaults: Default pre-selection behavior for config flow fields
         device_type: Optional device type override for sub-device inputs
+        calendar: When set, the field is driven by a calendar entity and gets
+            no input entity of its own
 
     Note:
         Whether a field is optional (can be disabled in config flow) is determined
@@ -70,6 +73,7 @@ class InputFieldInfo[T: (NumberEntityDescription, SwitchEntityDescription)]:
     force_required: bool | None = None
     # Optional device type for sub-device association
     device_type: str | None = None
+    calendar: CalendarFieldHint | None = None
 
 
 type InputFieldSection = Mapping[str, InputFieldInfo[Any]]

--- a/custom_components/haeo/flows/field_schema.py
+++ b/custom_components/haeo/flows/field_schema.py
@@ -33,6 +33,7 @@ from custom_components.haeo.core.schema import (
     VALUE_TYPE_CONSTANT,
     VALUE_TYPE_ENTITY,
     VALUE_TYPE_NONE,
+    as_calendar_value,
     as_constant_value,
     as_entity_value,
     as_none_value,
@@ -365,6 +366,15 @@ def build_choose_field_entries(
             msg = f"Missing schema metadata for field '{field_info.field_name}'"
             raise RuntimeError(msg)
         is_optional = schema_info.is_optional and not field_info.force_required
+
+        # Calendar-driven fields render as a plain calendar entity picker
+        # rather than a choose selector (no constant form exists).
+        if field_info.calendar is not None:
+            calendar_selector = EntitySelector(EntitySelectorConfig(domain="calendar", multiple=False))
+            marker = vol.Optional(field_info.field_name) if is_optional else vol.Required(field_info.field_name)
+            entries[field_info.field_name] = (marker, calendar_selector)
+            continue
+
         allowed_choices = _get_allowed_choices(schema_info, field_info)
         include_entities = inclusion_map.get(field_info.field_name)
         preferred = get_preferred_choice(field_info, current_data, allowed_choices=allowed_choices)
@@ -595,6 +605,8 @@ def get_choose_default(
 
     if is_entity_value(current_value):
         return current_value["value"]
+    if is_calendar_value(current_value):
+        return current_value["value"]
     if is_constant_value(current_value):
         return current_value["value"]
     if is_none_value(current_value):
@@ -643,6 +655,15 @@ def convert_choose_data_to_config(
         if field_name in exclude_keys:
             continue
         if field_name not in field_names:
+            continue
+
+        # Calendar fields store a calendar schema value from the entity picker
+        if input_fields[field_name].calendar is not None:
+            entity_id = value[0] if isinstance(value, list) and value else value
+            if isinstance(entity_id, str) and entity_id:
+                config[field_name] = as_calendar_value(entity_id)
+            else:
+                config[field_name] = as_none_value()
             continue
 
         # Disabled/none choice

--- a/custom_components/haeo/flows/tests/test_field_schema.py
+++ b/custom_components/haeo/flows/tests/test_field_schema.py
@@ -12,13 +12,16 @@ import voluptuous as vol
 from custom_components.haeo.const import DOMAIN
 from custom_components.haeo.core.model.const import OutputType
 from custom_components.haeo.core.schema import (
+    CalendarValue,
     ConstantValue,
     EntityValue,
     NoneValue,
+    as_calendar_value,
     as_constant_value,
     as_entity_value,
     as_none_value,
 )
+from custom_components.haeo.core.schema.field_hints import CalendarFieldHint
 from custom_components.haeo.elements.field_schema import FieldSchemaInfo
 from custom_components.haeo.elements.input_fields import InputFieldDefaults, InputFieldInfo
 from custom_components.haeo.flows.field_schema import (
@@ -1352,3 +1355,85 @@ def test_convert_sectioned_choose_data_to_config_handles_non_mapping_section(
     config = convert_sectioned_choose_data_to_config({"inputs": "invalid"}, input_fields, sections)
 
     assert config == {"inputs": {}}
+
+
+# --- Tests for calendar-driven fields ---
+
+
+def _calendar_field() -> InputFieldInfo[NumberEntityDescription]:
+    """Create a calendar-driven input field for testing."""
+    return InputFieldInfo(
+        field_name="window_calendar",
+        entity_description=NumberEntityDescription(key="window_calendar"),
+        output_type=OutputType.ENERGY,
+        time_series=True,
+        boundaries=True,
+        calendar=CalendarFieldHint(parser="number"),
+    )
+
+
+def test_calendar_field_renders_a_calendar_entity_selector() -> None:
+    """Calendar fields get a plain entity picker, not a choose selector."""
+    field = _calendar_field()
+
+    entries = build_choose_field_entries(
+        _field_map(field),
+        field_schema={"window_calendar": FieldSchemaInfo(value_type=CalendarValue, is_optional=False)},
+        inclusion_map={},
+    )
+
+    marker, selector = entries["window_calendar"]
+    assert marker.schema == "window_calendar"
+    assert isinstance(marker, vol.Required)
+    assert selector.config["domain"] == ["calendar"]
+    assert selector.config["multiple"] is False
+
+
+def test_optional_calendar_field_uses_an_optional_marker() -> None:
+    """Optional calendar fields are not required in the schema."""
+    field = _calendar_field()
+
+    entries = build_choose_field_entries(
+        _field_map(field),
+        field_schema={"window_calendar": FieldSchemaInfo(value_type=CalendarValue | NoneValue, is_optional=True)},
+        inclusion_map={},
+    )
+
+    marker, _selector = entries["window_calendar"]
+    assert isinstance(marker, vol.Optional)
+
+
+def test_convert_stores_a_calendar_schema_value() -> None:
+    """A selected calendar entity is stored as a calendar schema value."""
+    field = _calendar_field()
+
+    config = convert_choose_data_to_config({"window_calendar": "calendar.pool_pump"}, _field_map(field))
+
+    assert config["window_calendar"] == as_calendar_value("calendar.pool_pump")
+
+
+def test_convert_accepts_a_single_element_list() -> None:
+    """Entity pickers may hand back a one-element list."""
+    field = _calendar_field()
+
+    config = convert_choose_data_to_config({"window_calendar": ["calendar.pool_pump"]}, _field_map(field))
+
+    assert config["window_calendar"] == as_calendar_value("calendar.pool_pump")
+
+
+def test_convert_empty_calendar_selection_becomes_none() -> None:
+    """Clearing the picker disables the field."""
+    field = _calendar_field()
+
+    config = convert_choose_data_to_config({"window_calendar": ""}, _field_map(field))
+
+    assert config["window_calendar"] == as_none_value()
+
+
+def test_get_choose_default_surfaces_the_calendar_entity() -> None:
+    """Reconfigure pre-fills the picker with the stored entity ID."""
+    field = _calendar_field()
+
+    default = get_choose_default(field, {"window_calendar": as_calendar_value("calendar.pool_pump")})
+
+    assert default == "calendar.pool_pump"

--- a/custom_components/haeo/input_stores.py
+++ b/custom_components/haeo/input_stores.py
@@ -92,6 +92,7 @@ def _hint_from_field_info(field_info: InputFieldInfo[Any]) -> FieldHint:
         direction=field_info.direction,
         time_series=field_info.time_series,
         boundaries=field_info.boundaries,
+        calendar=field_info.calendar,
     )
 
 

--- a/custom_components/haeo/manifest.json
+++ b/custom_components/haeo/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "haeo",
   "name": "HAEO",
-  "after_dependencies": ["frontend", "http", "recorder"],
+  "after_dependencies": ["calendar", "frontend", "http", "recorder"],
   "codeowners": ["@TrentHouliston", "@BrendanAnnable"],
   "config_flow": true,
   "dependencies": [],

--- a/custom_components/haeo/number.py
+++ b/custom_components/haeo/number.py
@@ -126,12 +126,14 @@ async def async_setup_entry(
         # Combine all number fields from both sources
         all_fields = {**input_fields, **list_input_fields}
 
-        # Filter to only number fields (by entity description class name)
-        # Note: isinstance doesn't work due to Home Assistant's frozen_dataclass_compat wrapper
+        # Filter to only number fields (by entity description class name).
+        # Note: isinstance doesn't work due to Home Assistant's frozen_dataclass_compat wrapper.
+        # Calendar-driven fields resolve to boundary arrays with no meaningful
+        # scalar value, so they get no input entity.
         number_fields = [
             (field_path, field_info)
             for field_path, field_info in iter_input_field_paths(all_fields)
-            if type(field_info.entity_description).__name__ == "NumberEntityDescription"
+            if type(field_info.entity_description).__name__ == "NumberEntityDescription" and field_info.calendar is None
         ]
 
         surfaced_hints = get_surfaced_price_hints(element_type)

--- a/custom_components/haeo/tests/test_calendar_loader.py
+++ b/custom_components/haeo/tests/test_calendar_loader.py
@@ -1,0 +1,205 @@
+"""Tests for the calendar input loader and event-injecting state machine."""
+
+from datetime import UTC, datetime
+import logging
+from typing import Any
+from unittest.mock import Mock
+
+from homeassistant.components.calendar import CalendarEntity, CalendarEvent
+from homeassistant.components.calendar.const import DOMAIN as CALENDAR_DOMAIN
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_component import EntityComponent
+import numpy as np
+import pytest
+
+from conftest import FakeEntityState, FakeStateMachine
+from custom_components.haeo.calendar_loader import CALENDAR_EVENTS_ATTRIBUTE, CalendarInputLoader, CalendarStateMachine
+from custom_components.haeo.core.data.input_store import create_input_store
+from custom_components.haeo.core.model.const import OutputType
+from custom_components.haeo.core.schema.field_hints import CalendarFieldHint, FieldHint
+from custom_components.haeo.horizon import HorizonManager
+
+_LOGGER = logging.getLogger(__name__)
+
+FORECAST_TIMESTAMPS: tuple[float, ...] = (0.0, 3600.0, 7200.0)
+
+ENTITY_ID = "calendar.trips"
+
+
+class _MemStorage:
+    """In-memory storage double implementing the Storage protocol."""
+
+    def __init__(self, value: Any) -> None:
+        self.value = value
+
+    def read(self) -> Any:
+        return self.value
+
+    async def write(self, value: Any) -> None:
+        self.value = value
+
+
+def _calendar_store() -> Any:
+    """Build a calendar-driven store for the test calendar entity."""
+    return create_input_store(
+        storage=_MemStorage({"type": "calendar", "value": ENTITY_ID}),
+        hint=FieldHint(
+            output_type=OutputType.ENERGY,
+            time_series=True,
+            boundaries=True,
+            calendar=CalendarFieldHint(parser="presence"),
+        ),
+        get_forecast_timestamps=lambda: FORECAST_TIMESTAMPS,
+    )
+
+
+@pytest.fixture
+def horizon_manager() -> Mock:
+    """Return a mock horizon manager with fixed timestamps."""
+    manager = Mock(spec=HorizonManager)
+    manager.get_forecast_timestamps.return_value = FORECAST_TIMESTAMPS
+    manager.subscribe.return_value = Mock()
+    return manager
+
+
+class _StubCalendar(CalendarEntity):
+    """Calendar entity double returning canned events."""
+
+    _attr_name = "Trips"
+    _attr_has_entity_name = False
+
+    def __init__(self, events: list[CalendarEvent]) -> None:
+        self._events = events
+
+    @property
+    def event(self) -> CalendarEvent | None:
+        """Return the next upcoming event."""
+        return self._events[0] if self._events else None
+
+    async def async_get_events(
+        self,
+        hass: HomeAssistant,  # noqa: ARG002 (signature fixed by CalendarEntity)
+        start_date: datetime,  # noqa: ARG002
+        end_date: datetime,  # noqa: ARG002
+    ) -> list[CalendarEvent]:
+        """Return all canned events regardless of range."""
+        return self._events
+
+
+async def _add_stub_calendar(hass: HomeAssistant, events: list[CalendarEvent]) -> None:
+    """Register a stub calendar entity under calendar.trips."""
+    component: EntityComponent[CalendarEntity] = EntityComponent(_LOGGER, CALENDAR_DOMAIN, hass)
+    hass.data[CALENDAR_DOMAIN] = component
+    await component.async_add_entities([_StubCalendar(events)])
+    await hass.async_block_till_done()
+
+
+# --- CalendarStateMachine ---
+
+
+def test_state_machine_injects_events_for_known_calendars() -> None:
+    """Known calendar entities get events merged into their attributes."""
+    base = FakeStateMachine({ENTITY_ID: FakeEntityState(ENTITY_ID, "on", {"existing": 1})})
+    events = [{"start": "2026-01-01T00:00:00+00:00", "end": "2026-01-01T01:00:00+00:00"}]
+    sm = CalendarStateMachine(base, {ENTITY_ID: events})  # type: ignore[arg-type]  # test uses plain dicts
+
+    state = sm.get(ENTITY_ID)
+
+    assert state is not None
+    assert state.entity_id == ENTITY_ID
+    assert state.state == "on"
+    assert state.attributes["existing"] == 1
+    assert state.attributes[CALENDAR_EVENTS_ATTRIBUTE] == events
+    assert state.as_dict()["attributes"][CALENDAR_EVENTS_ATTRIBUTE] == events
+
+
+def test_state_machine_passes_through_other_entities() -> None:
+    """Entities without event lists are returned unmodified."""
+    base = FakeStateMachine({"sensor.x": FakeEntityState("sensor.x", "1.0", {})})
+    sm = CalendarStateMachine(base, {})
+
+    state = sm.get("sensor.x")
+
+    assert state is not None
+    assert CALENDAR_EVENTS_ATTRIBUTE not in state.attributes
+    assert sm.get("sensor.missing") is None
+
+
+# --- CalendarInputLoader ---
+
+
+async def test_loader_fetches_events_and_loads_store(hass: HomeAssistant, horizon_manager: Mock) -> None:
+    """The loader fetches calendar events and resolves the store."""
+    await _add_stub_calendar(
+        hass,
+        [
+            CalendarEvent(
+                start=datetime.fromtimestamp(0.0, tz=UTC),
+                end=datetime.fromtimestamp(3600.0, tz=UTC),
+                summary="Trip",
+            )
+        ],
+    )
+    store = _calendar_store()
+    loader = CalendarInputLoader(hass, {("EV", ("trip", "trip_calendar")): store}, horizon_manager)
+
+    await loader.async_start()
+
+    assert store.available
+    value = store.value
+    assert isinstance(value, dict)
+    np.testing.assert_allclose(value["presence"], [1.0, 0.0, 0.0])
+    loader.cleanup()
+
+
+async def test_loader_without_calendar_component_leaves_store_unavailable(
+    hass: HomeAssistant,
+    horizon_manager: Mock,
+) -> None:
+    """Without the calendar integration the store cannot load."""
+    store = _calendar_store()
+    loader = CalendarInputLoader(hass, {("EV", ("trip", "trip_calendar")): store}, horizon_manager)
+
+    await loader.async_start()
+
+    assert not store.available
+    loader.cleanup()
+
+
+async def test_loader_reloads_on_calendar_state_change(hass: HomeAssistant, horizon_manager: Mock) -> None:
+    """A calendar entity state change triggers a reload."""
+    await _add_stub_calendar(hass, [])
+    store = _calendar_store()
+    loader = CalendarInputLoader(hass, {("EV", ("trip", "trip_calendar")): store}, horizon_manager)
+    await loader.async_start()
+    value = store.value
+    assert isinstance(value, dict)
+    np.testing.assert_allclose(value["presence"], [0.0, 0.0, 0.0])
+
+    component: EntityComponent[CalendarEntity] = hass.data[CALENDAR_DOMAIN]
+    entity = component.get_entity(ENTITY_ID)
+    assert isinstance(entity, _StubCalendar)
+    entity._events = [
+        CalendarEvent(
+            start=datetime.fromtimestamp(3600.0, tz=UTC),
+            end=datetime.fromtimestamp(7200.0, tz=UTC),
+            summary="Trip",
+        )
+    ]
+    hass.states.async_set(ENTITY_ID, "on")
+    await hass.async_block_till_done()
+
+    value = store.value
+    assert isinstance(value, dict)
+    np.testing.assert_allclose(value["presence"], [0.0, 1.0, 0.0])
+    loader.cleanup()
+
+
+async def test_loader_without_calendar_stores_is_inert(hass: HomeAssistant, horizon_manager: Mock) -> None:
+    """A store map without calendar stores subscribes to nothing."""
+    loader = CalendarInputLoader(hass, {}, horizon_manager)
+
+    await loader.async_start()
+
+    horizon_manager.subscribe.assert_not_called()
+    loader.cleanup()

--- a/custom_components/haeo/tests/test_init.py
+++ b/custom_components/haeo/tests/test_init.py
@@ -557,6 +557,8 @@ async def test_async_setup_entry_raises_config_entry_not_ready_on_timeout(
 
     # Create a mock input store that never becomes ready
     class NeverReadyStore:
+        source_kind = "entity"
+
         async def wait_ready(self) -> None:
             # Wait forever - will timeout
             await asyncio.sleep(100)
@@ -650,6 +652,8 @@ async def test_setup_reentry_after_timeout_failure(
 
     # Create a mock input store that fails first time, succeeds second time
     class ConditionalReadyStore:
+        source_kind = "entity"
+
         def __init__(self) -> None:
             self._ready = False
 


### PR DESCRIPTION
Calendar schema values are now first-class through the data path:

- FieldHint/InputFieldInfo gain a CalendarFieldHint (distance/number/
  presence parsers) that marks a field as calendar-driven.
- resolve_field dispatches calendar values to a new calendar resolver
  that fuses events into CalendarBoundaryData (presence, span, and
  start/end edge arrays aligned to horizon boundaries; distances
  normalized to kilometres).
- create_input_store builds DRIVEN stores with a calendar source kind,
  and async_load resolves them through as_calendar_value.
- A new CalendarInputLoader fetches upcoming events over the horizon
  via the calendar integration's async_get_events, injects them as the
  haeo_events attribute through a state-machine decorator, and reloads
  on calendar state changes and horizon updates.
- Calendar-driven fields get no number entity; binary on/off states now
  load as 1/0 through the extractor fallback.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>