### PR TITLE
feat: add a deferrable load model element with priced deficit and overage

### DIFF
--- a/custom_components/haeo/core/adapters/policy_compilation.py
+++ b/custom_components/haeo/core/adapters/policy_compilation.py
@@ -39,12 +39,13 @@ from numpy.typing import NDArray
 from custom_components.haeo.core.model.elements import MODEL_ELEMENT_TYPE_CONNECTION, ModelElementConfig
 from custom_components.haeo.core.model.elements.battery import BatteryElementConfig
 from custom_components.haeo.core.model.elements.connection import ConnectionElementConfig
+from custom_components.haeo.core.model.elements.deferrable_load import DeferrableLoadElementConfig
 from custom_components.haeo.core.model.elements.node import NodeElementConfig
 from custom_components.haeo.core.model.elements.policy_pricing import ELEMENT_TYPE as MODEL_ELEMENT_TYPE_POLICY_PRICING
 from custom_components.haeo.core.model.elements.policy_pricing import PolicyPricingElementConfig, PolicyPricingTerm
 
 # Non-connection element configs (nodes and batteries) that can carry tags
-_TaggableConfig = NodeElementConfig | BatteryElementConfig
+_TaggableConfig = NodeElementConfig | BatteryElementConfig | DeferrableLoadElementConfig
 
 # A rule grouping identifies a rule by its source/destination sets,
 # independent of price. Rules with the same grouping share VLAN structure.

--- a/custom_components/haeo/core/model/elements/__init__.py
+++ b/custom_components/haeo/core/model/elements/__init__.py
@@ -21,6 +21,13 @@ from .connection import Connection as Connection
 from .connection import ConnectionElementConfig as ConnectionElementConfig
 from .connection import ConnectionElementTypeName as ConnectionElementTypeName
 from .connection import ConnectionOutputName as ConnectionOutputName
+from .deferrable_load import DEFERRABLE_LOAD_OUTPUT_NAMES as DEFERRABLE_LOAD_OUTPUT_NAMES
+from .deferrable_load import ELEMENT_TYPE as MODEL_ELEMENT_TYPE_DEFERRABLE_LOAD
+from .deferrable_load import DeferrableLoad as DeferrableLoad
+from .deferrable_load import DeferrableLoadConstraintName as DeferrableLoadConstraintName
+from .deferrable_load import DeferrableLoadElementConfig as DeferrableLoadElementConfig
+from .deferrable_load import DeferrableLoadElementTypeName as DeferrableLoadElementTypeName
+from .deferrable_load import DeferrableLoadOutputName as DeferrableLoadOutputName
 from .node import ELEMENT_TYPE as MODEL_ELEMENT_TYPE_NODE
 from .node import NODE_OUTPUT_NAMES
 from .node import Node as Node
@@ -45,11 +52,21 @@ from .segments import SocPricingSegmentSpec as SocPricingSegmentSpec
 
 # Type for all model element types
 ModelElementType = (
-    BatteryElementTypeName | NodeElementTypeName | ConnectionElementTypeName | PolicyPricingElementTypeName
+    BatteryElementTypeName
+    | DeferrableLoadElementTypeName
+    | NodeElementTypeName
+    | ConnectionElementTypeName
+    | PolicyPricingElementTypeName
 )
 
 # Typed configs for all model elements (discriminated by element_type)
-ModelElementConfig = BatteryElementConfig | NodeElementConfig | ConnectionElementConfig | PolicyPricingElementConfig
+ModelElementConfig = (
+    BatteryElementConfig
+    | DeferrableLoadElementConfig
+    | NodeElementConfig
+    | ConnectionElementConfig
+    | PolicyPricingElementConfig
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -67,6 +84,10 @@ ELEMENTS: Final[dict[ModelElementType, ElementSpec]] = {
         factory=Battery,
         output_names=BATTERY_OUTPUT_NAMES,
     ),
+    MODEL_ELEMENT_TYPE_DEFERRABLE_LOAD: ElementSpec(
+        factory=DeferrableLoad,
+        output_names=DEFERRABLE_LOAD_OUTPUT_NAMES,
+    ),
     MODEL_ELEMENT_TYPE_NODE: ElementSpec(
         factory=Node,
         output_names=NODE_OUTPUT_NAMES,
@@ -82,9 +103,11 @@ __all__ = [
     "BATTERY_POWER_CONSTRAINTS",
     "CONNECTION_OUTPUT_NAMES",
     "CONNECTION_POWER",
+    "DEFERRABLE_LOAD_OUTPUT_NAMES",
     "ELEMENTS",
     "MODEL_ELEMENT_TYPE_BATTERY",
     "MODEL_ELEMENT_TYPE_CONNECTION",
+    "MODEL_ELEMENT_TYPE_DEFERRABLE_LOAD",
     "MODEL_ELEMENT_TYPE_NODE",
     "MODEL_ELEMENT_TYPE_POLICY_PRICING",
     "Battery",
@@ -95,6 +118,10 @@ __all__ = [
     "ConnectionElementConfig",
     "ConnectionElementTypeName",
     "ConnectionOutputName",
+    "DeferrableLoad",
+    "DeferrableLoadConstraintName",
+    "DeferrableLoadElementConfig",
+    "DeferrableLoadOutputName",
     "EfficiencySegment",
     "ElementSpec",
     "ModelElementConfig",

--- a/custom_components/haeo/core/model/elements/battery.py
+++ b/custom_components/haeo/core/model/elements/battery.py
@@ -24,6 +24,7 @@ type BatteryConstraintName = Literal[
     "battery_energy_out_flow",
     "battery_soc_max",
     "battery_soc_min",
+    "battery_reserve_floor",
 ]
 
 # Type for all battery output names (union of base outputs and constraints)
@@ -32,6 +33,7 @@ type BatteryOutputName = (
         "battery_power_charge",
         "battery_power_discharge",
         "battery_energy_stored",
+        "battery_reserve_shortfall",
     ]
     | BatteryConstraintName
 )
@@ -43,12 +45,14 @@ BATTERY_OUTPUT_NAMES: Final[frozenset[BatteryOutputName]] = frozenset(
         BATTERY_POWER_CHARGE := "battery_power_charge",
         BATTERY_POWER_DISCHARGE := "battery_power_discharge",
         BATTERY_ENERGY_STORED := "battery_energy_stored",
+        BATTERY_RESERVE_SHORTFALL := "battery_reserve_shortfall",
         # Constraint shadow prices
         BATTERY_POWER_BALANCE := ELEMENT_POWER_BALANCE,
         BATTERY_ENERGY_IN_FLOW := "battery_energy_in_flow",
         BATTERY_ENERGY_OUT_FLOW := "battery_energy_out_flow",
         BATTERY_SOC_MAX := "battery_soc_max",
         BATTERY_SOC_MIN := "battery_soc_min",
+        BATTERY_RESERVE_FLOOR := "battery_reserve_floor",
     )
 )
 
@@ -64,6 +68,9 @@ class BatteryElementConfig(TypedDict):
     capacity: NDArray[np.floating[Any]] | float
     initial_charge: float
     salvage_value: NotRequired[float]
+    reserve_level: NotRequired[NDArray[np.floating[Any]] | float | None]
+    reserve_mask: NotRequired[NDArray[np.floating[Any]] | float | None]
+    reserve_price: NotRequired[NDArray[np.floating[Any]] | float | None]
     outbound_tags: NotRequired[set[int] | None]
     inbound_tags: NotRequired[set[int] | None]
 
@@ -79,6 +86,9 @@ class Battery(NetworkElement[BatteryOutputName]):
     capacity: TrackedParam[NDArray[np.float64]] = TrackedParam()
     initial_charge: TrackedParam[float] = TrackedParam()
     salvage_value: TrackedParam[float] = TrackedParam()
+    reserve_level: TrackedParam[NDArray[np.float64]] = TrackedParam()
+    reserve_mask: TrackedParam[NDArray[np.float64]] = TrackedParam()
+    reserve_price: TrackedParam[NDArray[np.float64]] = TrackedParam()
 
     def __init__(
         self,
@@ -89,6 +99,9 @@ class Battery(NetworkElement[BatteryOutputName]):
         capacity: NDArray[np.floating[Any]] | float,
         initial_charge: float,
         salvage_value: float = 0.0,
+        reserve_level: NDArray[np.floating[Any]] | float | None = None,
+        reserve_mask: NDArray[np.floating[Any]] | float | None = None,
+        reserve_price: NDArray[np.floating[Any]] | float | None = None,
         outbound_tags: set[int] | None = None,
         inbound_tags: set[int] | None = None,
     ) -> None:
@@ -107,6 +120,20 @@ class Battery(NetworkElement[BatteryOutputName]):
         self.capacity = broadcast_to_sequence(capacity, n_periods + 1)
         self.initial_charge = initial_charge
         self.salvage_value = salvage_value
+
+        # Reserve demand pricing: at masked boundaries (e.g. trip window
+        # ends), dropping below the reserve level is priced once per window
+        # rather than per interval — the structural decision to create the
+        # slack variables is made here; values update reactively.
+        self._has_reserve = reserve_price is not None and reserve_mask is not None
+        self.reserve_level = broadcast_to_sequence(reserve_level if reserve_level is not None else 0.0, n_periods + 1)
+        self.reserve_mask = broadcast_to_sequence(reserve_mask if reserve_mask is not None else 0.0, n_periods + 1)
+        self.reserve_price = broadcast_to_sequence(reserve_price if reserve_price is not None else 0.0, n_periods + 1)
+        self.reserve_shortfall = (
+            solver.addVariables(n_periods + 1, lb=0.0, name_prefix=f"{name}_reserve_short_", out_array=True)
+            if self._has_reserve
+            else None
+        )
 
         # Create all energy variables (including initial state at t=0)
         self.energy_in = solver.addVariables(n_periods + 1, lb=0.0, name_prefix=f"{name}_energy_in_", out_array=True)
@@ -183,10 +210,36 @@ class Battery(NetworkElement[BatteryOutputName]):
         """Return power consumed by charging the battery."""
         return self.power_consumption
 
+    @constraint(output=True, unit="$/kWh")
+    def battery_reserve_floor(self) -> list[highs_linear_expression] | None:
+        """Constraint: shortfall covers the drop below reserve at masked boundaries.
+
+        At boundaries where the mask is zero, the shortfall is only bounded
+        below by zero; its value is meaningful at masked boundaries.
+
+        Output: shadow price indicating the marginal cost of the reserve.
+        """
+        if self.reserve_shortfall is None:
+            return None
+        mask = self.reserve_mask[1:]
+        return list(self.reserve_shortfall[1:] >= mask * self.reserve_level[1:] - mask * self.stored_energy[1:])
+
     @cost
     def battery_salvage_value(self) -> highs_linear_expression:
         """Cost: salvage value of stored energy at the end of the horizon."""
         return -self.salvage_value * self.stored_energy[-1]
+
+    @cost
+    def battery_reserve_cost(self) -> highs_linear_expression | None:
+        """Cost: reserve shortfalls priced once per masked boundary.
+
+        This is demand-level pricing: the charge is on the lowest level hit
+        by each masked boundary, not integrated over every interval below
+        the reserve.
+        """
+        if self.reserve_shortfall is None:
+            return None
+        return (self.reserve_price[1:] * self.reserve_shortfall[1:]).sum()
 
     # Output methods
 
@@ -208,3 +261,15 @@ class Battery(NetworkElement[BatteryOutputName]):
     def battery_energy_stored(self) -> OutputData:
         """Output: energy currently stored in the battery."""
         return OutputData(type=OutputType.ENERGY, unit="kWh", values=self.extract_values(self.stored_energy))
+
+    @output
+    def battery_reserve_shortfall(self) -> OutputData:
+        """Output: drop below the reserve level at masked boundaries."""
+        if self.reserve_shortfall is None:
+            values: tuple[float, ...] = (0.0,) * (self.n_periods + 1)
+        else:
+            values = tuple(
+                float(v * m)
+                for v, m in zip(self.extract_values(self.reserve_shortfall), self.reserve_mask, strict=True)
+            )
+        return OutputData(type=OutputType.ENERGY, unit="kWh", values=values)

--- a/custom_components/haeo/core/model/elements/deferrable_load.py
+++ b/custom_components/haeo/core/model/elements/deferrable_load.py
@@ -1,0 +1,230 @@
+"""Deferrable load entity for electrical system modeling.
+
+A deferrable load absorbs a required amount of energy within scheduled
+windows (e.g. calendar events). Rather than enforcing the requirement as a
+hard constraint, any locked-in shortfall is priced at the end of the
+horizon, as is absorption beyond the total requirement. This keeps the
+optimization feasible when the requirement physically cannot be met while
+still making the optimizer work hard to meet it.
+"""
+
+from typing import Any, Final, Literal, NotRequired, TypedDict
+
+from highspy import Highs
+from highspy.highs import HighspyArray, highs_linear_expression
+import numpy as np
+from numpy.typing import NDArray
+
+from custom_components.haeo.core.model.const import OutputType
+from custom_components.haeo.core.model.element import ELEMENT_POWER_BALANCE, NetworkElement
+from custom_components.haeo.core.model.output_data import OutputData
+from custom_components.haeo.core.model.reactive import TrackedParam, constraint, cost, output
+from custom_components.haeo.core.model.util import broadcast_to_sequence
+
+# Model element type for deferrable loads
+ELEMENT_TYPE: Final = "deferrable_load"
+type DeferrableLoadElementTypeName = Literal["deferrable_load"]
+
+# Type for deferrable load constraint names (shadow prices exposed as outputs)
+type DeferrableLoadConstraintName = Literal[
+    "element_power_balance",
+    "deferrable_load_energy_flow",
+    "deferrable_load_capacity",
+    "deferrable_load_requirement",
+]
+
+# Type for all deferrable load output names (union of base outputs and constraints)
+type DeferrableLoadOutputName = (
+    Literal[
+        "deferrable_load_power",
+        "deferrable_load_energy_absorbed",
+        "deferrable_load_energy_deficit",
+    ]
+    | DeferrableLoadConstraintName
+)
+
+# All deferrable load output names (includes constraint shadow prices)
+DEFERRABLE_LOAD_OUTPUT_NAMES: Final[frozenset[DeferrableLoadOutputName]] = frozenset(
+    (
+        # Base outputs
+        DEFERRABLE_LOAD_POWER := "deferrable_load_power",
+        DEFERRABLE_LOAD_ENERGY_ABSORBED := "deferrable_load_energy_absorbed",
+        DEFERRABLE_LOAD_ENERGY_DEFICIT := "deferrable_load_energy_deficit",
+        # Constraint shadow prices
+        DEFERRABLE_LOAD_POWER_BALANCE := ELEMENT_POWER_BALANCE,
+        DEFERRABLE_LOAD_ENERGY_FLOW := "deferrable_load_energy_flow",
+        DEFERRABLE_LOAD_CAPACITY := "deferrable_load_capacity",
+        DEFERRABLE_LOAD_REQUIREMENT := "deferrable_load_requirement",
+    )
+)
+
+
+class DeferrableLoadElementConfig(TypedDict):
+    """Configuration for DeferrableLoad model elements."""
+
+    element_type: DeferrableLoadElementTypeName
+    name: str
+    capacity: NDArray[np.floating[Any]] | float
+    required: NDArray[np.floating[Any]] | float
+    initial_energy: NotRequired[float]
+    deficit_price: float
+    overage_price: NotRequired[float]
+    outbound_tags: NotRequired[set[int] | None]
+    inbound_tags: NotRequired[set[int] | None]
+
+
+class DeferrableLoad(NetworkElement[DeferrableLoadOutputName]):
+    """Deferrable load entity for electrical system modeling.
+
+    Tracks cumulative absorbed energy against two boundary-aligned profiles:
+
+    - ``capacity``: the maximum cumulative energy absorbable by each boundary
+      (opens as scheduled windows begin).
+    - ``required``: the cumulative energy that should have been absorbed by
+      each boundary (due as scheduled windows end).
+
+    The deficit variable is non-decreasing, so a shortfall against the
+    requirement at any boundary stays locked in even if absorption later
+    catches up. The final deficit is priced at ``deficit_price`` and any
+    absorption beyond the final requirement at ``overage_price``.
+    """
+
+    # Parameters
+    capacity: TrackedParam[NDArray[np.float64]] = TrackedParam()
+    required: TrackedParam[NDArray[np.float64]] = TrackedParam()
+    initial_energy: TrackedParam[float] = TrackedParam()
+    deficit_price: TrackedParam[float] = TrackedParam()
+    overage_price: TrackedParam[float] = TrackedParam()
+
+    def __init__(
+        self,
+        name: str,
+        periods: NDArray[np.floating[Any]],
+        *,
+        solver: Highs,
+        capacity: NDArray[np.floating[Any]] | float,
+        required: NDArray[np.floating[Any]] | float,
+        deficit_price: float,
+        initial_energy: float = 0.0,
+        overage_price: float = 0.0,
+        outbound_tags: set[int] | None = None,
+        inbound_tags: set[int] | None = None,
+    ) -> None:
+        """Initialize a deferrable load entity."""
+        super().__init__(
+            name=name,
+            periods=periods,
+            solver=solver,
+            output_names=DEFERRABLE_LOAD_OUTPUT_NAMES,
+            outbound_tags=outbound_tags,
+            inbound_tags=inbound_tags,
+        )
+        n_periods = self.n_periods
+
+        # Set tracked parameters (broadcasts profiles to n_periods + 1)
+        self.capacity = broadcast_to_sequence(capacity, n_periods + 1)
+        self.required = broadcast_to_sequence(required, n_periods + 1)
+        self.initial_energy = initial_energy
+        self.deficit_price = deficit_price
+        self.overage_price = overage_price
+
+        # Cumulative absorbed energy (including initial state at t=0)
+        self.energy = solver.addVariables(n_periods + 1, lb=0.0, name_prefix=f"{name}_energy_", out_array=True)
+        # Locked-in shortfall against the requirement at each boundary
+        self.deficit = solver.addVariables(n_periods + 1, lb=0.0, name_prefix=f"{name}_deficit_", out_array=True)
+        # Absorption beyond the final requirement
+        self.overage = solver.addVariables(1, lb=0.0, name_prefix=f"{name}_overage_", out_array=True)
+
+    @property
+    def power_consumption(self) -> HighspyArray:
+        """Power being consumed to absorb energy.
+
+        Computed on-demand so that accessing self.periods triggers dependency
+        tracking when called from within @constraint or @cost decorated methods.
+        """
+        return (self.energy[1:] - self.energy[:-1]) * (1.0 / self.periods)
+
+    @constraint
+    def deferrable_load_initial_energy(self) -> highs_linear_expression:
+        """Constraint: energy[0] == initial_energy."""
+        return self.energy[0] == self.initial_energy
+
+    @constraint
+    def deferrable_load_initial_deficit(self) -> highs_linear_expression:
+        """Constraint: deficit[0] == 0."""
+        return self.deficit[0] == 0.0
+
+    @constraint(output=True, unit="$/kWh")
+    def deferrable_load_energy_flow(self) -> list[highs_linear_expression]:
+        """Constraint: cumulative absorbed energy can only increase.
+
+        Output: shadow price indicating the marginal value of energy flow constraints.
+        """
+        return list(self.energy[1:] >= self.energy[:-1])
+
+    @constraint(output=True, unit="$/kWh")
+    def deferrable_load_capacity(self) -> list[highs_linear_expression]:
+        """Constraint: absorbed energy cannot exceed the opened capacity.
+
+        Output: shadow price indicating the marginal value of additional capacity.
+        """
+        return list(self.energy[1:] <= self.capacity[1:])
+
+    @constraint(output=True, unit="$/kWh")
+    def deferrable_load_requirement(self) -> list[highs_linear_expression]:
+        """Constraint: absorbed energy plus deficit covers the requirement.
+
+        Output: shadow price indicating the marginal cost of the requirement.
+        """
+        return list(self.energy[1:] + self.deficit[1:] >= self.required[1:])
+
+    @constraint
+    def deferrable_load_deficit_locked_in(self) -> list[highs_linear_expression]:
+        """Constraint: the deficit never shrinks.
+
+        A shortfall at a deadline stays priced even if absorption later
+        catches up past the requirement profile.
+        """
+        return list(self.deficit[1:] >= self.deficit[:-1])
+
+    @constraint
+    def deferrable_load_overage(self) -> highs_linear_expression:
+        """Constraint: overage covers absorption beyond the final requirement."""
+        return self.overage[0] >= self.energy[-1] - self.required[-1]
+
+    def element_power_produced(self) -> HighspyArray | None:
+        """Deferrable loads never produce power."""
+        return None
+
+    def element_power_consumed(self) -> HighspyArray:
+        """Return power consumed by absorbing energy."""
+        return self.power_consumption
+
+    @cost
+    def deferrable_load_deficit_cost(self) -> highs_linear_expression:
+        """Cost: the locked-in final shortfall priced at deficit_price."""
+        return self.deficit_price * self.deficit[-1]
+
+    @cost
+    def deferrable_load_overage_cost(self) -> highs_linear_expression:
+        """Cost: absorption beyond the final requirement priced at overage_price."""
+        return self.overage_price * self.overage[0]
+
+    # Output methods
+
+    @output
+    def deferrable_load_power(self) -> OutputData:
+        """Output: power being consumed to absorb energy."""
+        return OutputData(
+            type=OutputType.POWER, unit="kW", values=self.extract_values(self.power_consumption), direction="-"
+        )
+
+    @output
+    def deferrable_load_energy_absorbed(self) -> OutputData:
+        """Output: cumulative energy absorbed toward the requirement."""
+        return OutputData(type=OutputType.ENERGY, unit="kWh", values=self.extract_values(self.energy))
+
+    @output
+    def deferrable_load_energy_deficit(self) -> OutputData:
+        """Output: locked-in shortfall against the requirement."""
+        return OutputData(type=OutputType.ENERGY, unit="kWh", values=self.extract_values(self.deficit))

--- a/custom_components/haeo/core/model/elements/deferrable_load.py
+++ b/custom_components/haeo/core/model/elements/deferrable_load.py
@@ -67,7 +67,7 @@ class DeferrableLoadElementConfig(TypedDict):
     capacity: NDArray[np.floating[Any]] | float
     required: NDArray[np.floating[Any]] | float
     initial_energy: NotRequired[float]
-    deficit_price: float
+    deficit_price: NDArray[np.floating[Any]] | float
     overage_price: NotRequired[float]
     outbound_tags: NotRequired[set[int] | None]
     inbound_tags: NotRequired[set[int] | None]
@@ -85,15 +85,16 @@ class DeferrableLoad(NetworkElement[DeferrableLoadOutputName]):
 
     The deficit variable is non-decreasing, so a shortfall against the
     requirement at any boundary stays locked in even if absorption later
-    catches up. The final deficit is priced at ``deficit_price`` and any
-    absorption beyond the final requirement at ``overage_price``.
+    catches up. Each deficit increment is priced at ``deficit_price`` for
+    the boundary where it locks in (a scalar applies uniformly), and any
+    absorption beyond the final requirement is priced at ``overage_price``.
     """
 
     # Parameters
     capacity: TrackedParam[NDArray[np.float64]] = TrackedParam()
     required: TrackedParam[NDArray[np.float64]] = TrackedParam()
     initial_energy: TrackedParam[float] = TrackedParam()
-    deficit_price: TrackedParam[float] = TrackedParam()
+    deficit_price: TrackedParam[NDArray[np.float64]] = TrackedParam()
     overage_price: TrackedParam[float] = TrackedParam()
 
     def __init__(
@@ -104,7 +105,7 @@ class DeferrableLoad(NetworkElement[DeferrableLoadOutputName]):
         solver: Highs,
         capacity: NDArray[np.floating[Any]] | float,
         required: NDArray[np.floating[Any]] | float,
-        deficit_price: float,
+        deficit_price: NDArray[np.floating[Any]] | float,
         initial_energy: float = 0.0,
         overage_price: float = 0.0,
         outbound_tags: set[int] | None = None,
@@ -125,7 +126,7 @@ class DeferrableLoad(NetworkElement[DeferrableLoadOutputName]):
         self.capacity = broadcast_to_sequence(capacity, n_periods + 1)
         self.required = broadcast_to_sequence(required, n_periods + 1)
         self.initial_energy = initial_energy
-        self.deficit_price = deficit_price
+        self.deficit_price = broadcast_to_sequence(deficit_price, n_periods + 1)
         self.overage_price = overage_price
 
         # Cumulative absorbed energy (including initial state at t=0)
@@ -166,9 +167,14 @@ class DeferrableLoad(NetworkElement[DeferrableLoadOutputName]):
     def deferrable_load_capacity(self) -> list[highs_linear_expression]:
         """Constraint: absorbed energy cannot exceed the opened capacity.
 
+        Live telemetry can report more energy already absorbed than the
+        schedule planned for (e.g. an EV that drove further than forecast),
+        so the effective capacity never sits below the initial energy —
+        stale telemetry must not make the optimization infeasible.
+
         Output: shadow price indicating the marginal value of additional capacity.
         """
-        return list(self.energy[1:] <= self.capacity[1:])
+        return list(self.energy[1:] <= np.maximum(self.capacity[1:], self.initial_energy))
 
     @constraint(output=True, unit="$/kWh")
     def deferrable_load_requirement(self) -> list[highs_linear_expression]:
@@ -189,8 +195,14 @@ class DeferrableLoad(NetworkElement[DeferrableLoadOutputName]):
 
     @constraint
     def deferrable_load_overage(self) -> highs_linear_expression:
-        """Constraint: overage covers absorption beyond the final requirement."""
-        return self.overage[0] >= self.energy[-1] - self.required[-1]
+        """Constraint: overage covers absorption beyond the final requirement.
+
+        Energy already absorbed before the horizon is not overage — an
+        overshoot reported by live telemetry is a fact, not a decision to
+        price.
+        """
+        baseline = np.maximum(self.required[-1], self.initial_energy)
+        return self.overage[0] >= self.energy[-1] - baseline
 
     def element_power_produced(self) -> HighspyArray | None:
         """Deferrable loads never produce power."""
@@ -202,8 +214,12 @@ class DeferrableLoad(NetworkElement[DeferrableLoadOutputName]):
 
     @cost
     def deferrable_load_deficit_cost(self) -> highs_linear_expression:
-        """Cost: the locked-in final shortfall priced at deficit_price."""
-        return self.deficit_price * self.deficit[-1]
+        """Cost: each locked-in deficit increment priced at its boundary.
+
+        With a scalar price this telescopes to price times the final deficit.
+        """
+        increments = self.deficit[1:] - self.deficit[:-1]
+        return (self.deficit_price[1:] * increments).sum()
 
     @cost
     def deferrable_load_overage_cost(self) -> highs_linear_expression:

--- a/custom_components/haeo/core/model/network.py
+++ b/custom_components/haeo/core/model/network.py
@@ -14,6 +14,7 @@ from .element import Element, NetworkElement
 from .elements import ELEMENTS, ModelElementConfig
 from .elements.battery import Battery, BatteryElementConfig
 from .elements.connection import Connection, ConnectionElementConfig, ConnectionOutputName
+from .elements.deferrable_load import DeferrableLoad, DeferrableLoadElementConfig
 from .elements.node import Node, NodeElementConfig
 from .elements.policy_pricing import PolicyPricing, PolicyPricingElementConfig
 from .reactive.decorators import clear_ranging_cache
@@ -178,6 +179,9 @@ class Network:
 
     @overload
     def add(self, element_config: BatteryElementConfig) -> Battery: ...
+
+    @overload
+    def add(self, element_config: DeferrableLoadElementConfig) -> DeferrableLoad: ...
 
     @overload
     def add(self, element_config: NodeElementConfig) -> Node: ...

--- a/custom_components/haeo/core/model/output_names.py
+++ b/custom_components/haeo/core/model/output_names.py
@@ -8,16 +8,18 @@ from typing import Final
 
 from .elements.battery import BATTERY_OUTPUT_NAMES, BatteryOutputName
 from .elements.connection import CONNECTION_OUTPUT_NAMES, ConnectionOutputName
+from .elements.deferrable_load import DEFERRABLE_LOAD_OUTPUT_NAMES, DeferrableLoadOutputName
 from .elements.node import NODE_OUTPUT_NAMES, NodeOutputName
 
 # Combined type for all possible output names
-type ModelOutputName = BatteryOutputName | ConnectionOutputName | NodeOutputName
+type ModelOutputName = BatteryOutputName | ConnectionOutputName | DeferrableLoadOutputName | NodeOutputName
 
 # Model-level output names
 MODEL_OUTPUT_NAMES: Final[frozenset[str]] = frozenset(
     {
         *BATTERY_OUTPUT_NAMES,
         *CONNECTION_OUTPUT_NAMES,
+        *DEFERRABLE_LOAD_OUTPUT_NAMES,
         *NODE_OUTPUT_NAMES,
     }
 )
@@ -25,10 +27,12 @@ MODEL_OUTPUT_NAMES: Final[frozenset[str]] = frozenset(
 __all__ = [
     "BATTERY_OUTPUT_NAMES",
     "CONNECTION_OUTPUT_NAMES",
+    "DEFERRABLE_LOAD_OUTPUT_NAMES",
     "MODEL_OUTPUT_NAMES",
     "NODE_OUTPUT_NAMES",
     "BatteryOutputName",
     "ConnectionOutputName",
+    "DeferrableLoadOutputName",
     "ModelOutputName",
     "NodeOutputName",
 ]

--- a/custom_components/haeo/core/model/tests/test_battery_reserve.py
+++ b/custom_components/haeo/core/model/tests/test_battery_reserve.py
@@ -1,0 +1,146 @@
+"""Tests for battery reserve demand pricing."""
+
+import numpy as np
+import pytest
+
+from custom_components.haeo.core.model import Network
+from custom_components.haeo.core.model.elements import MODEL_ELEMENT_TYPE_CONNECTION, MODEL_ELEMENT_TYPE_NODE
+from custom_components.haeo.core.model.elements.battery import BATTERY_RESERVE_SHORTFALL, Battery
+
+
+def _build_network(
+    *,
+    initial_charge: float,
+    drain: list[float],
+    reserve_level: float | None = None,
+    reserve_mask: np.ndarray | None = None,
+    reserve_price: float | None = None,
+    import_price: list[float] | None = None,
+) -> tuple[Network, Battery]:
+    """Build a battery that is force-drained, with optional grid and reserve."""
+    n = len(drain)
+    network = Network(name="test_network", periods=np.array([1.0] * n))
+
+    battery = network.add(
+        {
+            "element_type": "battery",
+            "name": "batt",
+            "capacity": 20.0,
+            "initial_charge": initial_charge,
+            "reserve_level": reserve_level,
+            "reserve_mask": reserve_mask,
+            "reserve_price": reserve_price,
+        }
+    )
+    network.add({"element_type": MODEL_ELEMENT_TYPE_NODE, "name": "sink", "is_source": False, "is_sink": True})
+    network.add(
+        {
+            "element_type": MODEL_ELEMENT_TYPE_CONNECTION,
+            "name": "batt_to_sink",
+            "source": "batt",
+            "target": "sink",
+            "tags": {1},
+            "segments": {
+                "power_limit": {"segment_type": "power_limit", "max_power": np.array(drain), "fixed": True},
+            },
+        }
+    )
+    if import_price is not None:
+        network.add({"element_type": MODEL_ELEMENT_TYPE_NODE, "name": "grid", "is_source": True, "is_sink": False})
+        network.add(
+            {
+                "element_type": MODEL_ELEMENT_TYPE_CONNECTION,
+                "name": "grid_to_batt",
+                "source": "grid",
+                "target": "batt",
+                "tags": {1},
+                "segments": {
+                    "pricing": {"segment_type": "pricing", "price": np.array(import_price)},
+                },
+            }
+        )
+    return network, battery
+
+
+def test_no_reserve_battery_is_unchanged() -> None:
+    """Without reserve config the battery behaves as before with a zero output."""
+    network, battery = _build_network(initial_charge=10.0, drain=[0.0, 8.0])
+
+    network.optimize()
+
+    shortfall = battery.outputs()[BATTERY_RESERVE_SHORTFALL].values
+    np.testing.assert_allclose(shortfall, [0.0, 0.0, 0.0])
+
+
+def test_reserve_shortfall_priced_once_at_masked_boundary() -> None:
+    """Dropping below the reserve is priced on the lowest level, once."""
+    # Drain 8 kWh in period 2: stored 10 → 10 → 2, reserve 5 checked at the end.
+    network, battery = _build_network(
+        initial_charge=10.0,
+        drain=[0.0, 8.0],
+        reserve_level=5.0,
+        reserve_mask=np.array([0.0, 0.0, 1.0]),
+        reserve_price=2.0,
+    )
+
+    cost = network.optimize()
+
+    shortfall = battery.outputs()[BATTERY_RESERVE_SHORTFALL].values
+    np.testing.assert_allclose(shortfall, [0.0, 0.0, 3.0])
+    assert cost == pytest.approx(3.0 * 2.0)
+
+
+def test_reserve_avoided_by_precharging_when_cheaper() -> None:
+    """The optimizer tops up ahead of the drain when energy beats the penalty."""
+    network, battery = _build_network(
+        initial_charge=10.0,
+        drain=[0.0, 8.0],
+        reserve_level=5.0,
+        reserve_mask=np.array([0.0, 0.0, 1.0]),
+        reserve_price=2.0,
+        import_price=[0.1, 0.1],
+    )
+
+    cost = network.optimize()
+
+    shortfall = battery.outputs()[BATTERY_RESERVE_SHORTFALL].values
+    np.testing.assert_allclose(shortfall, [0.0, 0.0, 0.0])
+    # 3 kWh topped up at 0.1 beats a 3 kWh shortfall at 2.0.
+    assert cost == pytest.approx(3.0 * 0.1)
+
+
+def test_expensive_energy_leaves_the_shortfall() -> None:
+    """When topping up costs more than the penalty, the shortfall stays."""
+    network, battery = _build_network(
+        initial_charge=10.0,
+        drain=[0.0, 8.0],
+        reserve_level=5.0,
+        reserve_mask=np.array([0.0, 0.0, 1.0]),
+        reserve_price=0.2,
+        import_price=[0.5, 0.5],
+    )
+
+    cost = network.optimize()
+
+    shortfall = battery.outputs()[BATTERY_RESERVE_SHORTFALL].values
+    np.testing.assert_allclose(shortfall, [0.0, 0.0, 3.0])
+    assert cost == pytest.approx(3.0 * 0.2)
+
+
+def test_unmasked_boundaries_are_not_priced() -> None:
+    """Being below reserve mid-window costs nothing until a masked boundary."""
+    # Drain happens in period 1, recovery impossible, but only the final
+    # boundary is masked — one charge despite two boundaries below reserve.
+    network, battery = _build_network(
+        initial_charge=6.0,
+        drain=[4.0, 0.0],
+        reserve_level=5.0,
+        reserve_mask=np.array([0.0, 0.0, 1.0]),
+        reserve_price=2.0,
+    )
+
+    cost = network.optimize()
+
+    shortfall = battery.outputs()[BATTERY_RESERVE_SHORTFALL].values
+    np.testing.assert_allclose(shortfall, [0.0, 0.0, 3.0])
+    assert cost == pytest.approx(3.0 * 2.0)

--- a/custom_components/haeo/core/model/tests/test_data/battery.py
+++ b/custom_components/haeo/core/model/tests/test_data/battery.py
@@ -22,6 +22,7 @@ VALID_CASES: list[ElementTestCase] = [
             "output_cost": 0.0,
         },
         "expected_outputs": {
+            "battery_reserve_shortfall": {"type": "energy", "unit": "kWh", "values": (0.0, 0.0, 0.0, 0.0)},
             "battery_energy_stored": {"type": "energy", "unit": "kWh", "values": (2.0, 7.0, 9.0, 9.0)},
             "battery_power_charge": {"type": "power", "unit": "kW", "values": (5.0, 2.0, 0.0)},
             "battery_power_discharge": {"type": "power", "unit": "kW", "values": (0.0, 0.0, 0.0)},
@@ -48,6 +49,7 @@ VALID_CASES: list[ElementTestCase] = [
             "output_cost": 0.0,
         },
         "expected_outputs": {
+            "battery_reserve_shortfall": {"type": "energy", "unit": "kWh", "values": (0.0, 0.0, 0.0, 0.0)},
             "battery_energy_stored": {"type": "energy", "unit": "kWh", "values": (2.0, 7.0, 9.0, 9.0)},
             "battery_power_charge": {"type": "power", "unit": "kW", "values": (5.0, 2.0, 0.0)},
             "battery_power_discharge": {"type": "power", "unit": "kW", "values": (0.0, 0.0, 0.0)},
@@ -73,6 +75,7 @@ VALID_CASES: list[ElementTestCase] = [
             "output_cost": 0.0,
         },
         "expected_outputs": {
+            "battery_reserve_shortfall": {"type": "energy", "unit": "kWh", "values": (0.0, 0.0, 0.0, 0.0)},
             "battery_energy_stored": {"type": "energy", "unit": "kWh", "values": (8.0, 5.0, 2.0, 2.0)},
             "battery_power_charge": {"type": "power", "unit": "kW", "values": (0.0, 0.0, 0.0)},
             "battery_power_discharge": {"type": "power", "unit": "kW", "values": (3.0, 3.0, 0.0)},
@@ -98,6 +101,7 @@ VALID_CASES: list[ElementTestCase] = [
             "output_cost": 0.0,
         },
         "expected_outputs": {
+            "battery_reserve_shortfall": {"type": "energy", "unit": "kWh", "values": (0.0, 0.0, 0.0, 0.0)},
             "battery_energy_stored": {"type": "energy", "unit": "kWh", "values": (5.0, 7.0, 6.0, 7.0)},
             "battery_power_charge": {"type": "power", "unit": "kW", "values": (2.0, 0.0, 1.0)},
             "battery_power_discharge": {"type": "power", "unit": "kW", "values": (0.0, 1.0, 0.0)},

--- a/custom_components/haeo/core/model/tests/test_deferrable_load.py
+++ b/custom_components/haeo/core/model/tests/test_deferrable_load.py
@@ -1,0 +1,175 @@
+"""Tests for the deferrable load model element."""
+
+import numpy as np
+import pytest
+
+from custom_components.haeo.core.model import Network
+from custom_components.haeo.core.model.elements import (
+    MODEL_ELEMENT_TYPE_CONNECTION,
+    MODEL_ELEMENT_TYPE_NODE,
+    SegmentSpec,
+)
+from custom_components.haeo.core.model.elements.deferrable_load import DeferrableLoad
+
+
+def _build_network(
+    *,
+    capacity: np.ndarray | float,
+    required: np.ndarray | float,
+    deficit_price: float = 10.0,
+    initial_energy: float = 0.0,
+    overage_price: float = 0.0,
+    supply_price: list[float] | None = None,
+    max_supply_power: list[float] | None = None,
+) -> tuple[Network, DeferrableLoad]:
+    """Build a grid-fed deferrable load network."""
+    prices = supply_price if supply_price is not None else [0.1, 0.2]
+    n = len(prices)
+    network = Network(name="test_network", periods=np.array([1.0] * n))
+
+    network.add({"element_type": MODEL_ELEMENT_TYPE_NODE, "name": "grid", "is_source": True, "is_sink": True})
+    load = network.add(
+        {
+            "element_type": "deferrable_load",
+            "name": "load",
+            "capacity": capacity,
+            "required": required,
+            "deficit_price": deficit_price,
+            "initial_energy": initial_energy,
+            "overage_price": overage_price,
+        }
+    )
+    segments: dict[str, SegmentSpec] = {
+        "pricing": {"segment_type": "pricing", "price": np.array(prices)},
+    }
+    if max_supply_power is not None:
+        segments["power_limit"] = {"segment_type": "power_limit", "max_power": np.array(max_supply_power)}
+    network.add(
+        {
+            "element_type": MODEL_ELEMENT_TYPE_CONNECTION,
+            "name": "grid_to_load",
+            "source": "grid",
+            "target": "load",
+            "tags": {1},
+            "segments": segments,
+        }
+    )
+    return network, load
+
+
+def test_requirement_met_in_cheapest_period() -> None:
+    """The load absorbs its requirement when energy is cheapest."""
+    network, load = _build_network(
+        capacity=np.array([5.0, 5.0, 5.0]),
+        required=np.array([0.0, 0.0, 5.0]),
+    )
+
+    cost = network.optimize()
+
+    absorbed = load.extract_values(load.energy)
+    np.testing.assert_allclose(absorbed, [0.0, 5.0, 5.0])
+    deficit = load.extract_values(load.deficit)
+    np.testing.assert_allclose(deficit, [0.0, 0.0, 0.0])
+    assert cost == pytest.approx(5.0 * 0.1)
+
+
+def test_unmeetable_requirement_prices_the_deficit() -> None:
+    """A physically unmeetable requirement is priced, not infeasible."""
+    network, load = _build_network(
+        capacity=np.array([8.0, 8.0, 8.0]),
+        required=np.array([0.0, 0.0, 8.0]),
+        deficit_price=5.0,
+        max_supply_power=[2.0, 2.0],
+    )
+
+    cost = network.optimize()
+
+    absorbed = load.extract_values(load.energy)
+    assert absorbed[-1] == pytest.approx(4.0)  # 2 kW x 2 h is all the supply allows
+    deficit = load.extract_values(load.deficit)
+    assert deficit[-1] == pytest.approx(4.0)
+    # Absorbing at both period prices plus the priced shortfall.
+    assert cost == pytest.approx(2.0 * 0.1 + 2.0 * 0.2 + 4.0 * 5.0)
+
+
+def test_deficit_stays_locked_in_after_deadline() -> None:
+    """A missed deadline stays priced even if capacity later allows catch-up."""
+    network, load = _build_network(
+        capacity=np.array([3.0, 3.0, 6.0]),
+        required=np.array([0.0, 3.0, 3.0]),
+        deficit_price=5.0,
+        supply_price=[0.1, 0.1],
+        max_supply_power=[0.0, 100.0],  # nothing available before the first deadline
+    )
+
+    network.optimize()
+
+    deficit = load.extract_values(load.deficit)
+    assert deficit[1] == pytest.approx(3.0)
+    # The shortfall persists at the horizon end even though absorption resumed.
+    assert deficit[-1] == pytest.approx(3.0)
+
+
+def test_cheap_deficit_price_beats_expensive_energy() -> None:
+    """When energy costs more than the deficit price, the load stays unmet."""
+    network, load = _build_network(
+        capacity=np.array([4.0, 4.0, 4.0]),
+        required=np.array([0.0, 0.0, 4.0]),
+        deficit_price=0.05,
+        supply_price=[0.5, 0.5],
+    )
+
+    cost = network.optimize()
+
+    absorbed = load.extract_values(load.energy)
+    np.testing.assert_allclose(absorbed, [0.0, 0.0, 0.0])
+    assert cost == pytest.approx(4.0 * 0.05)
+
+
+def test_initial_energy_counts_toward_requirement() -> None:
+    """Energy already absorbed before the horizon reduces what must flow."""
+    network, load = _build_network(
+        capacity=np.array([5.0, 5.0, 5.0]),
+        required=np.array([0.0, 0.0, 5.0]),
+        initial_energy=2.0,
+    )
+
+    cost = network.optimize()
+
+    absorbed = load.extract_values(load.energy)
+    assert absorbed[0] == pytest.approx(2.0)
+    assert absorbed[-1] == pytest.approx(5.0)
+    assert cost == pytest.approx(3.0 * 0.1)
+
+
+def test_overage_is_priced() -> None:
+    """Absorbing beyond the requirement costs the overage price."""
+    network, load = _build_network(
+        capacity=np.array([10.0, 10.0, 10.0]),
+        required=np.array([0.0, 0.0, 4.0]),
+        # Negative supply price would reward unlimited absorption; the
+        # overage price caps the free lunch at the requirement.
+        supply_price=[-0.2, -0.2],
+        overage_price=1.0,
+    )
+
+    network.optimize()
+
+    absorbed = load.extract_values(load.energy)
+    # Requirement is worth absorbing at negative price, overage is not
+    # (1.0 overage price outweighs the 0.2 reward).
+    assert absorbed[-1] == pytest.approx(4.0)
+
+
+def test_outputs_present() -> None:
+    """The element exposes power, absorbed, and deficit outputs."""
+    network, load = _build_network(
+        capacity=np.array([5.0, 5.0, 5.0]),
+        required=np.array([0.0, 0.0, 5.0]),
+    )
+    network.optimize()
+
+    outputs = load.outputs()
+    assert outputs["deferrable_load_energy_absorbed"].values[-1] == pytest.approx(5.0)
+    assert outputs["deferrable_load_energy_deficit"].values[-1] == pytest.approx(0.0)
+    assert len(outputs["deferrable_load_power"].values) == 2

--- a/custom_components/haeo/core/model/tests/test_deferrable_load.py
+++ b/custom_components/haeo/core/model/tests/test_deferrable_load.py
@@ -173,3 +173,34 @@ def test_outputs_present() -> None:
     assert outputs["deferrable_load_energy_absorbed"].values[-1] == pytest.approx(5.0)
     assert outputs["deferrable_load_energy_deficit"].values[-1] == pytest.approx(0.0)
     assert len(outputs["deferrable_load_power"].values) == 2
+
+
+def test_initial_energy_beyond_capacity_stays_feasible() -> None:
+    """Telemetry reporting more absorbed than planned must not crash the model."""
+    network, load = _build_network(
+        capacity=np.array([3.0, 3.0, 3.0]),
+        required=np.array([0.0, 0.0, 3.0]),
+        initial_energy=5.0,  # the car drove further than the schedule planned
+    )
+
+    cost = network.optimize()
+
+    absorbed = load.extract_values(load.energy)
+    assert absorbed[0] == pytest.approx(5.0)
+    deficit = load.extract_values(load.deficit)
+    np.testing.assert_allclose(deficit, [0.0, 0.0, 0.0])
+    assert cost == pytest.approx(0.0)
+
+
+def test_initial_overshoot_is_not_priced_as_overage() -> None:
+    """An initial overshoot is a fact from telemetry, not priced overage."""
+    network, _load = _build_network(
+        capacity=np.array([4.0, 4.0, 4.0]),
+        required=np.array([0.0, 0.0, 4.0]),
+        initial_energy=6.0,
+        overage_price=100.0,
+    )
+
+    cost = network.optimize()
+
+    assert cost == pytest.approx(0.0)


### PR DESCRIPTION
:robot: Stacked on #492.

## Summary

Adds a `deferrable_load` model element: a sink that absorbs a required amount of energy within scheduled windows, with the requirement priced rather than hard.

- **Capacity profile** (cumulative, boundary-aligned) opens as windows begin — absorption cannot run ahead of the schedule.
- **Requirement profile** (cumulative) falls due as windows end.
- **Deficit**: a non-decreasing variable ≥ requirement − absorbed. Because it can never shrink, a missed deadline stays priced even if absorption later catches up. Each deficit increment is charged at `deficit_price` for the boundary where it locks in (scalar or time series — with a scalar this telescopes to price × final deficit).
- **Overage**: absorption beyond the total requirement is priced at `overage_price`.

This keeps the optimization feasible when a requirement physically cannot be met while still making the optimizer work to meet it. The EV element (#495) uses it for the trip energy sink — the deficit price is the public charging price. It also lays the model-layer groundwork for deferrable loads (#37).

> Note: the branch name (`feature/battery-min-charge`) is historical — an earlier revision implemented this as a battery minimum-charge constraint; the deferrable load with a priced deficit replaced it per review.

## Testing
- `test_deferrable_load.py`: requirement met in the cheapest period; unmeetable requirements price the deficit instead of going infeasible; deficits stay locked in after missed deadlines; a cheap deficit price beats expensive energy; initial energy credits; overage pricing caps negative-price free lunches.
- `uv run check`: all 11 gates pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

:robot: **Update — telemetry hardening and battery reserve pricing:**
- The deferrable load's effective capacity never sits below `initial_energy`, and an initial overshoot is not priced as overage — live telemetry reporting more absorbed energy than planned (an EV that drove further than forecast) can no longer make the optimization infeasible.
- The model battery gains optional **reserve demand pricing**: at masked boundaries (e.g. trip window ends), dropping below a reserve level is priced once on the lowest level hit, not per interval below the reserve. Batteries without reserve config are structurally unchanged.