### PR TITLE
Add the EV element with calendar-driven trip modeling

### DIFF
--- a/custom_components/haeo/core/adapters/elements/ev.py
+++ b/custom_components/haeo/core/adapters/elements/ev.py
@@ -1,0 +1,452 @@
+"""EV element adapter for model layer integration."""
+
+from collections.abc import Mapping
+from dataclasses import replace
+from typing import Any, Final, Literal
+
+import numpy as np
+from numpy.typing import NDArray
+
+from custom_components.haeo.core.adapters.output_utils import connection_power, expect_output_data
+from custom_components.haeo.core.const import ConnectivityLevel
+from custom_components.haeo.core.data.loader.calendar_resolver import CalendarBoundaryData
+from custom_components.haeo.core.model import ModelElementConfig, ModelOutputName, ModelOutputValue
+from custom_components.haeo.core.model import battery as model_battery
+from custom_components.haeo.core.model.const import OutputType
+from custom_components.haeo.core.model.elements import (
+    MODEL_ELEMENT_TYPE_BATTERY,
+    MODEL_ELEMENT_TYPE_CONNECTION,
+    MODEL_ELEMENT_TYPE_NODE,
+)
+from custom_components.haeo.core.model.elements.connection import CONNECTION_SEGMENTS
+from custom_components.haeo.core.model.output_data import OutputData
+from custom_components.haeo.core.schema import extract_connection_target
+from custom_components.haeo.core.schema.elements import ElementType
+from custom_components.haeo.core.schema.elements.ev import (
+    CONF_CAPACITY,
+    CONF_CONNECTED,
+    CONF_CURRENT_SOC,
+    CONF_ENERGY_PER_DISTANCE,
+    CONF_MAX_CHARGE_RATE,
+    CONF_MAX_DISCHARGE_RATE,
+    CONF_ODOMETER,
+    CONF_ODOMETER_AT_DISCONNECT,
+    CONF_PUBLIC_CHARGING_PRICE,
+    CONF_TRIP_CALENDAR,
+    ELEMENT_TYPE,
+    SECTION_CHARGING,
+    SECTION_PUBLIC_CHARGING,
+    SECTION_TRIP,
+    SECTION_VEHICLE,
+    EvConfigData,
+)
+from custom_components.haeo.core.schema.sections import (
+    CONF_CONNECTION,
+    CONF_EFFICIENCY_SOURCE_TARGET,
+    CONF_EFFICIENCY_TARGET_SOURCE,
+    CONF_MAX_POWER_SOURCE_TARGET,
+    CONF_MAX_POWER_TARGET_SOURCE,
+    SECTION_EFFICIENCY,
+    SECTION_POWER_LIMITS,
+)
+
+# Effectively unlimited power (kW) for trip/public flows that are only
+# gated by the away mask, not by a physical charger.
+_UNLIMITED_POWER: Final = 1.0e6
+
+# Threshold above which a connected flag counts as plugged in.
+_CONNECTED_THRESHOLD: Final = 0.5
+
+# Default public charging price ($/kWh) when none is configured. High enough
+# that home charging always wins when physically possible, but finite so the
+# trip energy requirement can never make the optimization infeasible.
+DEFAULT_PUBLIC_CHARGING_PRICE: Final = 10.0
+
+# EV-specific output names for translation/sensor mapping
+type EvOutputName = Literal[
+    "ev_power_charge",
+    "ev_power_discharge",
+    "ev_power_active",
+    "ev_state_of_charge",
+    "ev_energy_stored",
+    "ev_trip_energy_delivered",
+    "ev_public_charge_power",
+    "ev_power_max_charge_price",
+    "ev_power_max_discharge_price",
+]
+
+EV_OUTPUT_NAMES: Final[frozenset[EvOutputName]] = frozenset(
+    (
+        EV_POWER_CHARGE := "ev_power_charge",
+        EV_POWER_DISCHARGE := "ev_power_discharge",
+        EV_POWER_ACTIVE := "ev_power_active",
+        EV_STATE_OF_CHARGE := "ev_state_of_charge",
+        EV_ENERGY_STORED := "ev_energy_stored",
+        EV_TRIP_ENERGY_DELIVERED := "ev_trip_energy_delivered",
+        EV_PUBLIC_CHARGE_POWER := "ev_public_charge_power",
+        EV_POWER_MAX_CHARGE_PRICE := "ev_power_max_charge_price",
+        EV_POWER_MAX_DISCHARGE_PRICE := "ev_power_max_discharge_price",
+    )
+)
+
+type EvDeviceName = Literal[ElementType.EV]
+
+EV_DEVICE_NAMES: Final[frozenset[EvDeviceName]] = frozenset(
+    (EV_DEVICE_EV := ElementType.EV,),
+)
+
+
+class EvAdapter:
+    """Adapter for EV elements."""
+
+    element_type: str = ELEMENT_TYPE
+    advanced: bool = False
+    connectivity: ConnectivityLevel = ConnectivityLevel.ADVANCED
+    can_source: bool = True
+    can_sink: bool = True
+
+    def model_elements(self, config: EvConfigData) -> list[ModelElementConfig]:
+        """Create model elements for EV configuration.
+
+        Creates 7 model elements:
+        1. {name} - Battery (EV battery)
+        2. {name}:charge - Connection (network → EV, home charging)
+        3. {name}:discharge - Connection (EV → network, V2G)
+        4. {name}:trip - Battery (trip energy sink with min-charge requirement)
+        5. {name}:trip_connection - Connection (EV → trip battery, away only)
+        6. {name}:public_grid - Node (public charging source)
+        7. {name}:public_connection - Connection (public grid → trip battery, priced)
+
+        Trip windows come from the trip calendar: while away the home
+        connections are masked off and trip energy (distance times consumption)
+        must be delivered into the trip battery by each trip's end — from
+        the EV pack or from the public grid at the public charging price.
+        """
+        name = config["name"]
+        vehicle = config[SECTION_VEHICLE]
+        charging = config[SECTION_CHARGING]
+        power_limits = config[SECTION_POWER_LIMITS]
+        efficiency = config[SECTION_EFFICIENCY]
+        target_name = extract_connection_target(config[CONF_CONNECTION])
+
+        capacity = vehicle[CONF_CAPACITY]
+        capacity_first = float(capacity[0])
+        # current_soc is already a 0-1 ratio (the loader converts percent fields)
+        initial_charge = vehicle[CONF_CURRENT_SOC] * capacity_first
+        energy_per_distance = float(vehicle[CONF_ENERGY_PER_DISTANCE])
+
+        max_charge = charging[CONF_MAX_CHARGE_RATE]
+        max_discharge = charging.get(CONF_MAX_DISCHARGE_RATE, 0.0)
+
+        trip = config.get(SECTION_TRIP, {})
+        calendar = trip.get(CONF_TRIP_CALENDAR)
+        connected_live = trip.get(CONF_CONNECTED)
+
+        # Trip energy requirements from the calendar (distances in km):
+        # capacity opens at each trip's start, the requirement is due by its
+        # end. Cumulative sums let multiple trips share the one sink.
+        trip_capacity: NDArray[np.float64] | float = 0.0
+        trip_required: NDArray[np.float64] | float = 0.0
+        if calendar is not None:
+            trip_capacity = np.cumsum(calendar["value_edge_start"]) * energy_per_distance
+            trip_required = np.cumsum(calendar["value_edge_end"]) * energy_per_distance
+
+        connected_flag = _combine_connected(calendar, connected_live)
+        away_flag = _invert_flag(connected_flag)
+
+        trip_initial = _trip_progress_energy(trip, energy_per_distance, connected_flag, trip_required)
+
+        # Home charging limits zeroed while away via connected_flag
+        home_max_charge = _apply_connected_mask(max_charge, connected_flag)
+        home_max_discharge = _apply_connected_mask(max_discharge, connected_flag)
+
+        return [
+            # 1. EV Battery
+            {
+                "element_type": MODEL_ELEMENT_TYPE_BATTERY,
+                "name": name,
+                "capacity": capacity,
+                "initial_charge": initial_charge,
+                "salvage_value": 0.0,
+            },
+            # 2. Home charging: network → EV
+            {
+                "element_type": MODEL_ELEMENT_TYPE_CONNECTION,
+                "name": f"{name}:charge",
+                "source": target_name,
+                "target": name,
+                "segments": {
+                    "efficiency": {
+                        "segment_type": "efficiency",
+                        "efficiency": efficiency.get(CONF_EFFICIENCY_TARGET_SOURCE),
+                    },
+                    "power_limit": {
+                        "segment_type": "power_limit",
+                        "max_power": _combine_limits(
+                            home_max_charge,
+                            power_limits.get(CONF_MAX_POWER_TARGET_SOURCE),
+                        ),
+                    },
+                },
+            },
+            # 3. V2G discharge: EV → network
+            {
+                "element_type": MODEL_ELEMENT_TYPE_CONNECTION,
+                "name": f"{name}:discharge",
+                "source": name,
+                "target": target_name,
+                "segments": {
+                    "efficiency": {
+                        "segment_type": "efficiency",
+                        "efficiency": efficiency.get(CONF_EFFICIENCY_SOURCE_TARGET),
+                    },
+                    "power_limit": {
+                        "segment_type": "power_limit",
+                        "max_power": _combine_limits(
+                            home_max_discharge,
+                            power_limits.get(CONF_MAX_POWER_SOURCE_TARGET),
+                        ),
+                    },
+                },
+            },
+            # 4. Trip battery (energy sink for trip consumption)
+            {
+                "element_type": MODEL_ELEMENT_TYPE_BATTERY,
+                "name": f"{name}:trip",
+                "capacity": trip_capacity,
+                "initial_charge": trip_initial,
+                "min_charge": trip_required,
+                "salvage_value": 0.0,
+            },
+            # 5. Trip connection: EV → trip battery. Driving power is not
+            # limited by the charger, only by being away.
+            {
+                "element_type": MODEL_ELEMENT_TYPE_CONNECTION,
+                "name": f"{name}:trip_connection",
+                "source": name,
+                "target": f"{name}:trip",
+                "segments": {
+                    "power_limit": {
+                        "segment_type": "power_limit",
+                        "max_power": _mask_or_zero(away_flag, _UNLIMITED_POWER),
+                    },
+                },
+            },
+            # 6. Public charging grid (source-only node)
+            {
+                "element_type": MODEL_ELEMENT_TYPE_NODE,
+                "name": f"{name}:public_grid",
+                "is_source": True,
+                "is_sink": False,
+            },
+            # 7. Public charging: public grid → trip battery. Always present
+            # and always priced: it is the relief valve that keeps the trip
+            # requirement feasible when home charging cannot cover it.
+            {
+                "element_type": MODEL_ELEMENT_TYPE_CONNECTION,
+                "name": f"{name}:public_connection",
+                "source": f"{name}:public_grid",
+                "target": f"{name}:trip",
+                "is_external": True,
+                "segments": {
+                    "power_limit": {
+                        "segment_type": "power_limit",
+                        "max_power": _mask_or_zero(away_flag, _UNLIMITED_POWER),
+                    },
+                    "pricing": {
+                        "segment_type": "pricing",
+                        "price": _public_price(config),
+                    },
+                },
+            },
+        ]
+
+    def outputs(
+        self,
+        name: str,
+        model_outputs: Mapping[str, Mapping[ModelOutputName, ModelOutputValue]],
+        *,
+        config: EvConfigData,
+        **_kwargs: Any,
+    ) -> Mapping[EvDeviceName, Mapping[EvOutputName, OutputData]]:
+        """Map model outputs to EV-specific output names."""
+        battery_outputs = model_outputs[name]
+        trip_outputs = model_outputs[f"{name}:trip"]
+        charge_conn = model_outputs.get(f"{name}:charge")
+        discharge_conn = model_outputs.get(f"{name}:discharge")
+
+        energy_stored = expect_output_data(battery_outputs[model_battery.BATTERY_ENERGY_STORED])
+        period_count = len(expect_output_data(battery_outputs[model_battery.BATTERY_POWER_CHARGE]).values)
+
+        power_charge = replace(connection_power(charge_conn, period_count), type=OutputType.POWER, direction="-")
+        power_discharge = replace(connection_power(discharge_conn, period_count), type=OutputType.POWER, direction="+")
+
+        ev_outputs: dict[EvOutputName, OutputData] = {
+            EV_POWER_CHARGE: power_charge,
+            EV_POWER_DISCHARGE: power_discharge,
+            EV_ENERGY_STORED: energy_stored,
+        }
+
+        # Active power (discharge - charge)
+        ev_outputs[EV_POWER_ACTIVE] = replace(
+            power_discharge,
+            values=[d - c for d, c in zip(power_discharge.values, power_charge.values, strict=True)],
+            direction=None,
+            type=OutputType.POWER,
+        )
+
+        # State of charge as a 0-1 ratio (display scales percent outputs)
+        vehicle = config[SECTION_VEHICLE]
+        capacity_first = float(vehicle[CONF_CAPACITY][0])
+        if capacity_first > 0:
+            soc_values = [float(e) / capacity_first for e in energy_stored.values]
+        else:
+            soc_values = [0.0] * len(energy_stored.values)
+
+        ev_outputs[EV_STATE_OF_CHARGE] = OutputData(
+            type=OutputType.STATE_OF_CHARGE,
+            unit="%",
+            values=tuple(soc_values),
+            direction=None,
+        )
+
+        # Trip energy delivered so far (trip battery energy stored)
+        trip_energy = expect_output_data(trip_outputs[model_battery.BATTERY_ENERGY_STORED])
+        ev_outputs[EV_TRIP_ENERGY_DELIVERED] = replace(trip_energy, type=OutputType.ENERGY)
+
+        # Public charging power
+        pub_connection = model_outputs.get(f"{name}:public_connection")
+        if pub_connection is not None:
+            ev_outputs[EV_PUBLIC_CHARGE_POWER] = replace(
+                connection_power(pub_connection, period_count), type=OutputType.POWER
+            )
+
+        # Shadow prices for the home charge/discharge power limits
+        shadow_mappings: tuple[tuple[EvOutputName, Mapping[ModelOutputName, ModelOutputValue] | None], ...] = (
+            (EV_POWER_MAX_CHARGE_PRICE, charge_conn),
+            (EV_POWER_MAX_DISCHARGE_PRICE, discharge_conn),
+        )
+        for output_name, conn in shadow_mappings:
+            if (
+                conn is not None
+                and isinstance(segments_output := conn.get(CONNECTION_SEGMENTS), Mapping)
+                and isinstance(power_limit_outputs := segments_output.get("power_limit"), Mapping)
+                and (shadow := expect_output_data(power_limit_outputs.get("power_limit"))) is not None
+            ):
+                ev_outputs[output_name] = shadow
+
+        return {EV_DEVICE_EV: ev_outputs}
+
+
+adapter = EvAdapter()
+
+
+def _public_price(config: EvConfigData) -> NDArray[np.floating[Any]] | float:
+    """Return the configured public charging price or the high default."""
+    public_charging = config.get(SECTION_PUBLIC_CHARGING, {})
+    price = public_charging.get(CONF_PUBLIC_CHARGING_PRICE)
+    if price is None:
+        return DEFAULT_PUBLIC_CHARGING_PRICE
+    return price
+
+
+def _combine_connected(
+    calendar: CalendarBoundaryData | None,
+    connected_live: NDArray[np.floating[Any]] | float | None,
+) -> NDArray[np.floating[Any]] | float | None:
+    """Combine calendar presence and the live connected sensor.
+
+    The calendar is authoritative for the future (away during trip windows);
+    the live sensor pins the present interval. Without a calendar the live
+    sensor value applies across the whole horizon. Returns per-interval
+    values, a scalar, or None when neither source is configured.
+    """
+    if calendar is None:
+        return connected_live
+
+    # presence marks periods overlapping a trip window; drop the trailing
+    # boundary entry to get the n per-interval mask.
+    connected = 1.0 - np.asarray(calendar["presence"][:-1], dtype=np.float64)
+
+    if connected_live is not None:
+        live_now = float(np.atleast_1d(connected_live)[0])
+        connected = connected.copy()
+        connected[0] = live_now
+
+    return connected
+
+
+def _trip_progress_energy(
+    trip: Mapping[str, Any],
+    energy_per_distance: float,
+    connected_flag: NDArray[np.floating[Any]] | float | None,
+    trip_required: NDArray[np.float64] | float,
+) -> float:
+    """Energy already consumed on the current trip, from odometer readings.
+
+    Only applies while the EV is away: the distance driven since disconnect
+    counts toward the current trip's requirement so the optimizer does not
+    double-charge for distance already covered.
+    """
+    if connected_flag is None:
+        return 0.0
+    if float(np.atleast_1d(connected_flag)[0]) >= _CONNECTED_THRESHOLD:
+        return 0.0
+
+    odometer = trip.get(CONF_ODOMETER)
+    odometer_at_disconnect = trip.get(CONF_ODOMETER_AT_DISCONNECT)
+    if odometer is None or odometer_at_disconnect is None:
+        return 0.0
+
+    progress = max(0.0, float(odometer) - float(odometer_at_disconnect)) * energy_per_distance
+    return min(progress, float(np.max(np.atleast_1d(trip_required))))
+
+
+def _apply_connected_mask(
+    value: NDArray[np.floating[Any]] | float | None,
+    connected_flag: NDArray[np.floating[Any]] | float | None,
+) -> NDArray[np.floating[Any]] | float | None:
+    """Apply connected flag as a mask to a power limit value.
+
+    When connected_flag is 0.0, the result is 0.0 (disabled).
+    When connected_flag is 1.0, the result is the original value.
+    """
+    if connected_flag is None:
+        return value
+    if value is None:
+        return None
+    return value * connected_flag
+
+
+def _invert_flag(
+    flag: NDArray[np.floating[Any]] | float | None,
+) -> NDArray[np.floating[Any]] | float | None:
+    """Invert a binary flag (1.0 → 0.0, 0.0 → 1.0)."""
+    if flag is None:
+        return None
+    return 1.0 - flag
+
+
+def _mask_or_zero(
+    flag: NDArray[np.floating[Any]] | float | None,
+    magnitude: float,
+) -> NDArray[np.floating[Any]] | float:
+    """Scale a binary mask to a power limit; no mask means no flow."""
+    if flag is None:
+        return 0.0
+    return flag * magnitude
+
+
+def _combine_limits(
+    *limits: NDArray[np.floating[Any]] | float | None,
+) -> NDArray[np.floating[Any]] | float | None:
+    """Combine multiple power limit values by taking the element-wise minimum.
+
+    None values are ignored. If all values are None, returns None.
+    """
+    result: NDArray[np.floating[Any]] | float | None = None
+    for limit in limits:
+        if limit is None:
+            continue
+        result = limit if result is None else np.minimum(result, limit)
+    return result

--- a/custom_components/haeo/core/adapters/elements/ev.py
+++ b/custom_components/haeo/core/adapters/elements/ev.py
@@ -1,7 +1,7 @@
 """EV element adapter for model layer integration."""
 
 from collections.abc import Mapping
-from dataclasses import replace
+from dataclasses import dataclass, replace
 from typing import Any, Final, Literal
 
 import numpy as np
@@ -18,6 +18,7 @@ from custom_components.haeo.core.model.elements import (
     MODEL_ELEMENT_TYPE_CONNECTION,
     MODEL_ELEMENT_TYPE_DEFERRABLE_LOAD,
 )
+from custom_components.haeo.core.model.elements.battery import BATTERY_RESERVE_SHORTFALL, BatteryElementConfig
 from custom_components.haeo.core.model.elements.connection import CONNECTION_SEGMENTS
 from custom_components.haeo.core.model.elements.deferrable_load import (
     DEFERRABLE_LOAD_ENERGY_ABSORBED,
@@ -36,6 +37,8 @@ from custom_components.haeo.core.schema.elements.ev import (
     CONF_ODOMETER,
     CONF_ODOMETER_AT_DISCONNECT,
     CONF_PUBLIC_CHARGING_PRICE,
+    CONF_RESERVE_PRICE,
+    CONF_RESERVE_SOC,
     CONF_TRIP_CALENDAR,
     ELEMENT_TYPE,
     SECTION_CHARGING,
@@ -75,6 +78,7 @@ type EvOutputName = Literal[
     "ev_energy_stored",
     "ev_trip_energy_delivered",
     "ev_trip_energy_deficit",
+    "ev_reserve_shortfall",
     "ev_power_max_charge_price",
     "ev_power_max_discharge_price",
 ]
@@ -88,6 +92,7 @@ EV_OUTPUT_NAMES: Final[frozenset[EvOutputName]] = frozenset(
         EV_ENERGY_STORED := "ev_energy_stored",
         EV_TRIP_ENERGY_DELIVERED := "ev_trip_energy_delivered",
         EV_TRIP_ENERGY_DEFICIT := "ev_trip_energy_deficit",
+        EV_RESERVE_SHORTFALL := "ev_reserve_shortfall",
         EV_POWER_MAX_CHARGE_PRICE := "ev_power_max_charge_price",
         EV_POWER_MAX_DISCHARGE_PRICE := "ev_power_max_discharge_price",
     )
@@ -135,8 +140,9 @@ class EvAdapter:
 
         capacity = vehicle[CONF_CAPACITY]
         capacity_first = float(capacity[0])
-        # current_soc is already a 0-1 ratio (the loader converts percent fields)
-        initial_charge = vehicle[CONF_CURRENT_SOC] * capacity_first
+        # current_soc is already a 0-1 ratio (the loader converts percent
+        # fields); clamp so a glitched sensor cannot make the model infeasible
+        initial_charge = min(max(vehicle[CONF_CURRENT_SOC], 0.0), 1.0) * capacity_first
         energy_per_distance = float(vehicle[CONF_ENERGY_PER_DISTANCE])
 
         max_charge = charging[CONF_MAX_CHARGE_RATE]
@@ -158,21 +164,29 @@ class EvAdapter:
         connected_flag = _combine_connected(calendar, connected_live)
         away_flag = _invert_flag(connected_flag)
 
-        trip_initial = _trip_progress_energy(trip, energy_per_distance, connected_flag, trip_required)
+        trip_initial = _trip_progress_energy(trip, energy_per_distance, connected_flag)
 
         # Home charging limits zeroed while away via connected_flag
         home_max_charge = _apply_connected_mask(max_charge, connected_flag)
         home_max_discharge = _apply_connected_mask(max_discharge, connected_flag)
 
+        # EV pack battery, with reserve demand pricing at trip window ends
+        pack: BatteryElementConfig = {
+            "element_type": MODEL_ELEMENT_TYPE_BATTERY,
+            "name": name,
+            "capacity": capacity,
+            "initial_charge": initial_charge,
+            "salvage_value": 0.0,
+        }
+        reserve = _reserve_config(config, calendar)
+        if reserve is not None:
+            pack["reserve_level"] = reserve.level
+            pack["reserve_mask"] = reserve.mask
+            pack["reserve_price"] = reserve.price
+
         return [
             # 1. EV Battery
-            {
-                "element_type": MODEL_ELEMENT_TYPE_BATTERY,
-                "name": name,
-                "capacity": capacity,
-                "initial_charge": initial_charge,
-                "salvage_value": 0.0,
-            },
+            pack,
             # 2. Home charging: network → EV
             {
                 "element_type": MODEL_ELEMENT_TYPE_CONNECTION,
@@ -297,6 +311,11 @@ class EvAdapter:
         trip_deficit = expect_output_data(trip_outputs[DEFERRABLE_LOAD_ENERGY_DEFICIT])
         ev_outputs[EV_TRIP_ENERGY_DEFICIT] = replace(trip_deficit, type=OutputType.ENERGY)
 
+        # Reserve shortfall, only when a reserve is configured
+        if config.get(SECTION_TRIP, {}).get(CONF_RESERVE_SOC) is not None:
+            reserve = expect_output_data(battery_outputs[BATTERY_RESERVE_SHORTFALL])
+            ev_outputs[EV_RESERVE_SHORTFALL] = replace(reserve, type=OutputType.ENERGY)
+
         # Shadow prices for the home charge/discharge power limits
         shadow_mappings: tuple[tuple[EvOutputName, Mapping[ModelOutputName, ModelOutputValue] | None], ...] = (
             (EV_POWER_MAX_CHARGE_PRICE, charge_conn),
@@ -356,13 +375,14 @@ def _trip_progress_energy(
     trip: Mapping[str, Any],
     energy_per_distance: float,
     connected_flag: NDArray[np.floating[Any]] | float | None,
-    trip_required: NDArray[np.float64] | float,
 ) -> float:
     """Energy already consumed on the current trip, from odometer readings.
 
     Only applies while the EV is away: the distance driven since disconnect
     counts toward the current trip's requirement so the optimizer does not
-    double-charge for distance already covered.
+    double-charge for distance already covered. The value is deliberately not
+    clamped to the trip requirement — a car that drove further than planned
+    reports more, and the deferrable load tolerates the overshoot.
     """
     if connected_flag is None:
         return 0.0
@@ -374,8 +394,58 @@ def _trip_progress_energy(
     if odometer is None or odometer_at_disconnect is None:
         return 0.0
 
-    progress = max(0.0, float(odometer) - float(odometer_at_disconnect)) * energy_per_distance
-    return min(progress, float(np.max(np.atleast_1d(trip_required))))
+    return max(0.0, float(odometer) - float(odometer_at_disconnect)) * energy_per_distance
+
+
+@dataclass(frozen=True)
+class _ReserveConfig:
+    """Battery reserve parameters derived from the trip configuration."""
+
+    level: NDArray[np.float64]
+    mask: NDArray[np.float64]
+    price: NDArray[np.floating[Any]] | float
+
+
+def _reserve_config(
+    config: EvConfigData,
+    calendar: CalendarBoundaryData | None,
+) -> _ReserveConfig | None:
+    """Battery reserve parameters from the trip reserve configuration.
+
+    The reserve is checked at each trip window's end — because the pack can
+    only drain while away, the level at a window's end is the lowest level
+    hit during that window, so one priced check per window prices the
+    window minimum (demand-level pricing). The price defaults to the public
+    charging price: the cost of restoring the buffer away from home.
+    """
+    trip = config.get(SECTION_TRIP, {})
+    reserve_soc = trip.get(CONF_RESERVE_SOC)
+    if reserve_soc is None or calendar is None:
+        return None
+
+    capacity = config[SECTION_VEHICLE][CONF_CAPACITY]
+    reserve_ratio = min(max(float(reserve_soc), 0.0), 1.0)
+    reserve_price = trip.get(CONF_RESERVE_PRICE)
+    if reserve_price is None:
+        reserve_price = _public_price(config)
+
+    return _ReserveConfig(
+        level=reserve_ratio * np.asarray(capacity, dtype=np.float64),
+        mask=(np.asarray(calendar["value_edge_end"], dtype=np.float64) > 0).astype(np.float64),
+        price=_to_boundaries(reserve_price, len(capacity)),
+    )
+
+
+def _to_boundaries(
+    value: NDArray[np.floating[Any]] | float,
+    n_boundaries: int,
+) -> NDArray[np.floating[Any]] | float:
+    """Extend an interval-shaped series to boundary length by repeating the end."""
+    if not isinstance(value, np.ndarray):
+        return value
+    if len(value) == n_boundaries - 1:
+        return np.append(value, value[-1])
+    return value
 
 
 def _apply_connected_mask(

--- a/custom_components/haeo/core/adapters/elements/ev.py
+++ b/custom_components/haeo/core/adapters/elements/ev.py
@@ -16,9 +16,13 @@ from custom_components.haeo.core.model.const import OutputType
 from custom_components.haeo.core.model.elements import (
     MODEL_ELEMENT_TYPE_BATTERY,
     MODEL_ELEMENT_TYPE_CONNECTION,
-    MODEL_ELEMENT_TYPE_NODE,
+    MODEL_ELEMENT_TYPE_DEFERRABLE_LOAD,
 )
 from custom_components.haeo.core.model.elements.connection import CONNECTION_SEGMENTS
+from custom_components.haeo.core.model.elements.deferrable_load import (
+    DEFERRABLE_LOAD_ENERGY_ABSORBED,
+    DEFERRABLE_LOAD_ENERGY_DEFICIT,
+)
 from custom_components.haeo.core.model.output_data import OutputData
 from custom_components.haeo.core.schema import extract_connection_target
 from custom_components.haeo.core.schema.elements import ElementType
@@ -70,7 +74,7 @@ type EvOutputName = Literal[
     "ev_state_of_charge",
     "ev_energy_stored",
     "ev_trip_energy_delivered",
-    "ev_public_charge_power",
+    "ev_trip_energy_deficit",
     "ev_power_max_charge_price",
     "ev_power_max_discharge_price",
 ]
@@ -83,7 +87,7 @@ EV_OUTPUT_NAMES: Final[frozenset[EvOutputName]] = frozenset(
         EV_STATE_OF_CHARGE := "ev_state_of_charge",
         EV_ENERGY_STORED := "ev_energy_stored",
         EV_TRIP_ENERGY_DELIVERED := "ev_trip_energy_delivered",
-        EV_PUBLIC_CHARGE_POWER := "ev_public_charge_power",
+        EV_TRIP_ENERGY_DEFICIT := "ev_trip_energy_deficit",
         EV_POWER_MAX_CHARGE_PRICE := "ev_power_max_charge_price",
         EV_POWER_MAX_DISCHARGE_PRICE := "ev_power_max_discharge_price",
     )
@@ -108,19 +112,19 @@ class EvAdapter:
     def model_elements(self, config: EvConfigData) -> list[ModelElementConfig]:
         """Create model elements for EV configuration.
 
-        Creates 7 model elements:
+        Creates 5 model elements:
         1. {name} - Battery (EV battery)
         2. {name}:charge - Connection (network → EV, home charging)
         3. {name}:discharge - Connection (EV → network, V2G)
-        4. {name}:trip - Battery (trip energy sink with min-charge requirement)
-        5. {name}:trip_connection - Connection (EV → trip battery, away only)
-        6. {name}:public_grid - Node (public charging source)
-        7. {name}:public_connection - Connection (public grid → trip battery, priced)
+        4. {name}:trip - Deferrable load (trip energy requirement)
+        5. {name}:trip_connection - Connection (EV → trip load, away only)
 
         Trip windows come from the trip calendar: while away the home
         connections are masked off and trip energy (distance times consumption)
-        must be delivered into the trip battery by each trip's end — from
-        the EV pack or from the public grid at the public charging price.
+        is due into the trip load by each trip's end. The requirement is not
+        hard — any shortfall is priced at the public charging price, which
+        models topping up publicly during the trip and keeps the optimization
+        feasible when home charging cannot cover the trip in time.
         """
         name = config["name"]
         vehicle = config[SECTION_VEHICLE]
@@ -209,16 +213,19 @@ class EvAdapter:
                     },
                 },
             },
-            # 4. Trip battery (energy sink for trip consumption)
+            # 4. Trip requirement as a deferrable load: capacity opens at
+            # each trip's start, the requirement is due by its end, and any
+            # locked-in shortfall is priced at the public charging price —
+            # the energy that would have to be bought publicly mid-trip.
             {
-                "element_type": MODEL_ELEMENT_TYPE_BATTERY,
+                "element_type": MODEL_ELEMENT_TYPE_DEFERRABLE_LOAD,
                 "name": f"{name}:trip",
                 "capacity": trip_capacity,
-                "initial_charge": trip_initial,
-                "min_charge": trip_required,
-                "salvage_value": 0.0,
+                "required": trip_required,
+                "initial_energy": trip_initial,
+                "deficit_price": _public_price(config),
             },
-            # 5. Trip connection: EV → trip battery. Driving power is not
+            # 5. Trip connection: EV → trip load. Driving power is not
             # limited by the charger, only by being away.
             {
                 "element_type": MODEL_ELEMENT_TYPE_CONNECTION,
@@ -229,33 +236,6 @@ class EvAdapter:
                     "power_limit": {
                         "segment_type": "power_limit",
                         "max_power": _mask_or_zero(away_flag, _UNLIMITED_POWER),
-                    },
-                },
-            },
-            # 6. Public charging grid (source-only node)
-            {
-                "element_type": MODEL_ELEMENT_TYPE_NODE,
-                "name": f"{name}:public_grid",
-                "is_source": True,
-                "is_sink": False,
-            },
-            # 7. Public charging: public grid → trip battery. Always present
-            # and always priced: it is the relief valve that keeps the trip
-            # requirement feasible when home charging cannot cover it.
-            {
-                "element_type": MODEL_ELEMENT_TYPE_CONNECTION,
-                "name": f"{name}:public_connection",
-                "source": f"{name}:public_grid",
-                "target": f"{name}:trip",
-                "is_external": True,
-                "segments": {
-                    "power_limit": {
-                        "segment_type": "power_limit",
-                        "max_power": _mask_or_zero(away_flag, _UNLIMITED_POWER),
-                    },
-                    "pricing": {
-                        "segment_type": "pricing",
-                        "price": _public_price(config),
                     },
                 },
             },
@@ -310,16 +290,12 @@ class EvAdapter:
             direction=None,
         )
 
-        # Trip energy delivered so far (trip battery energy stored)
-        trip_energy = expect_output_data(trip_outputs[model_battery.BATTERY_ENERGY_STORED])
+        # Trip energy delivered so far and the locked-in shortfall the
+        # optimizer expects to cover with public charging.
+        trip_energy = expect_output_data(trip_outputs[DEFERRABLE_LOAD_ENERGY_ABSORBED])
         ev_outputs[EV_TRIP_ENERGY_DELIVERED] = replace(trip_energy, type=OutputType.ENERGY)
-
-        # Public charging power
-        pub_connection = model_outputs.get(f"{name}:public_connection")
-        if pub_connection is not None:
-            ev_outputs[EV_PUBLIC_CHARGE_POWER] = replace(
-                connection_power(pub_connection, period_count), type=OutputType.POWER
-            )
+        trip_deficit = expect_output_data(trip_outputs[DEFERRABLE_LOAD_ENERGY_DEFICIT])
+        ev_outputs[EV_TRIP_ENERGY_DEFICIT] = replace(trip_deficit, type=OutputType.ENERGY)
 
         # Shadow prices for the home charge/discharge power limits
         shadow_mappings: tuple[tuple[EvOutputName, Mapping[ModelOutputName, ModelOutputValue] | None], ...] = (

--- a/custom_components/haeo/core/adapters/elements/tests/test_ev.py
+++ b/custom_components/haeo/core/adapters/elements/tests/test_ev.py
@@ -1,0 +1,56 @@
+"""Tests for EV adapter availability checks."""
+
+from homeassistant.core import HomeAssistant
+
+from custom_components.haeo.core.schema import (
+    as_calendar_value,
+    as_connection_target,
+    as_constant_value,
+    as_entity_value,
+)
+from custom_components.haeo.core.schema.elements import ElementType, ev
+from custom_components.haeo.elements.availability import schema_config_available
+
+
+def _ev_schema(soc_entity: str, *, with_trip: bool = False) -> ev.EvConfigSchema:
+    """Build an EV config schema pointing at the given SOC entity."""
+    config: dict[str, object] = {
+        "element_type": ElementType.EV,
+        "name": "test_ev",
+        "connection": as_connection_target("switchboard"),
+        ev.SECTION_VEHICLE: {
+            ev.CONF_CAPACITY: as_constant_value(60.0),
+            ev.CONF_ENERGY_PER_DISTANCE: as_constant_value(0.15),
+            ev.CONF_CURRENT_SOC: as_entity_value([soc_entity]),
+        },
+        ev.SECTION_CHARGING: {
+            ev.CONF_MAX_CHARGE_RATE: as_constant_value(7.4),
+        },
+        "power_limits": {},
+        "efficiency": {},
+    }
+    if with_trip:
+        config[ev.SECTION_TRIP] = {
+            ev.CONF_TRIP_CALENDAR: as_calendar_value("calendar.ev_trips"),
+            ev.CONF_CONNECTED: as_constant_value(1.0),
+        }
+    return config  # type: ignore[return-value]  # constructed to match EvConfigSchema
+
+
+async def test_available_returns_true_when_soc_sensor_exists(hass: HomeAssistant) -> None:
+    """EV availability requires the SOC sensor to exist."""
+    hass.states.async_set("sensor.ev_soc", "80.0", {"unit_of_measurement": "%"})
+
+    assert schema_config_available(_ev_schema("sensor.ev_soc"), sm=hass.states) is True
+
+
+async def test_available_returns_false_when_soc_sensor_missing(hass: HomeAssistant) -> None:
+    """A missing SOC sensor makes the EV unavailable."""
+    assert schema_config_available(_ev_schema("sensor.missing"), sm=hass.states) is False
+
+
+async def test_calendar_field_does_not_block_availability(hass: HomeAssistant) -> None:
+    """Calendar values are loaded separately and do not gate availability."""
+    hass.states.async_set("sensor.ev_soc", "80.0", {"unit_of_measurement": "%"})
+
+    assert schema_config_available(_ev_schema("sensor.ev_soc", with_trip=True), sm=hass.states) is True

--- a/custom_components/haeo/core/adapters/elements/tests/test_ev_model.py
+++ b/custom_components/haeo/core/adapters/elements/tests/test_ev_model.py
@@ -1,0 +1,317 @@
+"""Tests for EV element model mapping and trip optimization behavior."""
+
+from typing import Any
+
+import numpy as np
+import pytest
+
+from custom_components.haeo.core.adapters.elements.ev import (
+    DEFAULT_PUBLIC_CHARGING_PRICE,
+    EV_DEVICE_EV,
+    EV_ENERGY_STORED,
+    EV_POWER_ACTIVE,
+    EV_POWER_CHARGE,
+    EV_POWER_DISCHARGE,
+    EV_PUBLIC_CHARGE_POWER,
+    EV_STATE_OF_CHARGE,
+    EV_TRIP_ENERGY_DELIVERED,
+    adapter,
+)
+from custom_components.haeo.core.data.loader.calendar_resolver import CalendarBoundaryData
+from custom_components.haeo.core.model import Network
+from custom_components.haeo.core.model.elements import MODEL_ELEMENT_TYPE_NODE
+from custom_components.haeo.core.model.elements.battery import BATTERY_ENERGY_STORED
+from custom_components.haeo.core.schema import as_connection_target
+from custom_components.haeo.core.schema.elements import ElementType
+from custom_components.haeo.core.schema.elements.ev import EvConfigData
+
+
+def _boundary_data(
+    presence: list[float],
+    value_edge_start: list[float],
+    value_edge_end: list[float],
+) -> CalendarBoundaryData:
+    """Build calendar boundary data with a derived value_span."""
+    return CalendarBoundaryData(
+        presence=np.array(presence, dtype=np.float64),
+        value_span=np.array(presence, dtype=np.float64),
+        value_edge_start=np.array(value_edge_start, dtype=np.float64),
+        value_edge_end=np.array(value_edge_end, dtype=np.float64),
+    )
+
+
+def _ev_config(**overrides: Any) -> EvConfigData:
+    """Build an EV config with sensible defaults, applying overrides."""
+    config: dict[str, Any] = {
+        "element_type": ElementType.EV,
+        "name": "ev",
+        "connection": as_connection_target("home"),
+        "vehicle": {
+            "capacity": np.array([50.0] * 5),
+            "energy_per_distance": 0.2,
+            "current_soc": 0.10,
+        },
+        "charging": {
+            "max_charge_rate": 10.0,
+        },
+        "power_limits": {},
+        "efficiency": {},
+    }
+    config.update(overrides)
+    return config  # type: ignore[return-value]  # constructed to match EvConfigData
+
+
+def _elements_by_name(config: EvConfigData) -> dict[str, dict[str, Any]]:
+    return {element["name"]: dict(element) for element in adapter.model_elements(config)}
+
+
+# --- model_elements structure ---
+
+
+def test_model_elements_structure() -> None:
+    """The adapter creates the seven expected model elements."""
+    elements = _elements_by_name(_ev_config())
+
+    assert set(elements) == {
+        "ev",
+        "ev:charge",
+        "ev:discharge",
+        "ev:trip",
+        "ev:trip_connection",
+        "ev:public_grid",
+        "ev:public_connection",
+    }
+    assert elements["ev"]["element_type"] == "battery"
+    assert elements["ev"]["initial_charge"] == pytest.approx(5.0)  # SOC ratio 0.10 of 50 kWh
+    assert elements["ev:charge"]["source"] == "home"
+    assert elements["ev:charge"]["target"] == "ev"
+    assert elements["ev:discharge"]["source"] == "ev"
+    assert elements["ev:discharge"]["target"] == "home"
+    assert elements["ev:public_grid"]["is_source"] is True
+    assert elements["ev:public_grid"]["is_sink"] is False
+    assert elements["ev:public_connection"]["source"] == "ev:public_grid"
+    assert elements["ev:public_connection"]["target"] == "ev:trip"
+
+
+def test_no_trip_config_yields_inert_trip_battery() -> None:
+    """Without trip data the trip battery is empty and nothing can flow."""
+    elements = _elements_by_name(_ev_config())
+
+    trip = elements["ev:trip"]
+    assert trip["capacity"] == 0.0
+    assert trip["min_charge"] == 0.0
+    assert trip["initial_charge"] == 0.0
+    assert elements["ev:trip_connection"]["segments"]["power_limit"]["max_power"] == 0.0
+    assert elements["ev:public_connection"]["segments"]["power_limit"]["max_power"] == 0.0
+
+
+def test_default_public_price_applies_when_unconfigured() -> None:
+    """The public connection is always priced, defaulting to the high price."""
+    elements = _elements_by_name(_ev_config())
+
+    price = elements["ev:public_connection"]["segments"]["pricing"]["price"]
+    assert price == DEFAULT_PUBLIC_CHARGING_PRICE
+
+
+def test_configured_public_price_is_used() -> None:
+    """A configured public charging price replaces the default."""
+    elements = _elements_by_name(_ev_config(public_charging={"public_charging_price": 0.6}))
+
+    assert elements["ev:public_connection"]["segments"]["pricing"]["price"] == pytest.approx(0.6)
+
+
+def test_calendar_drives_trip_arrays_and_masks() -> None:
+    """Calendar presence and edges become trip capacity, requirement, and masks."""
+    config = _ev_config(
+        trip={
+            "trip_calendar": _boundary_data(
+                presence=[0.0, 0.0, 1.0, 0.0, 0.0],
+                value_edge_start=[0.0, 0.0, 30.0, 0.0, 0.0],
+                value_edge_end=[0.0, 0.0, 0.0, 30.0, 0.0],
+            ),
+        },
+    )
+    elements = _elements_by_name(config)
+
+    trip = elements["ev:trip"]
+    np.testing.assert_allclose(trip["capacity"], [0.0, 0.0, 6.0, 6.0, 6.0])  # 30 km * 0.2 kWh/km
+    np.testing.assert_allclose(trip["min_charge"], [0.0, 0.0, 0.0, 6.0, 6.0])
+
+    # Home charging masked off while away (period 2), trip flow open only then.
+    home_charge_limit = elements["ev:charge"]["segments"]["power_limit"]["max_power"]
+    np.testing.assert_allclose(home_charge_limit, [10.0, 10.0, 0.0, 10.0])
+    trip_limit = elements["ev:trip_connection"]["segments"]["power_limit"]["max_power"]
+    np.testing.assert_allclose(np.asarray(trip_limit) > 0, [False, False, True, False])
+
+
+def test_live_connected_sensor_pins_first_interval() -> None:
+    """The live sensor overrides the calendar for the current interval only."""
+    config = _ev_config(
+        trip={
+            "trip_calendar": _boundary_data(
+                presence=[0.0, 0.0, 1.0, 0.0, 0.0],
+                value_edge_start=[0.0, 0.0, 30.0, 0.0, 0.0],
+                value_edge_end=[0.0, 0.0, 0.0, 30.0, 0.0],
+            ),
+            "connected": 0.0,
+        },
+    )
+    elements = _elements_by_name(config)
+
+    home_charge_limit = elements["ev:charge"]["segments"]["power_limit"]["max_power"]
+    np.testing.assert_allclose(home_charge_limit, [0.0, 10.0, 0.0, 10.0])
+
+
+def test_odometer_progress_reduces_trip_requirement() -> None:
+    """While away, distance already driven becomes trip battery initial charge."""
+    config = _ev_config(
+        trip={
+            "trip_calendar": _boundary_data(
+                presence=[1.0, 0.0, 0.0, 0.0, 0.0],
+                value_edge_start=[30.0, 0.0, 0.0, 0.0, 0.0],
+                value_edge_end=[0.0, 30.0, 0.0, 0.0, 0.0],
+            ),
+            "connected": 0.0,
+            "odometer": 10_050.0,
+            "odometer_at_disconnect": 10_040.0,
+        },
+    )
+    elements = _elements_by_name(config)
+
+    # 10 km driven * 0.2 kWh/km = 2 kWh already consumed
+    assert elements["ev:trip"]["initial_charge"] == pytest.approx(2.0)
+
+
+def test_odometer_progress_ignored_while_connected() -> None:
+    """Stale odometer readings do not credit the trip battery when home."""
+    config = _ev_config(
+        trip={
+            "trip_calendar": _boundary_data(
+                presence=[0.0, 0.0, 1.0, 0.0, 0.0],
+                value_edge_start=[0.0, 0.0, 30.0, 0.0, 0.0],
+                value_edge_end=[0.0, 0.0, 0.0, 30.0, 0.0],
+            ),
+            "connected": 1.0,
+            "odometer": 10_050.0,
+            "odometer_at_disconnect": 10_000.0,
+        },
+    )
+    elements = _elements_by_name(config)
+
+    assert elements["ev:trip"]["initial_charge"] == 0.0
+
+
+# --- End-to-end optimization behavior ---
+
+
+def _solve_ev_network(config: EvConfigData, grid_price: list[float]) -> Network:
+    """Build and solve a grid + EV network from the adapter's model elements."""
+    n = len(grid_price)
+    network = Network(name="test", periods=np.array([1.0] * n))
+    network.add({"element_type": MODEL_ELEMENT_TYPE_NODE, "name": "home", "is_source": False, "is_sink": False})
+    network.add({"element_type": MODEL_ELEMENT_TYPE_NODE, "name": "grid", "is_source": True, "is_sink": True})
+    network.add(
+        {
+            "element_type": "connection",
+            "name": "grid:import",
+            "source": "grid",
+            "target": "home",
+            "tags": {1},
+            "segments": {
+                "pricing": {"segment_type": "pricing", "price": np.array(grid_price)},
+            },
+        }
+    )
+
+    # Policy compilation assigns tags in production; default them here.
+    ordered = sorted(adapter.model_elements(config), key=lambda e: e["element_type"] != "node")
+    for element in ordered:
+        if element["element_type"] == "connection":
+            element.setdefault("tags", {1})  # type: ignore[typeddict-unknown-key]  # spec allows tags
+        network.add(element)
+
+    network.optimize()
+    return network
+
+
+def test_optimizer_precharges_before_trip_in_cheap_period() -> None:
+    """The EV charges ahead of the trip when energy is cheapest."""
+    config = _ev_config(
+        trip={
+            "trip_calendar": _boundary_data(
+                presence=[0.0, 0.0, 1.0, 0.0, 0.0],
+                value_edge_start=[0.0, 0.0, 30.0, 0.0, 0.0],
+                value_edge_end=[0.0, 0.0, 0.0, 30.0, 0.0],
+            ),
+        },
+    )
+    network = _solve_ev_network(config, grid_price=[0.1, 0.5, 0.5, 0.5])
+
+    trip_stored = network.elements["ev:trip"].outputs()[BATTERY_ENERGY_STORED].values
+    assert trip_stored[3] == pytest.approx(6.0, abs=1e-6)
+
+    # The 1 kWh top-up (5 kWh initial vs 6 kWh trip) buys in the cheap period.
+    ev_stored = network.elements["ev"].outputs()[BATTERY_ENERGY_STORED].values
+    assert ev_stored[1] == pytest.approx(6.0, abs=1e-6)
+
+
+def test_public_charging_covers_shortfall() -> None:
+    """When home charging cannot cover the trip, the public grid fills the gap."""
+    config = _ev_config(
+        charging={"max_charge_rate": 2.0},
+        trip={
+            "trip_calendar": _boundary_data(
+                presence=[0.0, 0.0, 1.0, 0.0, 0.0],
+                value_edge_start=[0.0, 0.0, 100.0, 0.0, 0.0],
+                value_edge_end=[0.0, 0.0, 0.0, 100.0, 0.0],
+            ),
+        },
+        public_charging={"public_charging_price": 0.8},
+    )
+    # Trip needs 20 kWh; pack holds 5 + at most 4 charged before departure.
+    network = _solve_ev_network(config, grid_price=[0.1, 0.1, 0.1, 0.1])
+
+    trip_stored = network.elements["ev:trip"].outputs()[BATTERY_ENERGY_STORED].values
+    assert trip_stored[3] == pytest.approx(20.0, abs=1e-6)
+
+    public_power = network.elements["ev:public_connection"].outputs()["connection_power"].values
+    assert sum(public_power) > 0.0
+
+
+# --- Outputs mapping ---
+
+
+def test_outputs_mapping_from_solved_network() -> None:
+    """Adapter outputs map solved model values to EV output names."""
+    config = _ev_config(
+        trip={
+            "trip_calendar": _boundary_data(
+                presence=[0.0, 0.0, 1.0, 0.0, 0.0],
+                value_edge_start=[0.0, 0.0, 30.0, 0.0, 0.0],
+                value_edge_end=[0.0, 0.0, 0.0, 30.0, 0.0],
+            ),
+        },
+    )
+    network = _solve_ev_network(config, grid_price=[0.1, 0.5, 0.5, 0.5])
+    model_outputs = {name: element.outputs() for name, element in network.elements.items()}
+
+    outputs = adapter.outputs("ev", model_outputs, config=config)[EV_DEVICE_EV]
+
+    assert set(outputs) >= {
+        EV_POWER_CHARGE,
+        EV_POWER_DISCHARGE,
+        EV_POWER_ACTIVE,
+        EV_STATE_OF_CHARGE,
+        EV_ENERGY_STORED,
+        EV_TRIP_ENERGY_DELIVERED,
+        EV_PUBLIC_CHARGE_POWER,
+    }
+
+    assert outputs[EV_TRIP_ENERGY_DELIVERED].values[3] == pytest.approx(6.0, abs=1e-6)
+    # SOC is derived from stored energy over pack capacity.
+    assert outputs[EV_STATE_OF_CHARGE].values[0] == pytest.approx(0.10)
+    # Active power is discharge minus charge for every period.
+    np.testing.assert_allclose(
+        outputs[EV_POWER_ACTIVE].values,
+        np.asarray(outputs[EV_POWER_DISCHARGE].values) - np.asarray(outputs[EV_POWER_CHARGE].values),
+    )

--- a/custom_components/haeo/core/adapters/elements/tests/test_ev_model.py
+++ b/custom_components/haeo/core/adapters/elements/tests/test_ev_model.py
@@ -12,6 +12,7 @@ from custom_components.haeo.core.adapters.elements.ev import (
     EV_POWER_ACTIVE,
     EV_POWER_CHARGE,
     EV_POWER_DISCHARGE,
+    EV_RESERVE_SHORTFALL,
     EV_STATE_OF_CHARGE,
     EV_TRIP_ENERGY_DEFICIT,
     EV_TRIP_ENERGY_DELIVERED,
@@ -315,3 +316,119 @@ def test_outputs_mapping_from_solved_network() -> None:
         outputs[EV_POWER_ACTIVE].values,
         np.asarray(outputs[EV_POWER_DISCHARGE].values) - np.asarray(outputs[EV_POWER_CHARGE].values),
     )
+
+
+# --- Telemetry robustness ---
+
+
+def test_odometer_overshoot_beyond_trip_stays_feasible() -> None:
+    """A car that drove further than the scheduled trip must still solve."""
+    config = _ev_config(
+        trip={
+            "trip_calendar": _boundary_data(
+                presence=[1.0, 0.0, 0.0, 0.0, 0.0],
+                value_edge_start=[30.0, 0.0, 0.0, 0.0, 0.0],
+                value_edge_end=[0.0, 30.0, 0.0, 0.0, 0.0],
+            ),
+            "connected": 0.0,
+            "odometer": 10_100.0,
+            "odometer_at_disconnect": 10_000.0,  # 100 km driven on a 30 km trip
+        },
+    )
+    elements = _elements_by_name(config)
+    assert elements["ev:trip"]["initial_energy"] == pytest.approx(20.0)  # unclamped
+
+    network = _solve_ev_network(config, grid_price=[0.1, 0.1, 0.1, 0.1])
+
+    trip_outputs = network.elements["ev:trip"].outputs()
+    assert trip_outputs[DEFERRABLE_LOAD_ENERGY_DEFICIT].values[-1] == pytest.approx(0.0)
+
+
+def test_glitched_soc_sensor_is_clamped() -> None:
+    """A SOC reading above 100% cannot make the pack overfull."""
+    config = _ev_config()
+    config["vehicle"]["current_soc"] = 2.5  # 250% from a glitched sensor
+
+    elements = _elements_by_name(config)
+
+    assert elements["ev"]["initial_charge"] == pytest.approx(50.0)  # clamped to capacity
+
+
+# --- Reserve demand pricing ---
+
+
+def _reserve_trip(**extra: Any) -> dict[str, Any]:
+    """Trip config with a calendar and a 20% reserve."""
+    return {
+        "trip_calendar": _boundary_data(
+            presence=[0.0, 0.0, 1.0, 0.0, 0.0],
+            value_edge_start=[0.0, 0.0, 30.0, 0.0, 0.0],
+            value_edge_end=[0.0, 0.0, 0.0, 30.0, 0.0],
+        ),
+        "reserve_soc": 0.2,
+        **extra,
+    }
+
+
+def test_reserve_config_masks_trip_window_ends() -> None:
+    """The reserve applies at trip end boundaries with the pack-scaled level."""
+    config = _ev_config(trip=_reserve_trip(reserve_price=0.5))
+    elements = _elements_by_name(config)
+
+    battery = elements["ev"]
+    np.testing.assert_allclose(battery["reserve_level"], [10.0] * 5)  # 20% of 50 kWh
+    np.testing.assert_allclose(battery["reserve_mask"], [0.0, 0.0, 0.0, 1.0, 0.0])
+    assert battery["reserve_price"] == pytest.approx(0.5)
+
+
+def test_reserve_price_defaults_to_public_price() -> None:
+    """Without an explicit price the public charging price applies."""
+    config = _ev_config(trip=_reserve_trip(), public_charging={"public_charging_price": 0.7})
+    elements = _elements_by_name(config)
+
+    assert elements["ev"]["reserve_price"] == pytest.approx(0.7)
+
+
+def test_reserve_drives_extra_precharge() -> None:
+    """With a reserve, the optimizer charges for the trip plus the buffer."""
+    config = _ev_config(trip=_reserve_trip(reserve_price=2.0))
+    network = _solve_ev_network(config, grid_price=[0.1, 0.5, 0.5, 0.5])
+
+    # Pack ends the trip at the 10 kWh reserve instead of 0.
+    ev_stored = network.elements["ev"].outputs()[BATTERY_ENERGY_STORED].values
+    assert ev_stored[3] == pytest.approx(10.0, abs=1e-6)
+
+    outputs = adapter.outputs("ev", {n: e.outputs() for n, e in network.elements.items()}, config=config)[EV_DEVICE_EV]
+    assert outputs[EV_RESERVE_SHORTFALL].values[3] == pytest.approx(0.0, abs=1e-6)
+
+
+def test_reserve_shortfall_reported_when_unavoidable() -> None:
+    """When the buffer cannot be met, the shortfall sensor reports the dip."""
+    config = _ev_config(
+        charging={"max_charge_rate": 0.5},  # can only add 1 kWh before departure
+        trip=_reserve_trip(reserve_price=0.01),
+        public_charging={"public_charging_price": 10.0},
+    )
+    network = _solve_ev_network(config, grid_price=[0.1, 0.1, 0.1, 0.1])
+
+    outputs = adapter.outputs("ev", {n: e.outputs() for n, e in network.elements.items()}, config=config)[EV_DEVICE_EV]
+    # Pack holds at most 6 kWh at departure; the trip drains it toward zero,
+    # so the 10 kWh reserve is missed at the trip end boundary.
+    assert outputs[EV_RESERVE_SHORTFALL].values[3] > 0.0
+
+
+def test_no_reserve_means_no_reserve_output() -> None:
+    """Without reserve configuration the EV exposes no reserve sensor."""
+    config = _ev_config(
+        trip={
+            "trip_calendar": _boundary_data(
+                presence=[0.0, 0.0, 1.0, 0.0, 0.0],
+                value_edge_start=[0.0, 0.0, 30.0, 0.0, 0.0],
+                value_edge_end=[0.0, 0.0, 0.0, 30.0, 0.0],
+            ),
+        },
+    )
+    network = _solve_ev_network(config, grid_price=[0.1, 0.5, 0.5, 0.5])
+
+    outputs = adapter.outputs("ev", {n: e.outputs() for n, e in network.elements.items()}, config=config)[EV_DEVICE_EV]
+    assert EV_RESERVE_SHORTFALL not in outputs

--- a/custom_components/haeo/core/adapters/elements/tests/test_ev_model.py
+++ b/custom_components/haeo/core/adapters/elements/tests/test_ev_model.py
@@ -12,8 +12,8 @@ from custom_components.haeo.core.adapters.elements.ev import (
     EV_POWER_ACTIVE,
     EV_POWER_CHARGE,
     EV_POWER_DISCHARGE,
-    EV_PUBLIC_CHARGE_POWER,
     EV_STATE_OF_CHARGE,
+    EV_TRIP_ENERGY_DEFICIT,
     EV_TRIP_ENERGY_DELIVERED,
     adapter,
 )
@@ -21,6 +21,10 @@ from custom_components.haeo.core.data.loader.calendar_resolver import CalendarBo
 from custom_components.haeo.core.model import Network
 from custom_components.haeo.core.model.elements import MODEL_ELEMENT_TYPE_NODE
 from custom_components.haeo.core.model.elements.battery import BATTERY_ENERGY_STORED
+from custom_components.haeo.core.model.elements.deferrable_load import (
+    DEFERRABLE_LOAD_ENERGY_ABSORBED,
+    DEFERRABLE_LOAD_ENERGY_DEFICIT,
+)
 from custom_components.haeo.core.schema import as_connection_target
 from custom_components.haeo.core.schema.elements import ElementType
 from custom_components.haeo.core.schema.elements.ev import EvConfigData
@@ -69,7 +73,7 @@ def _elements_by_name(config: EvConfigData) -> dict[str, dict[str, Any]]:
 
 
 def test_model_elements_structure() -> None:
-    """The adapter creates the seven expected model elements."""
+    """The adapter creates the five expected model elements."""
     elements = _elements_by_name(_ev_config())
 
     assert set(elements) == {
@@ -78,8 +82,6 @@ def test_model_elements_structure() -> None:
         "ev:discharge",
         "ev:trip",
         "ev:trip_connection",
-        "ev:public_grid",
-        "ev:public_connection",
     }
     assert elements["ev"]["element_type"] == "battery"
     assert elements["ev"]["initial_charge"] == pytest.approx(5.0)  # SOC ratio 0.10 of 50 kWh
@@ -87,37 +89,34 @@ def test_model_elements_structure() -> None:
     assert elements["ev:charge"]["target"] == "ev"
     assert elements["ev:discharge"]["source"] == "ev"
     assert elements["ev:discharge"]["target"] == "home"
-    assert elements["ev:public_grid"]["is_source"] is True
-    assert elements["ev:public_grid"]["is_sink"] is False
-    assert elements["ev:public_connection"]["source"] == "ev:public_grid"
-    assert elements["ev:public_connection"]["target"] == "ev:trip"
+    assert elements["ev:trip"]["element_type"] == "deferrable_load"
+    assert elements["ev:trip_connection"]["source"] == "ev"
+    assert elements["ev:trip_connection"]["target"] == "ev:trip"
 
 
-def test_no_trip_config_yields_inert_trip_battery() -> None:
-    """Without trip data the trip battery is empty and nothing can flow."""
+def test_no_trip_config_yields_inert_trip_load() -> None:
+    """Without trip data the trip load requires nothing and nothing can flow."""
     elements = _elements_by_name(_ev_config())
 
     trip = elements["ev:trip"]
     assert trip["capacity"] == 0.0
-    assert trip["min_charge"] == 0.0
-    assert trip["initial_charge"] == 0.0
+    assert trip["required"] == 0.0
+    assert trip["initial_energy"] == 0.0
     assert elements["ev:trip_connection"]["segments"]["power_limit"]["max_power"] == 0.0
-    assert elements["ev:public_connection"]["segments"]["power_limit"]["max_power"] == 0.0
 
 
 def test_default_public_price_applies_when_unconfigured() -> None:
-    """The public connection is always priced, defaulting to the high price."""
+    """The trip deficit is always priced, defaulting to the high price."""
     elements = _elements_by_name(_ev_config())
 
-    price = elements["ev:public_connection"]["segments"]["pricing"]["price"]
-    assert price == DEFAULT_PUBLIC_CHARGING_PRICE
+    assert elements["ev:trip"]["deficit_price"] == DEFAULT_PUBLIC_CHARGING_PRICE
 
 
 def test_configured_public_price_is_used() -> None:
-    """A configured public charging price replaces the default."""
+    """A configured public charging price becomes the deficit price."""
     elements = _elements_by_name(_ev_config(public_charging={"public_charging_price": 0.6}))
 
-    assert elements["ev:public_connection"]["segments"]["pricing"]["price"] == pytest.approx(0.6)
+    assert elements["ev:trip"]["deficit_price"] == pytest.approx(0.6)
 
 
 def test_calendar_drives_trip_arrays_and_masks() -> None:
@@ -135,7 +134,7 @@ def test_calendar_drives_trip_arrays_and_masks() -> None:
 
     trip = elements["ev:trip"]
     np.testing.assert_allclose(trip["capacity"], [0.0, 0.0, 6.0, 6.0, 6.0])  # 30 km * 0.2 kWh/km
-    np.testing.assert_allclose(trip["min_charge"], [0.0, 0.0, 0.0, 6.0, 6.0])
+    np.testing.assert_allclose(trip["required"], [0.0, 0.0, 0.0, 6.0, 6.0])
 
     # Home charging masked off while away (period 2), trip flow open only then.
     home_charge_limit = elements["ev:charge"]["segments"]["power_limit"]["max_power"]
@@ -179,7 +178,7 @@ def test_odometer_progress_reduces_trip_requirement() -> None:
     elements = _elements_by_name(config)
 
     # 10 km driven * 0.2 kWh/km = 2 kWh already consumed
-    assert elements["ev:trip"]["initial_charge"] == pytest.approx(2.0)
+    assert elements["ev:trip"]["initial_energy"] == pytest.approx(2.0)
 
 
 def test_odometer_progress_ignored_while_connected() -> None:
@@ -198,7 +197,7 @@ def test_odometer_progress_ignored_while_connected() -> None:
     )
     elements = _elements_by_name(config)
 
-    assert elements["ev:trip"]["initial_charge"] == 0.0
+    assert elements["ev:trip"]["initial_energy"] == 0.0
 
 
 # --- End-to-end optimization behavior ---
@@ -247,16 +246,16 @@ def test_optimizer_precharges_before_trip_in_cheap_period() -> None:
     )
     network = _solve_ev_network(config, grid_price=[0.1, 0.5, 0.5, 0.5])
 
-    trip_stored = network.elements["ev:trip"].outputs()[BATTERY_ENERGY_STORED].values
-    assert trip_stored[3] == pytest.approx(6.0, abs=1e-6)
+    trip_absorbed = network.elements["ev:trip"].outputs()[DEFERRABLE_LOAD_ENERGY_ABSORBED].values
+    assert trip_absorbed[3] == pytest.approx(6.0, abs=1e-6)
 
     # The 1 kWh top-up (5 kWh initial vs 6 kWh trip) buys in the cheap period.
     ev_stored = network.elements["ev"].outputs()[BATTERY_ENERGY_STORED].values
     assert ev_stored[1] == pytest.approx(6.0, abs=1e-6)
 
 
-def test_public_charging_covers_shortfall() -> None:
-    """When home charging cannot cover the trip, the public grid fills the gap."""
+def test_shortfall_becomes_priced_deficit() -> None:
+    """When home charging cannot cover the trip, the shortfall is priced."""
     config = _ev_config(
         charging={"max_charge_rate": 2.0},
         trip={
@@ -271,11 +270,11 @@ def test_public_charging_covers_shortfall() -> None:
     # Trip needs 20 kWh; pack holds 5 + at most 4 charged before departure.
     network = _solve_ev_network(config, grid_price=[0.1, 0.1, 0.1, 0.1])
 
-    trip_stored = network.elements["ev:trip"].outputs()[BATTERY_ENERGY_STORED].values
-    assert trip_stored[3] == pytest.approx(20.0, abs=1e-6)
-
-    public_power = network.elements["ev:public_connection"].outputs()["connection_power"].values
-    assert sum(public_power) > 0.0
+    trip_outputs = network.elements["ev:trip"].outputs()
+    absorbed = trip_outputs[DEFERRABLE_LOAD_ENERGY_ABSORBED].values
+    deficit = trip_outputs[DEFERRABLE_LOAD_ENERGY_DEFICIT].values
+    assert absorbed[3] == pytest.approx(9.0, abs=1e-6)
+    assert deficit[-1] == pytest.approx(11.0, abs=1e-6)
 
 
 # --- Outputs mapping ---
@@ -304,10 +303,11 @@ def test_outputs_mapping_from_solved_network() -> None:
         EV_STATE_OF_CHARGE,
         EV_ENERGY_STORED,
         EV_TRIP_ENERGY_DELIVERED,
-        EV_PUBLIC_CHARGE_POWER,
+        EV_TRIP_ENERGY_DEFICIT,
     }
 
     assert outputs[EV_TRIP_ENERGY_DELIVERED].values[3] == pytest.approx(6.0, abs=1e-6)
+    assert outputs[EV_TRIP_ENERGY_DEFICIT].values[-1] == pytest.approx(0.0, abs=1e-6)
     # SOC is derived from stored energy over pack capacity.
     assert outputs[EV_STATE_OF_CHARGE].values[0] == pytest.approx(0.10)
     # Active power is discharge minus charge for every period.

--- a/custom_components/haeo/core/adapters/registry.py
+++ b/custom_components/haeo/core/adapters/registry.py
@@ -7,6 +7,7 @@ from custom_components.haeo.core.adapters.elements.battery import adapter as bat
 from custom_components.haeo.core.adapters.elements.battery_section import adapter as battery_section_adapter
 from custom_components.haeo.core.adapters.elements.connection import adapter as connection_adapter
 from custom_components.haeo.core.adapters.elements.deferrable_load import adapter as deferrable_load_adapter
+from custom_components.haeo.core.adapters.elements.ev import adapter as ev_adapter
 from custom_components.haeo.core.adapters.elements.grid import adapter as grid_adapter
 from custom_components.haeo.core.adapters.elements.inverter import adapter as inverter_adapter
 from custom_components.haeo.core.adapters.elements.load import adapter as load_adapter
@@ -59,6 +60,7 @@ ELEMENT_TYPES: dict[ElementType, ElementAdapter] = {
     ElementType.SOLAR: solar_adapter,
     ElementType.BATTERY: battery_adapter,
     ElementType.DEFERRABLE_LOAD: deferrable_load_adapter,
+    ElementType.EV: ev_adapter,
     ElementType.CONNECTION: connection_adapter,
     ElementType.NODE: node_adapter,
     ElementType.BATTERY_SECTION: battery_section_adapter,

--- a/custom_components/haeo/core/model/const.py
+++ b/custom_components/haeo/core/model/const.py
@@ -28,6 +28,9 @@ class OutputType(StrEnum):
 
     Other types:
         STATUS: Boolean or categorical status
+        AVAILABILITY: Binary availability schedule (0-1)
+        DISTANCE: Distance quantity (km)
+        ENERGY_PER_DISTANCE: Energy consumption per distance (kWh/km)
         DURATION: Time duration
         SHADOW_PRICE: Shadow prices from LP constraints
 
@@ -43,5 +46,8 @@ class OutputType(StrEnum):
     EFFICIENCY = auto()
     COST = auto()
     STATUS = auto()
+    AVAILABILITY = auto()
+    DISTANCE = auto()
+    ENERGY_PER_DISTANCE = auto()
     DURATION = auto()
     SHADOW_PRICE = auto()

--- a/custom_components/haeo/core/schema/elements/__init__.py
+++ b/custom_components/haeo/core/schema/elements/__init__.py
@@ -13,6 +13,7 @@ from custom_components.haeo.core.schema.elements.deferrable_load import (
     DeferrableLoadConfigSchema,
 )
 from custom_components.haeo.core.schema.elements.element_type import ElementType
+from custom_components.haeo.core.schema.elements.ev import EvConfigData, EvConfigSchema
 from custom_components.haeo.core.schema.elements.grid import GridConfigData, GridConfigSchema
 from custom_components.haeo.core.schema.elements.inverter import InverterConfigData, InverterConfigSchema
 from custom_components.haeo.core.schema.elements.load import LoadConfigData, LoadConfigSchema
@@ -25,6 +26,7 @@ ElementConfigSchema = (
     | BatteryConfigSchema
     | BatterySectionConfigSchema
     | DeferrableLoadConfigSchema
+    | EvConfigSchema
     | GridConfigSchema
     | LoadConfigSchema
     | SolarConfigSchema
@@ -38,6 +40,7 @@ ElementConfigData = (
     | BatteryConfigData
     | BatterySectionConfigData
     | DeferrableLoadConfigData
+    | EvConfigData
     | GridConfigData
     | LoadConfigData
     | SolarConfigData
@@ -51,6 +54,7 @@ ELEMENT_CONFIG_SCHEMAS: Final[dict[ElementType, type]] = {
     ElementType.BATTERY_SECTION: BatterySectionConfigSchema,
     ElementType.CONNECTION: ConnectionConfigSchema,
     ElementType.DEFERRABLE_LOAD: DeferrableLoadConfigSchema,
+    ElementType.EV: EvConfigSchema,
     ElementType.GRID: GridConfigSchema,
     ElementType.INVERTER: InverterConfigSchema,
     ElementType.LOAD: LoadConfigSchema,

--- a/custom_components/haeo/core/schema/elements/element_type.py
+++ b/custom_components/haeo/core/schema/elements/element_type.py
@@ -10,6 +10,7 @@ class ElementType(StrEnum):
     BATTERY_SECTION = "battery_section"
     CONNECTION = "connection"
     DEFERRABLE_LOAD = "deferrable_load"
+    EV = "ev"
     GRID = "grid"
     INVERTER = "inverter"
     LOAD = "load"

--- a/custom_components/haeo/core/schema/elements/ev.py
+++ b/custom_components/haeo/core/schema/elements/ev.py
@@ -1,0 +1,311 @@
+"""EV element schema definitions."""
+
+from typing import Annotated, Any, Final, Literal, NotRequired, TypedDict
+
+import numpy as np
+from numpy.typing import NDArray
+
+from custom_components.haeo.core.data.loader.calendar_resolver import CalendarBoundaryData
+from custom_components.haeo.core.model.const import OutputType
+from custom_components.haeo.core.schema import CalendarValue, ConstantValue, EntityValue, NoneValue
+from custom_components.haeo.core.schema.elements.element_type import ElementType
+from custom_components.haeo.core.schema.field_hints import CalendarFieldHint, FieldHint, SectionHints
+from custom_components.haeo.core.schema.sections import (
+    CONF_EFFICIENCY_SOURCE_TARGET,
+    CONF_EFFICIENCY_TARGET_SOURCE,
+    CONF_MAX_POWER_SOURCE_TARGET,
+    CONF_MAX_POWER_TARGET_SOURCE,
+    ConnectedCommonConfig,
+    ConnectedCommonData,
+    EfficiencyConfig,
+    EfficiencyData,
+    PowerLimitsConfig,
+    PowerLimitsData,
+)
+
+ELEMENT_TYPE = ElementType.EV
+
+# Section names
+SECTION_VEHICLE: Final = "vehicle"
+SECTION_CHARGING: Final = "charging"
+SECTION_TRIP: Final = "trip"
+SECTION_PUBLIC_CHARGING: Final = "public_charging"
+
+# Vehicle section field names
+CONF_CAPACITY: Final = "capacity"
+CONF_ENERGY_PER_DISTANCE: Final = "energy_per_distance"
+CONF_CURRENT_SOC: Final = "current_soc"
+
+# Charging section field names
+CONF_MAX_CHARGE_RATE: Final = "max_charge_rate"
+CONF_MAX_DISCHARGE_RATE: Final = "max_discharge_rate"
+
+# Trip section field names
+CONF_CONNECTED: Final = "connected"
+CONF_TRIP_CALENDAR: Final = "trip_calendar"
+CONF_ODOMETER: Final = "odometer"
+CONF_ODOMETER_AT_DISCONNECT: Final = "odometer_at_disconnect"
+
+# Public charging section field names
+CONF_PUBLIC_CHARGING_PRICE: Final = "public_charging_price"
+
+OPTIONAL_INPUT_FIELDS: Final[frozenset[str]] = frozenset(
+    {
+        CONF_CONNECTED,
+        CONF_TRIP_CALENDAR,
+        CONF_ODOMETER,
+        CONF_ODOMETER_AT_DISCONNECT,
+        CONF_MAX_DISCHARGE_RATE,
+        CONF_MAX_POWER_SOURCE_TARGET,
+        CONF_MAX_POWER_TARGET_SOURCE,
+        CONF_EFFICIENCY_SOURCE_TARGET,
+        CONF_EFFICIENCY_TARGET_SOURCE,
+        CONF_PUBLIC_CHARGING_PRICE,
+    }
+)
+
+
+# --- Vehicle section ---
+
+
+class VehicleConfig(TypedDict):
+    """Vehicle details configuration."""
+
+    capacity: EntityValue | ConstantValue
+    energy_per_distance: EntityValue | ConstantValue
+    current_soc: EntityValue
+
+
+class VehicleData(TypedDict):
+    """Loaded vehicle details."""
+
+    capacity: NDArray[np.floating[Any]]
+    energy_per_distance: float
+    current_soc: float
+
+
+# --- Charging section ---
+
+
+class ChargingConfig(TypedDict):
+    """Charging rate configuration."""
+
+    max_charge_rate: EntityValue | ConstantValue
+    max_discharge_rate: NotRequired[EntityValue | ConstantValue | NoneValue]
+
+
+class ChargingData(TypedDict):
+    """Loaded charging rate values."""
+
+    max_charge_rate: NDArray[np.floating[Any]] | float
+    max_discharge_rate: NotRequired[NDArray[np.floating[Any]] | float]
+
+
+# --- Trip section ---
+
+
+class TripConfig(TypedDict, total=False):
+    """Trip availability configuration.
+
+    The trip calendar drives future availability and per-trip energy
+    requirements; the connected sensor pins the present plugged-in state.
+    Odometer readings correct mid-trip energy accounting.
+    """
+
+    trip_calendar: CalendarValue | NoneValue
+    connected: EntityValue | ConstantValue | NoneValue
+    odometer: EntityValue | NoneValue
+    odometer_at_disconnect: EntityValue | NoneValue
+
+
+class TripData(TypedDict, total=False):
+    """Loaded trip availability values."""
+
+    trip_calendar: CalendarBoundaryData
+    connected: NDArray[np.floating[Any]] | float
+    odometer: float
+    odometer_at_disconnect: float
+
+
+# --- Public charging section ---
+
+
+class PublicChargingConfig(TypedDict, total=False):
+    """Public charging pricing configuration."""
+
+    public_charging_price: EntityValue | ConstantValue | NoneValue
+
+
+class PublicChargingData(TypedDict, total=False):
+    """Loaded public charging pricing values."""
+
+    public_charging_price: NDArray[np.floating[Any]] | float
+
+
+# --- Main element schemas ---
+
+
+class EvConfigSchema(ConnectedCommonConfig):
+    """EV element configuration as stored in Home Assistant."""
+
+    element_type: Literal[ElementType.EV]
+    vehicle: Annotated[
+        VehicleConfig,
+        SectionHints(
+            {
+                CONF_CAPACITY: FieldHint(
+                    output_type=OutputType.ENERGY,
+                    time_series=True,
+                    boundaries=True,
+                ),
+                CONF_ENERGY_PER_DISTANCE: FieldHint(
+                    output_type=OutputType.ENERGY_PER_DISTANCE,
+                    time_series=False,
+                ),
+                CONF_CURRENT_SOC: FieldHint(
+                    output_type=OutputType.STATE_OF_CHARGE,
+                    time_series=False,
+                    step=0.1,
+                ),
+            }
+        ),
+    ]
+    charging: Annotated[
+        ChargingConfig,
+        SectionHints(
+            {
+                CONF_MAX_CHARGE_RATE: FieldHint(
+                    output_type=OutputType.POWER,
+                    direction="+",
+                    time_series=True,
+                    step=0.1,
+                ),
+                CONF_MAX_DISCHARGE_RATE: FieldHint(
+                    output_type=OutputType.POWER,
+                    direction="-",
+                    time_series=True,
+                    step=0.1,
+                ),
+            }
+        ),
+    ]
+    trip: NotRequired[
+        Annotated[
+            TripConfig,
+            SectionHints(
+                {
+                    CONF_TRIP_CALENDAR: FieldHint(
+                        output_type=OutputType.DISTANCE,
+                        time_series=True,
+                        boundaries=True,
+                        calendar=CalendarFieldHint(parser="distance"),
+                    ),
+                    CONF_CONNECTED: FieldHint(
+                        output_type=OutputType.AVAILABILITY,
+                        time_series=True,
+                        default_mode="value",
+                        default_value=1.0,
+                    ),
+                    CONF_ODOMETER: FieldHint(
+                        output_type=OutputType.DISTANCE,
+                        time_series=False,
+                    ),
+                    CONF_ODOMETER_AT_DISCONNECT: FieldHint(
+                        output_type=OutputType.DISTANCE,
+                        time_series=False,
+                    ),
+                }
+            ),
+        ]
+    ]
+    public_charging: NotRequired[
+        Annotated[
+            PublicChargingConfig,
+            SectionHints(
+                {
+                    CONF_PUBLIC_CHARGING_PRICE: FieldHint(
+                        output_type=OutputType.PRICE,
+                        time_series=True,
+                    ),
+                }
+            ),
+        ]
+    ]
+    power_limits: Annotated[
+        PowerLimitsConfig,
+        SectionHints(
+            {
+                CONF_MAX_POWER_SOURCE_TARGET: FieldHint(
+                    output_type=OutputType.POWER_LIMIT,
+                    direction="+",
+                    time_series=True,
+                ),
+                CONF_MAX_POWER_TARGET_SOURCE: FieldHint(
+                    output_type=OutputType.POWER_LIMIT,
+                    direction="-",
+                    time_series=True,
+                ),
+            }
+        ),
+    ]
+    efficiency: Annotated[
+        EfficiencyConfig,
+        SectionHints(
+            {
+                CONF_EFFICIENCY_SOURCE_TARGET: FieldHint(
+                    output_type=OutputType.EFFICIENCY,
+                    time_series=True,
+                    default_mode="value",
+                    default_value=95.0,
+                ),
+                CONF_EFFICIENCY_TARGET_SOURCE: FieldHint(
+                    output_type=OutputType.EFFICIENCY,
+                    time_series=True,
+                    default_mode="value",
+                    default_value=95.0,
+                ),
+            }
+        ),
+    ]
+
+
+class EvConfigData(ConnectedCommonData):
+    """EV element configuration with loaded values."""
+
+    element_type: Literal[ElementType.EV]
+    vehicle: VehicleData
+    charging: ChargingData
+    trip: NotRequired[TripData]
+    public_charging: NotRequired[PublicChargingData]
+    power_limits: PowerLimitsData
+    efficiency: EfficiencyData
+
+
+__all__ = [
+    "CONF_CAPACITY",
+    "CONF_CONNECTED",
+    "CONF_CURRENT_SOC",
+    "CONF_ENERGY_PER_DISTANCE",
+    "CONF_MAX_CHARGE_RATE",
+    "CONF_MAX_DISCHARGE_RATE",
+    "CONF_ODOMETER",
+    "CONF_ODOMETER_AT_DISCONNECT",
+    "CONF_PUBLIC_CHARGING_PRICE",
+    "CONF_TRIP_CALENDAR",
+    "ELEMENT_TYPE",
+    "OPTIONAL_INPUT_FIELDS",
+    "SECTION_CHARGING",
+    "SECTION_PUBLIC_CHARGING",
+    "SECTION_TRIP",
+    "SECTION_VEHICLE",
+    "ChargingConfig",
+    "ChargingData",
+    "EvConfigData",
+    "EvConfigSchema",
+    "PublicChargingConfig",
+    "PublicChargingData",
+    "TripConfig",
+    "TripData",
+    "VehicleConfig",
+    "VehicleData",
+]

--- a/custom_components/haeo/core/schema/elements/ev.py
+++ b/custom_components/haeo/core/schema/elements/ev.py
@@ -45,6 +45,8 @@ CONF_CONNECTED: Final = "connected"
 CONF_TRIP_CALENDAR: Final = "trip_calendar"
 CONF_ODOMETER: Final = "odometer"
 CONF_ODOMETER_AT_DISCONNECT: Final = "odometer_at_disconnect"
+CONF_RESERVE_SOC: Final = "reserve_soc"
+CONF_RESERVE_PRICE: Final = "reserve_price"
 
 # Public charging section field names
 CONF_PUBLIC_CHARGING_PRICE: Final = "public_charging_price"
@@ -55,6 +57,8 @@ OPTIONAL_INPUT_FIELDS: Final[frozenset[str]] = frozenset(
         CONF_TRIP_CALENDAR,
         CONF_ODOMETER,
         CONF_ODOMETER_AT_DISCONNECT,
+        CONF_RESERVE_SOC,
+        CONF_RESERVE_PRICE,
         CONF_MAX_DISCHARGE_RATE,
         CONF_MAX_POWER_SOURCE_TARGET,
         CONF_MAX_POWER_TARGET_SOURCE,
@@ -116,6 +120,8 @@ class TripConfig(TypedDict, total=False):
     connected: EntityValue | ConstantValue | NoneValue
     odometer: EntityValue | NoneValue
     odometer_at_disconnect: EntityValue | NoneValue
+    reserve_soc: EntityValue | ConstantValue | NoneValue
+    reserve_price: EntityValue | ConstantValue | NoneValue
 
 
 class TripData(TypedDict, total=False):
@@ -125,6 +131,8 @@ class TripData(TypedDict, total=False):
     connected: NDArray[np.floating[Any]] | float
     odometer: float
     odometer_at_disconnect: float
+    reserve_soc: float
+    reserve_price: NDArray[np.floating[Any]] | float
 
 
 # --- Public charging section ---
@@ -214,6 +222,15 @@ class EvConfigSchema(ConnectedCommonConfig):
                         output_type=OutputType.DISTANCE,
                         time_series=False,
                     ),
+                    CONF_RESERVE_SOC: FieldHint(
+                        output_type=OutputType.STATE_OF_CHARGE,
+                        time_series=False,
+                        step=1.0,
+                    ),
+                    CONF_RESERVE_PRICE: FieldHint(
+                        output_type=OutputType.PRICE,
+                        time_series=True,
+                    ),
                 }
             ),
         ]
@@ -291,6 +308,8 @@ __all__ = [
     "CONF_ODOMETER",
     "CONF_ODOMETER_AT_DISCONNECT",
     "CONF_PUBLIC_CHARGING_PRICE",
+    "CONF_RESERVE_PRICE",
+    "CONF_RESERVE_SOC",
     "CONF_TRIP_CALENDAR",
     "ELEMENT_TYPE",
     "OPTIONAL_INPUT_FIELDS",

--- a/custom_components/haeo/core/units.py
+++ b/custom_components/haeo/core/units.py
@@ -36,6 +36,8 @@ class UnitOfMeasurement(StrEnum):
     GIGA_WATT_HOUR = "GWh"
     DOLLAR_PER_KWH = "$/kWh"
     PERCENT = "%"
+    KILOMETER = "km"
+    KILO_WATT_HOUR_PER_KILOMETER = "kWh/km"
 
     @classmethod
     def of(cls, value: object) -> "UnitOfMeasurement | None":

--- a/custom_components/haeo/elements/__init__.py
+++ b/custom_components/haeo/elements/__init__.py
@@ -72,6 +72,7 @@ from custom_components.haeo.core.adapters.elements.deferrable_load import (
     DEFERRABLE_LOAD_ELEMENT_OUTPUT_NAMES,
     DeferrableLoadDeviceName,
     DeferrableLoadElementOutputName,
+)
 from custom_components.haeo.core.adapters.elements.ev import (
     EV_DEVICE_NAMES,
     EV_OUTPUT_NAMES,

--- a/custom_components/haeo/elements/__init__.py
+++ b/custom_components/haeo/elements/__init__.py
@@ -72,6 +72,11 @@ from custom_components.haeo.core.adapters.elements.deferrable_load import (
     DEFERRABLE_LOAD_ELEMENT_OUTPUT_NAMES,
     DeferrableLoadDeviceName,
     DeferrableLoadElementOutputName,
+from custom_components.haeo.core.adapters.elements.ev import (
+    EV_DEVICE_NAMES,
+    EV_OUTPUT_NAMES,
+    EvDeviceName,
+    EvOutputName,
 )
 from custom_components.haeo.core.adapters.elements.grid import (
     GRID_DEVICE_NAMES,
@@ -127,6 +132,8 @@ from custom_components.haeo.core.schema.elements.deferrable_load import (
     OPTIONAL_INPUT_FIELDS as DEFERRABLE_LOAD_OPTIONAL_INPUT_FIELDS,
 )
 from custom_components.haeo.core.schema.elements.deferrable_load import DeferrableLoadConfigData
+from custom_components.haeo.core.schema.elements.ev import OPTIONAL_INPUT_FIELDS as EV_OPTIONAL_INPUT_FIELDS
+from custom_components.haeo.core.schema.elements.ev import EvConfigData
 from custom_components.haeo.core.schema.elements.grid import OPTIONAL_INPUT_FIELDS as GRID_OPTIONAL_INPUT_FIELDS
 from custom_components.haeo.core.schema.elements.grid import GridConfigData
 from custom_components.haeo.core.schema.elements.inverter import OPTIONAL_INPUT_FIELDS as INVERTER_OPTIONAL_INPUT_FIELDS
@@ -158,6 +165,7 @@ type ElementOutputName = (
     | BatterySectionOutputName
     | ConnectionOutputName
     | DeferrableLoadElementOutputName
+    | EvOutputName
     | GridOutputName
     | LoadOutputName
     | NodeOutputName
@@ -171,6 +179,7 @@ ELEMENT_OUTPUT_NAMES: Final[frozenset[ElementOutputName]] = frozenset(
     | BATTERY_SECTION_OUTPUT_NAMES
     | CONNECTION_OUTPUT_NAMES
     | DEFERRABLE_LOAD_ELEMENT_OUTPUT_NAMES
+    | EV_OUTPUT_NAMES
     | GRID_OUTPUT_NAMES
     | LOAD_OUTPUT_NAMES
     | NODE_OUTPUT_NAMES
@@ -184,6 +193,7 @@ type ElementDeviceName = (
     | BatterySectionDeviceName
     | ConnectionDeviceName
     | DeferrableLoadDeviceName
+    | EvDeviceName
     | GridDeviceName
     | LoadDeviceName
     | NodeDeviceName
@@ -200,6 +210,7 @@ ELEMENT_DEVICE_NAMES: Final[frozenset[ElementDeviceName]] = frozenset(
     | BATTERY_SECTION_DEVICE_NAMES
     | CONNECTION_DEVICE_NAMES
     | DEFERRABLE_LOAD_DEVICE_NAMES
+    | EV_DEVICE_NAMES
     | GRID_DEVICE_NAMES
     | LOAD_DEVICE_NAMES
     | NODE_DEVICE_NAMES
@@ -214,6 +225,7 @@ ELEMENT_DEVICE_NAMES_BY_TYPE: Final[dict[str, frozenset[ElementDeviceName]]] = {
     ElementType.BATTERY_SECTION: frozenset(BATTERY_SECTION_DEVICE_NAMES),
     ElementType.CONNECTION: frozenset(CONNECTION_DEVICE_NAMES),
     ElementType.DEFERRABLE_LOAD: frozenset(DEFERRABLE_LOAD_DEVICE_NAMES),
+    ElementType.EV: frozenset(EV_DEVICE_NAMES),
     ElementType.GRID: frozenset(GRID_DEVICE_NAMES),
     ElementType.LOAD: frozenset(LOAD_DEVICE_NAMES),
     ElementType.NODE: frozenset(NODE_DEVICE_NAMES),
@@ -237,6 +249,7 @@ ELEMENT_CONFIG_DATA: Final[dict[ElementType, type]] = {
     ElementType.BATTERY_SECTION: BatterySectionConfigData,
     ElementType.CONNECTION: ConnectionConfigData,
     ElementType.DEFERRABLE_LOAD: DeferrableLoadConfigData,
+    ElementType.EV: EvConfigData,
     ElementType.GRID: GridConfigData,
     ElementType.INVERTER: InverterConfigData,
     ElementType.LOAD: LoadConfigData,
@@ -250,6 +263,7 @@ ELEMENT_OPTIONAL_INPUT_FIELDS: Final[dict[ElementType, frozenset[str]]] = {
     ElementType.BATTERY_SECTION: BATTERY_SECTION_OPTIONAL_INPUT_FIELDS,
     ElementType.CONNECTION: CONNECTION_OPTIONAL_INPUT_FIELDS,
     ElementType.DEFERRABLE_LOAD: DEFERRABLE_LOAD_OPTIONAL_INPUT_FIELDS,
+    ElementType.EV: EV_OPTIONAL_INPUT_FIELDS,
     ElementType.GRID: GRID_OPTIONAL_INPUT_FIELDS,
     ElementType.INVERTER: INVERTER_OPTIONAL_INPUT_FIELDS,
     ElementType.LOAD: LOAD_OPTIONAL_INPUT_FIELDS,

--- a/custom_components/haeo/elements/field_hints.py
+++ b/custom_components/haeo/elements/field_hints.py
@@ -83,6 +83,27 @@ OUTPUT_TYPE_DEFAULTS: dict[OutputType, OutputTypeMetadata] = {
         max_value=PRICE_NATIVE_MAX_VALUE,
         step=0.001,
     ),
+    OutputType.AVAILABILITY: OutputTypeMetadata(
+        unit=None,
+        device_class=None,
+        min_value=0.0,
+        max_value=1.0,
+        step=1.0,
+    ),
+    OutputType.DISTANCE: OutputTypeMetadata(
+        unit=UnitOfMeasurement.KILOMETER,
+        device_class=NumberDeviceClass.DISTANCE,
+        min_value=0.0,
+        max_value=10_000_000.0,
+        step=0.1,
+    ),
+    OutputType.ENERGY_PER_DISTANCE: OutputTypeMetadata(
+        unit=UnitOfMeasurement.KILO_WATT_HOUR_PER_KILOMETER,
+        device_class=None,
+        min_value=0.01,
+        max_value=10.0,
+        step=0.01,
+    ),
 }
 
 

--- a/custom_components/haeo/flows/__init__.py
+++ b/custom_components/haeo/flows/__init__.py
@@ -351,6 +351,7 @@ def get_element_flow_classes() -> dict[ElementType, type]:
     from custom_components.haeo.flows.elements.battery_section import BatterySectionSubentryFlowHandler  # noqa: PLC0415
     from custom_components.haeo.flows.elements.connection import ConnectionSubentryFlowHandler  # noqa: PLC0415
     from custom_components.haeo.flows.elements.deferrable_load import DeferrableLoadSubentryFlowHandler  # noqa: PLC0415
+    from custom_components.haeo.flows.elements.ev import EvSubentryFlowHandler  # noqa: PLC0415
     from custom_components.haeo.flows.elements.grid import GridSubentryFlowHandler  # noqa: PLC0415
     from custom_components.haeo.flows.elements.inverter import InverterSubentryFlowHandler  # noqa: PLC0415
     from custom_components.haeo.flows.elements.load import LoadSubentryFlowHandler  # noqa: PLC0415
@@ -363,6 +364,7 @@ def get_element_flow_classes() -> dict[ElementType, type]:
         ElementType.BATTERY_SECTION: BatterySectionSubentryFlowHandler,
         ElementType.CONNECTION: ConnectionSubentryFlowHandler,
         ElementType.DEFERRABLE_LOAD: DeferrableLoadSubentryFlowHandler,
+        ElementType.EV: EvSubentryFlowHandler,
         ElementType.GRID: GridSubentryFlowHandler,
         ElementType.INVERTER: InverterSubentryFlowHandler,
         ElementType.LOAD: LoadSubentryFlowHandler,

--- a/custom_components/haeo/flows/element_flow.py
+++ b/custom_components/haeo/flows/element_flow.py
@@ -12,7 +12,7 @@ from collections.abc import Mapping
 from typing import Any
 
 from homeassistant.config_entries import ConfigEntry, ConfigSubentry, UnknownSubEntry
-from homeassistant.const import PERCENTAGE, UnitOfEnergy, UnitOfPower
+from homeassistant.const import PERCENTAGE, UnitOfEnergy, UnitOfLength, UnitOfPower
 from homeassistant.helpers.selector import SelectOptionDict, SelectSelector, SelectSelectorConfig, SelectSelectorMode
 from homeassistant.helpers.translation import async_get_translations
 import voluptuous as vol
@@ -49,8 +49,11 @@ def get_unit_spec_for_output_type(output_type: OutputType) -> UnitSpec | list[Un
             return PRICE_UNIT_SPEC
         case OutputType.PRICE_RATE:
             return None
+        case OutputType.DISTANCE:
+            return UnitOfLength
         case _:
-            # STATUS, COST, DURATION, SHADOW_PRICE - no unit filtering
+            # STATUS, AVAILABILITY, ENERGY_PER_DISTANCE, COST, DURATION,
+            # SHADOW_PRICE - no unit filtering
             return None
 
 

--- a/custom_components/haeo/flows/elements/ev.py
+++ b/custom_components/haeo/flows/elements/ev.py
@@ -1,0 +1,233 @@
+"""EV element configuration flows."""
+
+from typing import Any
+
+from homeassistant.config_entries import ConfigSubentryFlow, SubentryFlowResult
+import voluptuous as vol
+
+from custom_components.haeo.core.const import CONF_ELEMENT_TYPE, CONF_NAME
+from custom_components.haeo.core.schema import get_connection_target_name, normalize_connection_target
+from custom_components.haeo.core.schema.elements.ev import (
+    CONF_CAPACITY,
+    CONF_CONNECTED,
+    CONF_CURRENT_SOC,
+    CONF_ENERGY_PER_DISTANCE,
+    CONF_MAX_CHARGE_RATE,
+    CONF_MAX_DISCHARGE_RATE,
+    CONF_ODOMETER,
+    CONF_ODOMETER_AT_DISCONNECT,
+    CONF_PUBLIC_CHARGING_PRICE,
+    CONF_TRIP_CALENDAR,
+    ELEMENT_TYPE,
+    SECTION_CHARGING,
+    SECTION_PUBLIC_CHARGING,
+    SECTION_TRIP,
+    SECTION_VEHICLE,
+)
+from custom_components.haeo.core.schema.sections import (
+    CONF_CONNECTION,
+    CONF_EFFICIENCY_SOURCE_TARGET,
+    CONF_EFFICIENCY_TARGET_SOURCE,
+    CONF_MAX_POWER_SOURCE_TARGET,
+    CONF_MAX_POWER_TARGET_SOURCE,
+)
+from custom_components.haeo.elements import get_input_field_schema_info, get_input_fields
+from custom_components.haeo.elements.input_fields import InputFieldGroups
+from custom_components.haeo.flows.element_flow import ElementFlowMixin, build_sectioned_inclusion_map
+from custom_components.haeo.flows.entity_metadata import extract_entity_metadata
+from custom_components.haeo.flows.field_schema import (
+    SectionDefinition,
+    build_sectioned_choose_defaults,
+    build_sectioned_choose_schema,
+    convert_sectioned_choose_data_to_config,
+    preprocess_sectioned_choose_input,
+    validate_sectioned_choose_fields,
+)
+from custom_components.haeo.sections import build_common_fields, efficiency_section, power_limits_section
+
+
+class EvSubentryFlowHandler(ElementFlowMixin, ConfigSubentryFlow):
+    """Handle EV element configuration flows."""
+
+    def _get_sections(self) -> tuple[SectionDefinition, ...]:
+        """Return sections for the configuration step."""
+        return (
+            SectionDefinition(
+                key=SECTION_VEHICLE,
+                fields=(CONF_CAPACITY, CONF_ENERGY_PER_DISTANCE, CONF_CURRENT_SOC),
+                collapsed=False,
+            ),
+            SectionDefinition(
+                key=SECTION_CHARGING,
+                fields=(CONF_MAX_CHARGE_RATE, CONF_MAX_DISCHARGE_RATE),
+                collapsed=False,
+            ),
+            SectionDefinition(
+                key=SECTION_TRIP,
+                fields=(CONF_TRIP_CALENDAR, CONF_CONNECTED, CONF_ODOMETER, CONF_ODOMETER_AT_DISCONNECT),
+                collapsed=True,
+            ),
+            SectionDefinition(
+                key=SECTION_PUBLIC_CHARGING,
+                fields=(CONF_PUBLIC_CHARGING_PRICE,),
+                collapsed=True,
+            ),
+            power_limits_section(
+                (CONF_MAX_POWER_SOURCE_TARGET, CONF_MAX_POWER_TARGET_SOURCE),
+                collapsed=True,
+            ),
+            efficiency_section(
+                (CONF_EFFICIENCY_SOURCE_TARGET, CONF_EFFICIENCY_TARGET_SOURCE),
+                collapsed=True,
+            ),
+        )
+
+    async def async_step_user(self, user_input: dict[str, Any] | None = None) -> SubentryFlowResult:
+        """Handle user step: name, connection, trip entities, and input configuration."""
+        return await self._async_step_user(user_input)
+
+    async def async_step_reconfigure(self, user_input: dict[str, Any] | None = None) -> SubentryFlowResult:
+        """Handle reconfigure step."""
+        return await self._async_step_user(user_input)
+
+    async def _async_step_user(self, user_input: dict[str, Any] | None) -> SubentryFlowResult:
+        """Shared logic for user and reconfigure steps."""
+        subentry = self._get_subentry()
+        subentry_data = dict(subentry.data) if subentry else None
+        participants = self._get_participant_names()
+        current_connection = get_connection_target_name(subentry_data.get(CONF_CONNECTION)) if subentry_data else None
+        default_name = await self._async_get_default_name(ELEMENT_TYPE)
+        if not isinstance(current_connection, str):
+            current_connection = participants[0] if participants else ""
+        input_fields = get_input_fields(ELEMENT_TYPE)
+
+        sections = self._get_sections()
+        user_input = preprocess_sectioned_choose_input(user_input, input_fields, sections)
+        errors = self._validate_user_input(user_input, input_fields)
+
+        if user_input is not None and not errors:
+            config = self._build_config(user_input)
+            return self._finalize(config, user_input)
+
+        entity_metadata = extract_entity_metadata(self.hass, self._get_entry())
+        section_inclusion_map = build_sectioned_inclusion_map(input_fields, entity_metadata)
+        schema = self._build_schema(
+            participants,
+            input_fields,
+            section_inclusion_map,
+            current_connection,
+            subentry_data,
+        )
+        defaults = (
+            user_input
+            if user_input is not None
+            else self._build_defaults(
+                default_name,
+                input_fields,
+                subentry_data,
+                current_connection,
+            )
+        )
+        schema = self.add_suggested_values_to_schema(schema, defaults)
+
+        return self.async_show_form(step_id="user", data_schema=schema, errors=errors)
+
+    def _build_schema(
+        self,
+        participants: list[str],
+        input_fields: InputFieldGroups,
+        section_inclusion_map: dict[str, dict[str, list[str]]],
+        current_connection: str | None = None,
+        subentry_data: dict[str, Any] | None = None,
+    ) -> vol.Schema:
+        """Build the schema with name, connection, trip entities, and choose selectors."""
+        field_schema = get_input_field_schema_info(ELEMENT_TYPE, input_fields)
+        top_level = {
+            **build_common_fields(
+                include_connection=True,
+                participants=participants,
+                current_connection=current_connection,
+            ),
+        }
+        return build_sectioned_choose_schema(
+            self._get_sections(),
+            input_fields,
+            field_schema,
+            section_inclusion_map,
+            current_data=subentry_data,
+            top_level_entries=top_level,
+        )
+
+    def _build_defaults(
+        self,
+        default_name: str,
+        input_fields: InputFieldGroups,
+        subentry_data: dict[str, Any] | None = None,
+        connection_default: str | None = None,
+    ) -> dict[str, Any]:
+        """Build default values for the form."""
+        connection_default = (
+            connection_default
+            if connection_default is not None
+            else get_connection_target_name(subentry_data.get(CONF_CONNECTION))
+            if subentry_data
+            else None
+        )
+        trip_data = subentry_data.get(SECTION_TRIP) if subentry_data else None
+        if not isinstance(trip_data, dict):
+            trip_data = {}
+
+        defaults: dict[str, Any] = {
+            CONF_NAME: default_name if subentry_data is None else subentry_data.get(CONF_NAME),
+            CONF_CONNECTION: connection_default,
+            **build_sectioned_choose_defaults(
+                self._get_sections(),
+                input_fields,
+                current_data=subentry_data,
+            ),
+        }
+        return defaults
+
+    def _validate_user_input(
+        self,
+        user_input: dict[str, Any] | None,
+        input_fields: InputFieldGroups,
+    ) -> dict[str, str] | None:
+        """Validate user input and return errors dict if any."""
+        if user_input is None:
+            return None
+        errors: dict[str, str] = {}
+        self._validate_name(user_input.get(CONF_NAME), errors)
+        field_schema = get_input_field_schema_info(ELEMENT_TYPE, input_fields)
+        errors.update(
+            validate_sectioned_choose_fields(
+                user_input,
+                input_fields,
+                field_schema,
+                self._get_sections(),
+            )
+        )
+        return errors if errors else None
+
+    def _build_config(self, user_input: dict[str, Any]) -> dict[str, Any]:
+        """Build final config dict from user input."""
+        input_fields = get_input_fields(ELEMENT_TYPE)
+        config_dict = convert_sectioned_choose_data_to_config(
+            user_input,
+            input_fields,
+            self._get_sections(),
+        )
+        return {
+            CONF_ELEMENT_TYPE: ELEMENT_TYPE,
+            CONF_NAME: user_input[CONF_NAME],
+            CONF_CONNECTION: normalize_connection_target(user_input[CONF_CONNECTION]),
+            **config_dict,
+        }
+
+    def _finalize(self, config: dict[str, Any], user_input: dict[str, Any]) -> SubentryFlowResult:
+        """Finalize the flow by creating or updating the entry."""
+        name = str(user_input[CONF_NAME])
+        subentry = self._get_subentry()
+        if subentry is not None:
+            return self.async_update_and_abort(self._get_entry(), subentry, title=name, data=config)
+        return self.async_create_entry(title=name, data=config)

--- a/custom_components/haeo/flows/elements/ev.py
+++ b/custom_components/haeo/flows/elements/ev.py
@@ -17,6 +17,8 @@ from custom_components.haeo.core.schema.elements.ev import (
     CONF_ODOMETER,
     CONF_ODOMETER_AT_DISCONNECT,
     CONF_PUBLIC_CHARGING_PRICE,
+    CONF_RESERVE_PRICE,
+    CONF_RESERVE_SOC,
     CONF_TRIP_CALENDAR,
     ELEMENT_TYPE,
     SECTION_CHARGING,
@@ -64,7 +66,14 @@ class EvSubentryFlowHandler(ElementFlowMixin, ConfigSubentryFlow):
             ),
             SectionDefinition(
                 key=SECTION_TRIP,
-                fields=(CONF_TRIP_CALENDAR, CONF_CONNECTED, CONF_ODOMETER, CONF_ODOMETER_AT_DISCONNECT),
+                fields=(
+                    CONF_TRIP_CALENDAR,
+                    CONF_CONNECTED,
+                    CONF_ODOMETER,
+                    CONF_ODOMETER_AT_DISCONNECT,
+                    CONF_RESERVE_SOC,
+                    CONF_RESERVE_PRICE,
+                ),
                 collapsed=True,
             ),
             SectionDefinition(

--- a/custom_components/haeo/flows/elements/tests/test_ev_flow.py
+++ b/custom_components/haeo/flows/elements/tests/test_ev_flow.py
@@ -1,0 +1,148 @@
+"""Tests for EV element config flow."""
+
+from types import MappingProxyType
+from typing import Any
+from unittest.mock import Mock
+
+from homeassistant.config_entries import SOURCE_RECONFIGURE, ConfigSubentry
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from conftest import add_participant
+from custom_components.haeo.core.const import CONF_ELEMENT_TYPE, CONF_NAME
+from custom_components.haeo.core.schema import as_calendar_value, as_constant_value, as_entity_value
+from custom_components.haeo.core.schema.elements import node
+from custom_components.haeo.core.schema.elements.ev import (
+    CONF_CAPACITY,
+    CONF_CONNECTED,
+    CONF_CURRENT_SOC,
+    CONF_ENERGY_PER_DISTANCE,
+    CONF_MAX_CHARGE_RATE,
+    CONF_ODOMETER,
+    CONF_ODOMETER_AT_DISCONNECT,
+    CONF_TRIP_CALENDAR,
+    ELEMENT_TYPE,
+    SECTION_CHARGING,
+    SECTION_PUBLIC_CHARGING,
+    SECTION_TRIP,
+    SECTION_VEHICLE,
+)
+from custom_components.haeo.core.schema.sections import CONF_CONNECTION, SECTION_EFFICIENCY, SECTION_POWER_LIMITS
+from custom_components.haeo.elements import get_input_fields
+from custom_components.haeo.flows.conftest import create_flow
+
+
+def _user_input(trip: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Build sectioned EV user input with sensible defaults."""
+    return {
+        CONF_NAME: "Test EV",
+        CONF_CONNECTION: "TestNode",
+        SECTION_VEHICLE: {
+            CONF_CAPACITY: 60.0,
+            CONF_ENERGY_PER_DISTANCE: 0.15,
+            CONF_CURRENT_SOC: ["sensor.ev_soc"],
+        },
+        SECTION_CHARGING: {
+            CONF_MAX_CHARGE_RATE: 7.4,
+        },
+        SECTION_TRIP: trip or {},
+        SECTION_PUBLIC_CHARGING: {},
+        SECTION_POWER_LIMITS: {},
+        SECTION_EFFICIENCY: {},
+    }
+
+
+async def test_user_step_creates_entry_with_calendar(
+    hass: HomeAssistant,
+    hub_entry: MockConfigEntry,
+) -> None:
+    """Submitting with a trip calendar stores a calendar schema value."""
+    add_participant(hass, hub_entry, "TestNode", node.ELEMENT_TYPE)
+
+    flow = create_flow(hass, hub_entry, ELEMENT_TYPE)
+    flow.async_create_entry = Mock(return_value={"type": FlowResultType.CREATE_ENTRY, "title": "Test EV", "data": {}})
+
+    user_input = _user_input(
+        trip={
+            CONF_TRIP_CALENDAR: "calendar.ev_trips",
+            CONF_CONNECTED: ["binary_sensor.ev_plugged_in"],
+            CONF_ODOMETER: ["sensor.ev_odometer"],
+        }
+    )
+    result = await flow.async_step_user(user_input=user_input)
+
+    assert result.get("type") == FlowResultType.CREATE_ENTRY
+
+    data = flow.async_create_entry.call_args.kwargs["data"]
+    assert data[SECTION_TRIP][CONF_TRIP_CALENDAR] == as_calendar_value("calendar.ev_trips")
+    assert data[SECTION_TRIP][CONF_CONNECTED] == as_entity_value(["binary_sensor.ev_plugged_in"])
+    assert data[SECTION_TRIP][CONF_ODOMETER] == as_entity_value(["sensor.ev_odometer"])
+    assert data[SECTION_VEHICLE][CONF_CAPACITY] == as_constant_value(60.0)
+    assert data[SECTION_VEHICLE][CONF_CURRENT_SOC] == as_entity_value(["sensor.ev_soc"])
+
+
+async def test_user_step_without_trip_creates_entry(
+    hass: HomeAssistant,
+    hub_entry: MockConfigEntry,
+) -> None:
+    """The trip section is optional; a minimal EV still creates an entry."""
+    add_participant(hass, hub_entry, "TestNode", node.ELEMENT_TYPE)
+
+    flow = create_flow(hass, hub_entry, ELEMENT_TYPE)
+    flow.async_create_entry = Mock(return_value={"type": FlowResultType.CREATE_ENTRY, "title": "Test EV", "data": {}})
+
+    result = await flow.async_step_user(user_input=_user_input())
+
+    assert result.get("type") == FlowResultType.CREATE_ENTRY
+    data = flow.async_create_entry.call_args.kwargs["data"]
+    assert CONF_TRIP_CALENDAR not in data[SECTION_TRIP]
+
+
+async def test_reconfigure_defaults_surface_calendar_entity(
+    hass: HomeAssistant,
+    hub_entry: MockConfigEntry,
+) -> None:
+    """Reconfigure defaults surface the stored calendar entity ID."""
+    add_participant(hass, hub_entry, "TestNode", node.ELEMENT_TYPE)
+
+    from custom_components.haeo.core.schema import as_connection_target  # noqa: PLC0415
+
+    existing_config = {
+        CONF_ELEMENT_TYPE: ELEMENT_TYPE,
+        CONF_NAME: "Test EV",
+        CONF_CONNECTION: as_connection_target("TestNode"),
+        SECTION_VEHICLE: {
+            CONF_CAPACITY: as_constant_value(60.0),
+            CONF_ENERGY_PER_DISTANCE: as_constant_value(0.15),
+            CONF_CURRENT_SOC: as_entity_value(["sensor.ev_soc"]),
+        },
+        SECTION_CHARGING: {CONF_MAX_CHARGE_RATE: as_constant_value(7.4)},
+        SECTION_TRIP: {
+            CONF_TRIP_CALENDAR: as_calendar_value("calendar.ev_trips"),
+            CONF_ODOMETER_AT_DISCONNECT: as_entity_value(["sensor.odo_disc"]),
+        },
+        SECTION_PUBLIC_CHARGING: {},
+        SECTION_POWER_LIMITS: {},
+        SECTION_EFFICIENCY: {},
+    }
+    existing_subentry = ConfigSubentry(
+        data=MappingProxyType(existing_config),
+        subentry_type=ELEMENT_TYPE,
+        title="Test EV",
+        unique_id=None,
+    )
+    hass.config_entries.async_add_subentry(hub_entry, existing_subentry)
+
+    flow = create_flow(hass, hub_entry, ELEMENT_TYPE)
+    flow.context = {"subentry_id": existing_subentry.subentry_id, "source": SOURCE_RECONFIGURE}
+    flow._get_reconfigure_subentry = Mock(return_value=existing_subentry)
+
+    result = await flow.async_step_reconfigure(user_input=None)
+    assert result.get("type") == FlowResultType.FORM
+    assert result.get("step_id") == "user"
+
+    input_fields = get_input_fields({CONF_ELEMENT_TYPE: ELEMENT_TYPE})
+    defaults = flow._build_defaults("Test EV", input_fields, dict(existing_subentry.data))
+    assert defaults[SECTION_TRIP][CONF_TRIP_CALENDAR] == "calendar.ev_trips"
+    assert defaults[SECTION_TRIP][CONF_ODOMETER_AT_DISCONNECT] == ["sensor.odo_disc"]

--- a/custom_components/haeo/flows/tests/test_data/ev.py
+++ b/custom_components/haeo/flows/tests/test_data/ev.py
@@ -17,6 +17,8 @@ from custom_components.haeo.core.schema.elements.ev import (
     CONF_ODOMETER,
     CONF_ODOMETER_AT_DISCONNECT,
     CONF_PUBLIC_CHARGING_PRICE,
+    CONF_RESERVE_PRICE,
+    CONF_RESERVE_SOC,
     CONF_TRIP_CALENDAR,
     SECTION_CHARGING,
     SECTION_PUBLIC_CHARGING,
@@ -53,6 +55,8 @@ VALID_DATA = [
                 CONF_CONNECTED: as_entity_value(["binary_sensor.ev_plugged_in"]),
                 CONF_ODOMETER: as_entity_value(["sensor.ev_odometer"]),
                 CONF_ODOMETER_AT_DISCONNECT: as_entity_value(["sensor.ev_odometer_at_disconnect"]),
+                CONF_RESERVE_SOC: as_constant_value(20.0),
+                CONF_RESERVE_PRICE: as_constant_value(0.6),
             },
             SECTION_PUBLIC_CHARGING: {
                 CONF_PUBLIC_CHARGING_PRICE: as_constant_value(0.35),

--- a/custom_components/haeo/flows/tests/test_data/ev.py
+++ b/custom_components/haeo/flows/tests/test_data/ev.py
@@ -1,0 +1,90 @@
+"""Test EV config flow data for choose selector approach."""
+
+from custom_components.haeo.core.const import CONF_NAME
+from custom_components.haeo.core.schema import (
+    as_calendar_value,
+    as_connection_target,
+    as_constant_value,
+    as_entity_value,
+)
+from custom_components.haeo.core.schema.elements.ev import (
+    CONF_CAPACITY,
+    CONF_CONNECTED,
+    CONF_CURRENT_SOC,
+    CONF_ENERGY_PER_DISTANCE,
+    CONF_MAX_CHARGE_RATE,
+    CONF_MAX_DISCHARGE_RATE,
+    CONF_ODOMETER,
+    CONF_ODOMETER_AT_DISCONNECT,
+    CONF_PUBLIC_CHARGING_PRICE,
+    CONF_TRIP_CALENDAR,
+    SECTION_CHARGING,
+    SECTION_PUBLIC_CHARGING,
+    SECTION_TRIP,
+    SECTION_VEHICLE,
+)
+from custom_components.haeo.core.schema.sections import (
+    CONF_CONNECTION,
+    CONF_EFFICIENCY_SOURCE_TARGET,
+    CONF_EFFICIENCY_TARGET_SOURCE,
+    CONF_MAX_POWER_SOURCE_TARGET,
+    CONF_MAX_POWER_TARGET_SOURCE,
+    SECTION_EFFICIENCY,
+    SECTION_POWER_LIMITS,
+)
+
+VALID_DATA = [
+    {
+        "description": "Basic EV with charge rate and public charging price",
+        "config": {
+            CONF_NAME: "Test EV",
+            CONF_CONNECTION: as_connection_target("switchboard"),
+            SECTION_VEHICLE: {
+                CONF_CAPACITY: as_constant_value(60.0),
+                CONF_ENERGY_PER_DISTANCE: as_constant_value(0.15),
+                CONF_CURRENT_SOC: as_entity_value(["sensor.ev_soc"]),
+            },
+            SECTION_CHARGING: {
+                CONF_MAX_CHARGE_RATE: as_constant_value(7.4),
+                CONF_MAX_DISCHARGE_RATE: as_constant_value(5.0),
+            },
+            SECTION_TRIP: {
+                CONF_TRIP_CALENDAR: as_calendar_value("calendar.ev_trips"),
+                CONF_CONNECTED: as_entity_value(["binary_sensor.ev_plugged_in"]),
+                CONF_ODOMETER: as_entity_value(["sensor.ev_odometer"]),
+                CONF_ODOMETER_AT_DISCONNECT: as_entity_value(["sensor.ev_odometer_at_disconnect"]),
+            },
+            SECTION_PUBLIC_CHARGING: {
+                CONF_PUBLIC_CHARGING_PRICE: as_constant_value(0.35),
+            },
+            SECTION_POWER_LIMITS: {
+                CONF_MAX_POWER_SOURCE_TARGET: as_constant_value(10.0),
+                CONF_MAX_POWER_TARGET_SOURCE: as_constant_value(10.0),
+            },
+            SECTION_EFFICIENCY: {
+                CONF_EFFICIENCY_SOURCE_TARGET: as_constant_value(95.0),
+                CONF_EFFICIENCY_TARGET_SOURCE: as_constant_value(95.0),
+            },
+        },
+    },
+    {
+        "description": "Minimal EV - charge only, no V2G",
+        "config": {
+            CONF_NAME: "Commuter EV",
+            CONF_CONNECTION: as_connection_target("switchboard"),
+            SECTION_VEHICLE: {
+                CONF_CAPACITY: as_constant_value(40.0),
+                CONF_ENERGY_PER_DISTANCE: as_constant_value(0.18),
+                CONF_CURRENT_SOC: as_entity_value(["sensor.car_soc"]),
+            },
+            SECTION_CHARGING: {
+                CONF_MAX_CHARGE_RATE: as_constant_value(3.6),
+            },
+            SECTION_PUBLIC_CHARGING: {},
+            SECTION_POWER_LIMITS: {},
+            SECTION_EFFICIENCY: {},
+        },
+    },
+]
+
+INVALID_DATA: list[dict[str, object]] = []

--- a/custom_components/haeo/translations/en.json
+++ b/custom_components/haeo/translations/en.json
@@ -284,6 +284,83 @@
       "error": { "missing_name": "Name is required", "name_exists": "A device with this name already exists" },
       "abort": { "reconfigure_successful": "Configuration updated successfully" }
     },
+    "ev": {
+      "flow_title": "EV",
+      "entry_type": "EV",
+      "initiate_flow": { "user": "EV", "reconfigure": "EV" },
+      "step": {
+        "user": {
+          "title": "EV Configuration",
+          "description": "Configure your electric vehicle with battery details, charging rates, and trip planning",
+          "data": {
+            "capacity": "Battery capacity",
+            "connected": "Plugged in",
+            "connection": "Connection",
+            "current_soc": "Current state of charge",
+            "efficiency_source_target": "Discharge efficiency",
+            "efficiency_target_source": "Charge efficiency",
+            "energy_per_distance": "Energy per distance",
+            "max_charge_rate": "Max charge rate",
+            "max_discharge_rate": "Max discharge rate",
+            "max_power_source_target": "Max discharge power",
+            "max_power_target_source": "Max charge power",
+            "name": "EV Name",
+            "odometer": "Odometer",
+            "odometer_at_disconnect": "Odometer at disconnect",
+            "public_charging_price": "Public charging price",
+            "reserve_price": "Reserve shortfall price",
+            "reserve_soc": "Reserve state of charge",
+            "trip_calendar": "Trip calendar"
+          },
+          "sections": {
+            "charging": {
+              "data": { "max_charge_rate": "Max charge rate", "max_discharge_rate": "Max discharge rate" },
+              "name": "Charging"
+            },
+            "common": { "data": { "connection": "Connection", "name": "EV Name" }, "name": "Common settings" },
+            "efficiency": {
+              "data": {
+                "efficiency_source_target": "Discharge efficiency",
+                "efficiency_target_source": "Charge efficiency"
+              },
+              "name": "Efficiency"
+            },
+            "power_limits": {
+              "data": {
+                "max_power_source_target": "Max discharge power",
+                "max_power_target_source": "Max charge power"
+              },
+              "name": "Power limits"
+            },
+            "public_charging": {
+              "data": { "public_charging_price": "Public charging price" },
+              "name": "Public charging"
+            },
+            "trip": {
+              "data": {
+                "connected": "Plugged in",
+                "odometer": "Odometer",
+                "odometer_at_disconnect": "Odometer at disconnect",
+                "reserve_price": "Reserve shortfall price",
+                "reserve_soc": "Reserve state of charge",
+                "trip_calendar": "Trip calendar"
+              },
+              "name": "Trips"
+            },
+            "vehicle": {
+              "data": {
+                "capacity": "Battery capacity",
+                "current_soc": "Current state of charge",
+                "energy_per_distance": "Energy per distance"
+              },
+              "name": "Vehicle"
+            }
+          }
+        }
+      },
+      "error": { "missing_name": "Name is required", "name_exists": "A device with this name already exists" },
+      "abort": { "reconfigure_successful": "Configuration updated successfully" }
+    },
     "grid": {
       "flow_title": "Grid",
       "entry_type": "Grid",
@@ -491,6 +568,7 @@
     "battery_section": { "name": "{name}" },
     "connection": { "name": "{name}" },
     "deferrable_load": { "name": "{name}" },
+    "ev": { "name": "{name}" },
     "grid": { "name": "{name}" },
     "inverter": { "name": "{name}" },
     "load": { "name": "{name}" },
@@ -527,6 +605,21 @@
       "deferrable_load_deficit_price": { "name": "Shortfall price" },
       "deferrable_load_max_power": { "name": "Max power" },
       "deferrable_load_overage_price": { "name": "Overage price" },
+      "ev_capacity": { "name": "Battery capacity" },
+      "ev_connected": { "name": "Plugged in" },
+      "ev_current_soc": { "name": "Current state of charge" },
+      "ev_efficiency_source_target": { "name": "Discharge efficiency" },
+      "ev_efficiency_target_source": { "name": "Charge efficiency" },
+      "ev_energy_per_distance": { "name": "Energy per distance" },
+      "ev_max_charge_rate": { "name": "Max charge rate" },
+      "ev_max_discharge_rate": { "name": "Max discharge rate" },
+      "ev_max_power_source_target": { "name": "Max discharge power" },
+      "ev_max_power_target_source": { "name": "Max charge power" },
+      "ev_odometer": { "name": "Odometer" },
+      "ev_odometer_at_disconnect": { "name": "Odometer at disconnect" },
+      "ev_public_charging_price": { "name": "Public charging price" },
+      "ev_reserve_price": { "name": "Reserve shortfall price" },
+      "ev_reserve_soc": { "name": "Reserve state of charge" },
       "grid_max_power_source_target": { "name": "Import limit" },
       "grid_max_power_target_source": { "name": "Export limit" },
       "grid_price_source_target": { "name": "Import price" },
@@ -566,6 +659,16 @@
       "deferrable_load_energy_absorbed": { "name": "Energy absorbed" },
       "deferrable_load_energy_deficit": { "name": "Energy shortfall" },
       "deferrable_load_power": { "name": "Power" },
+      "ev_energy_stored": { "name": "Energy stored" },
+      "ev_power_active": { "name": "Active power" },
+      "ev_power_charge": { "name": "Charge power" },
+      "ev_power_discharge": { "name": "Discharge power" },
+      "ev_power_max_charge_price": { "name": "Max charge power shadow price" },
+      "ev_power_max_discharge_price": { "name": "Max discharge power shadow price" },
+      "ev_reserve_shortfall": { "name": "Reserve shortfall" },
+      "ev_state_of_charge": { "name": "State of charge" },
+      "ev_trip_energy_deficit": { "name": "Trip energy shortfall" },
+      "ev_trip_energy_delivered": { "name": "Trip energy delivered" },
       "grid_cost_import": { "name": "Import cost" },
       "grid_cost_net": { "name": "Net cost" },
       "grid_power_active": { "name": "Active power" },


### PR DESCRIPTION
:robot: Stacked on #494. Replaces #361.

## Summary

Adds the EV element with calendar-driven trip modeling. One EV composes seven model elements:

1. `{name}` — Battery (the physical pack)
2. `{name}:charge` — network → EV home charging, masked by the plugged-in state
3. `{name}:discharge` — EV → network (V2G), same mask
4. `{name}:trip` — Battery used as a trip-energy sink: capacity opens at each trip's start and the min-charge requirement is due by its end (calendar distance × energy-per-distance, cumulative across trips)
5. `{name}:trip_connection` — EV → trip battery, open only while away
6. `{name}:public_grid` — source-only node
7. `{name}:public_connection` — public grid → trip battery, **always present and always priced** (default $10/kWh): the relief valve that keeps the trip requirement feasible when home charging cannot cover it, and the price signal that makes home charging win whenever physically possible

## Semantics

- **Trip calendar** (calendar entity): events become trip windows; distance is parsed from the event text ("50 km", "30 mi", …). Authoritative for future availability.
- **Plugged-in sensor** (optional): pins the present interval only.
- **Odometer / odometer at disconnect** (optional): while away, distance already driven credits the current trip's requirement so the optimizer doesn't double-charge for it.

## Changes

- `core/schema/elements/ev.py`, `core/adapters/elements/ev.py`, `flows/elements/ev.py` + full registry/translation wiring
- New `OutputType` members: `AVAILABILITY`, `DISTANCE`, `ENERGY_PER_DISTANCE` with entity metadata and picker unit filtering
- Flow layer renders calendar-driven fields as a calendar entity picker and stores `{"type": "calendar", ...}` values

## Testing

- `test_ev_model.py` includes end-to-end LP tests: the EV pre-charges in the cheap period ahead of a trip, and public charging covers the shortfall when the charger physically cannot
- `test_ev_flow.py`, `test_ev.py`, parametrized flow/translation suites
- `uv run check`: all 11 gates pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

:robot: **Update:** the trip sink is now a **deferrable load** (#494) instead of a battery with a hard min-charge. The requirement is priced, not enforced: any locked-in shortfall costs the public charging price, which models topping up publicly mid-trip. This drops the public grid node and public connection (5 model elements instead of 7) and replaces the `ev_public_charge_power` output with `ev_trip_energy_deficit` ("Trip energy shortfall") — the energy the optimizer expects to buy publicly.

---

:robot: **Update — telemetry hardening and trip reserve:**
- Pack initial charge clamps to [0, capacity] (glitched SOC sensors), and odometer trip progress is no longer clamped to the planned requirement — the deferrable load tolerates the overshoot.
- New optional trip fields **Reserve state of charge** and **Reserve shortfall price**: while away the pack can only drain, so the reserve is priced once per trip on the lowest level hit during the window (demand-level pricing), defaulting to the public charging price. A **Reserve shortfall** sensor appears when configured.