### PR TITLE
feat: add the deferrable load as a user-facing element type

### DIFF
--- a/custom_components/haeo/core/adapters/elements/deferrable_load.py
+++ b/custom_components/haeo/core/adapters/elements/deferrable_load.py
@@ -1,0 +1,168 @@
+"""Deferrable load element adapter for model layer integration."""
+
+from collections.abc import Mapping
+from dataclasses import replace
+from typing import Any, Final, Literal
+
+import numpy as np
+from numpy.typing import NDArray
+
+from custom_components.haeo.core.adapters.output_utils import connection_power, expect_output_data
+from custom_components.haeo.core.const import ConnectivityLevel
+from custom_components.haeo.core.model import ModelElementConfig, ModelOutputName, ModelOutputValue
+from custom_components.haeo.core.model.const import OutputType
+from custom_components.haeo.core.model.elements import MODEL_ELEMENT_TYPE_CONNECTION, MODEL_ELEMENT_TYPE_DEFERRABLE_LOAD
+from custom_components.haeo.core.model.elements.deferrable_load import (
+    DEFERRABLE_LOAD_ENERGY_ABSORBED,
+    DEFERRABLE_LOAD_ENERGY_DEFICIT,
+    DeferrableLoadElementConfig,
+)
+from custom_components.haeo.core.model.output_data import OutputData
+from custom_components.haeo.core.schema import extract_connection_target
+from custom_components.haeo.core.schema.elements import ElementType
+from custom_components.haeo.core.schema.elements.deferrable_load import (
+    CONF_DEFICIT_PRICE,
+    CONF_MAX_POWER,
+    CONF_OVERAGE_PRICE,
+    CONF_WINDOW_CALENDAR,
+    ELEMENT_TYPE,
+    SECTION_POWER,
+    SECTION_PRICING,
+    SECTION_SCHEDULE,
+    DeferrableLoadConfigData,
+)
+from custom_components.haeo.core.schema.sections import CONF_CONNECTION
+
+# Effectively unlimited power (kW) for window-gated flow when no physical
+# device power limit is configured.
+_UNLIMITED_POWER: Final = 1.0e6
+
+# Deferrable-load-specific output names for translation/sensor mapping
+type DeferrableLoadElementOutputName = Literal[
+    "deferrable_load_power",
+    "deferrable_load_energy_absorbed",
+    "deferrable_load_energy_deficit",
+]
+
+DEFERRABLE_LOAD_ELEMENT_OUTPUT_NAMES: Final[frozenset[DeferrableLoadElementOutputName]] = frozenset(
+    (
+        DEFERRABLE_POWER := "deferrable_load_power",
+        DEFERRABLE_ENERGY_ABSORBED := "deferrable_load_energy_absorbed",
+        DEFERRABLE_ENERGY_DEFICIT := "deferrable_load_energy_deficit",
+    )
+)
+
+type DeferrableLoadDeviceName = Literal[ElementType.DEFERRABLE_LOAD]
+
+DEFERRABLE_LOAD_DEVICE_NAMES: Final[frozenset[DeferrableLoadDeviceName]] = frozenset(
+    (DEFERRABLE_LOAD_DEVICE := ElementType.DEFERRABLE_LOAD,),
+)
+
+
+class DeferrableLoadAdapter:
+    """Adapter for deferrable load elements."""
+
+    element_type: str = ELEMENT_TYPE
+    advanced: bool = False
+    connectivity: ConnectivityLevel = ConnectivityLevel.ADVANCED
+    can_source: bool = False
+    can_sink: bool = True
+
+    def model_elements(self, config: DeferrableLoadConfigData) -> list[ModelElementConfig]:
+        """Create model elements for deferrable load configuration.
+
+        Creates 2 model elements:
+        1. {name} - Deferrable load (energy requirement per calendar window)
+        2. {name}:connection - Connection (network → load), open only during windows
+
+        Calendar events define the run windows; each event's text carries the
+        energy (kWh) that window must absorb. Capacity opens at each window's
+        start, the requirement is due by its end, and any locked-in shortfall
+        is priced at the deficit price instead of being a hard constraint.
+        """
+        name = config["name"]
+        schedule = config[SECTION_SCHEDULE]
+        pricing = config[SECTION_PRICING]
+        power = config.get(SECTION_POWER, {})
+
+        calendar = schedule[CONF_WINDOW_CALENDAR]
+        capacity = np.cumsum(calendar["value_edge_start"])
+        required = np.cumsum(calendar["value_edge_end"])
+
+        # Power may only flow while a window is open.
+        window_mask = np.asarray(calendar["presence"][:-1], dtype=np.float64)
+        max_power = power.get(CONF_MAX_POWER)
+        if max_power is None:
+            max_power = _UNLIMITED_POWER
+        gated_power = max_power * window_mask
+
+        deficit_price = pricing[CONF_DEFICIT_PRICE]
+        # Overage is a single end-of-horizon charge, so a series collapses
+        # to its first value.
+        overage_price = float(np.atleast_1d(pricing.get(CONF_OVERAGE_PRICE, 0.0))[0])
+
+        load: DeferrableLoadElementConfig = {
+            "element_type": MODEL_ELEMENT_TYPE_DEFERRABLE_LOAD,
+            "name": name,
+            "capacity": capacity,
+            "required": required,
+            "deficit_price": _to_boundaries(deficit_price, len(capacity)),
+            "overage_price": overage_price,
+        }
+
+        return [
+            load,
+            {
+                "element_type": MODEL_ELEMENT_TYPE_CONNECTION,
+                "name": f"{name}:connection",
+                "source": extract_connection_target(config[CONF_CONNECTION]),
+                "target": name,
+                "segments": {
+                    "power_limit": {
+                        "segment_type": "power_limit",
+                        "max_power": gated_power,
+                    },
+                },
+            },
+        ]
+
+    def outputs(
+        self,
+        name: str,
+        model_outputs: Mapping[str, Mapping[ModelOutputName, ModelOutputValue]],
+        *,
+        config: DeferrableLoadConfigData,  # noqa: ARG002 (protocol signature)
+        **_kwargs: Any,
+    ) -> Mapping[DeferrableLoadDeviceName, Mapping[DeferrableLoadElementOutputName, OutputData]]:
+        """Map model outputs to deferrable-load-specific output names."""
+        load_outputs = model_outputs[name]
+        connection = model_outputs.get(f"{name}:connection")
+
+        absorbed = expect_output_data(load_outputs[DEFERRABLE_LOAD_ENERGY_ABSORBED])
+        deficit = expect_output_data(load_outputs[DEFERRABLE_LOAD_ENERGY_DEFICIT])
+        period_count = len(absorbed.values) - 1
+
+        power = replace(connection_power(connection, period_count), type=OutputType.POWER, direction="-")
+
+        return {
+            DEFERRABLE_LOAD_DEVICE: {
+                DEFERRABLE_POWER: power,
+                DEFERRABLE_ENERGY_ABSORBED: replace(absorbed, type=OutputType.ENERGY),
+                DEFERRABLE_ENERGY_DEFICIT: replace(deficit, type=OutputType.ENERGY),
+            }
+        }
+
+
+adapter = DeferrableLoadAdapter()
+
+
+def _to_boundaries(
+    value: NDArray[np.floating[Any]] | float,
+    n_boundaries: int,
+) -> NDArray[np.floating[Any]] | float:
+    """Extend an interval-shaped series to boundary length by repeating the end."""
+    if not isinstance(value, np.ndarray):
+        return value
+    if len(value) == n_boundaries - 1:
+        return np.append(value, value[-1])
+    return value

--- a/custom_components/haeo/core/adapters/elements/tests/test_deferrable_load.py
+++ b/custom_components/haeo/core/adapters/elements/tests/test_deferrable_load.py
@@ -1,0 +1,24 @@
+"""Tests for deferrable load adapter availability checks."""
+
+from homeassistant.core import HomeAssistant
+
+from custom_components.haeo.core.schema import as_calendar_value, as_connection_target, as_constant_value
+from custom_components.haeo.core.schema.elements import ElementType, deferrable_load
+from custom_components.haeo.elements.availability import schema_config_available
+
+
+async def test_available_with_calendar_and_constants(hass: HomeAssistant) -> None:
+    """Calendar values do not gate availability; constants are always available."""
+    config: deferrable_load.DeferrableLoadConfigSchema = {
+        "element_type": ElementType.DEFERRABLE_LOAD,
+        "name": "pump",
+        "connection": as_connection_target("switchboard"),
+        deferrable_load.SECTION_SCHEDULE: {
+            deferrable_load.CONF_WINDOW_CALENDAR: as_calendar_value("calendar.pool_pump"),
+        },
+        deferrable_load.SECTION_PRICING: {
+            deferrable_load.CONF_DEFICIT_PRICE: as_constant_value(10.0),
+        },
+    }
+
+    assert schema_config_available(config, sm=hass.states) is True

--- a/custom_components/haeo/core/adapters/elements/tests/test_deferrable_load_model.py
+++ b/custom_components/haeo/core/adapters/elements/tests/test_deferrable_load_model.py
@@ -1,0 +1,156 @@
+"""Tests for deferrable load element model mapping and optimization behavior."""
+
+from typing import Any
+
+import numpy as np
+import pytest
+
+from custom_components.haeo.core.adapters.elements.deferrable_load import (
+    DEFERRABLE_ENERGY_ABSORBED,
+    DEFERRABLE_ENERGY_DEFICIT,
+    DEFERRABLE_LOAD_DEVICE,
+    DEFERRABLE_POWER,
+    adapter,
+)
+from custom_components.haeo.core.data.loader.calendar_resolver import CalendarBoundaryData
+from custom_components.haeo.core.model import Network
+from custom_components.haeo.core.model.elements import MODEL_ELEMENT_TYPE_NODE
+from custom_components.haeo.core.model.elements.deferrable_load import (
+    DEFERRABLE_LOAD_ENERGY_ABSORBED,
+    DEFERRABLE_LOAD_ENERGY_DEFICIT,
+)
+from custom_components.haeo.core.schema import as_connection_target
+from custom_components.haeo.core.schema.elements import ElementType
+from custom_components.haeo.core.schema.elements.deferrable_load import DeferrableLoadConfigData
+
+
+def _boundary_data(
+    presence: list[float],
+    value_edge_start: list[float],
+    value_edge_end: list[float],
+) -> CalendarBoundaryData:
+    """Build calendar boundary data with a derived value_span."""
+    return CalendarBoundaryData(
+        presence=np.array(presence, dtype=np.float64),
+        value_span=np.array(presence, dtype=np.float64),
+        value_edge_start=np.array(value_edge_start, dtype=np.float64),
+        value_edge_end=np.array(value_edge_end, dtype=np.float64),
+    )
+
+
+def _config(**overrides: Any) -> DeferrableLoadConfigData:
+    """Build a deferrable load config with a window in period 2."""
+    config: dict[str, Any] = {
+        "element_type": ElementType.DEFERRABLE_LOAD,
+        "name": "pump",
+        "connection": as_connection_target("home"),
+        "schedule": {
+            "window_calendar": _boundary_data(
+                presence=[0.0, 0.0, 1.0, 0.0, 0.0],
+                value_edge_start=[0.0, 0.0, 6.0, 0.0, 0.0],
+                value_edge_end=[0.0, 0.0, 0.0, 6.0, 0.0],
+            ),
+        },
+        "pricing": {
+            "deficit_price": 10.0,
+        },
+    }
+    config.update(overrides)
+    return config  # type: ignore[return-value]  # constructed to match DeferrableLoadConfigData
+
+
+def _elements_by_name(config: DeferrableLoadConfigData) -> dict[str, dict[str, Any]]:
+    return {element["name"]: dict(element) for element in adapter.model_elements(config)}
+
+
+def test_model_elements_structure() -> None:
+    """The adapter creates the load and its window-gated connection."""
+    elements = _elements_by_name(_config(power={"max_power": 1.5}))
+
+    assert set(elements) == {"pump", "pump:connection"}
+    load = elements["pump"]
+    assert load["element_type"] == "deferrable_load"
+    np.testing.assert_allclose(load["capacity"], [0.0, 0.0, 6.0, 6.0, 6.0])
+    np.testing.assert_allclose(load["required"], [0.0, 0.0, 0.0, 6.0, 6.0])
+    assert load["deficit_price"] == pytest.approx(10.0)
+
+    connection = elements["pump:connection"]
+    assert connection["source"] == "home"
+    assert connection["target"] == "pump"
+    # Power may only flow while the window is open (period 2).
+    np.testing.assert_allclose(
+        connection["segments"]["power_limit"]["max_power"],
+        [0.0, 0.0, 1.5, 0.0],
+    )
+
+
+def test_unlimited_power_when_unconfigured() -> None:
+    """Without a max power the window gate alone limits flow."""
+    elements = _elements_by_name(_config())
+
+    max_power = elements["pump:connection"]["segments"]["power_limit"]["max_power"]
+    assert max_power[2] > 1e5
+    np.testing.assert_allclose(max_power[[0, 1, 3]], [0.0, 0.0, 0.0])
+
+
+def _solve(config: DeferrableLoadConfigData, grid_price: list[float]) -> Network:
+    """Build and solve a grid + deferrable load network."""
+    n = len(grid_price)
+    network = Network(name="test", periods=np.array([1.0] * n))
+    network.add({"element_type": MODEL_ELEMENT_TYPE_NODE, "name": "home", "is_source": False, "is_sink": False})
+    network.add({"element_type": MODEL_ELEMENT_TYPE_NODE, "name": "grid", "is_source": True, "is_sink": True})
+    network.add(
+        {
+            "element_type": "connection",
+            "name": "grid:import",
+            "source": "grid",
+            "target": "home",
+            "tags": {1},
+            "segments": {
+                "pricing": {"segment_type": "pricing", "price": np.array(grid_price)},
+            },
+        }
+    )
+    # Policy compilation assigns tags in production; default them here.
+    for element in adapter.model_elements(config):
+        if element["element_type"] == "connection":
+            element.setdefault("tags", {1})  # type: ignore[typeddict-unknown-key]  # spec allows tags
+        network.add(element)
+    network.optimize()
+    return network
+
+
+def test_window_energy_absorbed_within_window() -> None:
+    """The load absorbs its window energy inside the window."""
+    network = _solve(_config(power={"max_power": 10.0}), grid_price=[0.1, 0.1, 0.1, 0.1])
+
+    load_outputs = network.elements["pump"].outputs()
+    absorbed = load_outputs[DEFERRABLE_LOAD_ENERGY_ABSORBED].values
+    np.testing.assert_allclose(absorbed, [0.0, 0.0, 0.0, 6.0, 6.0])
+    assert load_outputs[DEFERRABLE_LOAD_ENERGY_DEFICIT].values[-1] == pytest.approx(0.0)
+
+
+def test_too_small_window_prices_the_shortfall() -> None:
+    """When the device cannot absorb enough in the window, the deficit is priced."""
+    config = _config(power={"max_power": 2.0}, pricing={"deficit_price": 5.0})
+    network = _solve(config, grid_price=[0.1, 0.1, 0.1, 0.1])
+
+    load_outputs = network.elements["pump"].outputs()
+    absorbed = load_outputs[DEFERRABLE_LOAD_ENERGY_ABSORBED].values
+    deficit = load_outputs[DEFERRABLE_LOAD_ENERGY_DEFICIT].values
+    assert absorbed[-1] == pytest.approx(2.0)  # 2 kW for the one-hour window
+    assert deficit[-1] == pytest.approx(4.0)
+
+
+def test_outputs_mapping() -> None:
+    """Adapter outputs expose power, absorbed energy, and the shortfall."""
+    config = _config(power={"max_power": 10.0})
+    network = _solve(config, grid_price=[0.1, 0.1, 0.1, 0.1])
+    model_outputs = {name: element.outputs() for name, element in network.elements.items()}
+
+    outputs = adapter.outputs("pump", model_outputs, config=config)[DEFERRABLE_LOAD_DEVICE]
+
+    assert set(outputs) == {DEFERRABLE_POWER, DEFERRABLE_ENERGY_ABSORBED, DEFERRABLE_ENERGY_DEFICIT}
+    assert outputs[DEFERRABLE_ENERGY_ABSORBED].values[-1] == pytest.approx(6.0)
+    assert outputs[DEFERRABLE_ENERGY_DEFICIT].values[-1] == pytest.approx(0.0)
+    np.testing.assert_allclose(outputs[DEFERRABLE_POWER].values, [0.0, 0.0, 6.0, 0.0])

--- a/custom_components/haeo/core/adapters/registry.py
+++ b/custom_components/haeo/core/adapters/registry.py
@@ -6,6 +6,7 @@ from typing import Any, Protocol, TypeGuard, runtime_checkable
 from custom_components.haeo.core.adapters.elements.battery import adapter as battery_adapter
 from custom_components.haeo.core.adapters.elements.battery_section import adapter as battery_section_adapter
 from custom_components.haeo.core.adapters.elements.connection import adapter as connection_adapter
+from custom_components.haeo.core.adapters.elements.deferrable_load import adapter as deferrable_load_adapter
 from custom_components.haeo.core.adapters.elements.grid import adapter as grid_adapter
 from custom_components.haeo.core.adapters.elements.inverter import adapter as inverter_adapter
 from custom_components.haeo.core.adapters.elements.load import adapter as load_adapter
@@ -57,6 +58,7 @@ ELEMENT_TYPES: dict[ElementType, ElementAdapter] = {
     ElementType.INVERTER: inverter_adapter,
     ElementType.SOLAR: solar_adapter,
     ElementType.BATTERY: battery_adapter,
+    ElementType.DEFERRABLE_LOAD: deferrable_load_adapter,
     ElementType.CONNECTION: connection_adapter,
     ElementType.NODE: node_adapter,
     ElementType.BATTERY_SECTION: battery_section_adapter,

--- a/custom_components/haeo/core/schema/elements/__init__.py
+++ b/custom_components/haeo/core/schema/elements/__init__.py
@@ -8,6 +8,10 @@ from custom_components.haeo.core.schema.elements.battery_section import (
     BatterySectionConfigSchema,
 )
 from custom_components.haeo.core.schema.elements.connection import ConnectionConfigData, ConnectionConfigSchema
+from custom_components.haeo.core.schema.elements.deferrable_load import (
+    DeferrableLoadConfigData,
+    DeferrableLoadConfigSchema,
+)
 from custom_components.haeo.core.schema.elements.element_type import ElementType
 from custom_components.haeo.core.schema.elements.grid import GridConfigData, GridConfigSchema
 from custom_components.haeo.core.schema.elements.inverter import InverterConfigData, InverterConfigSchema
@@ -20,6 +24,7 @@ ElementConfigSchema = (
     InverterConfigSchema
     | BatteryConfigSchema
     | BatterySectionConfigSchema
+    | DeferrableLoadConfigSchema
     | GridConfigSchema
     | LoadConfigSchema
     | SolarConfigSchema
@@ -32,6 +37,7 @@ ElementConfigData = (
     InverterConfigData
     | BatteryConfigData
     | BatterySectionConfigData
+    | DeferrableLoadConfigData
     | GridConfigData
     | LoadConfigData
     | SolarConfigData
@@ -44,6 +50,7 @@ ELEMENT_CONFIG_SCHEMAS: Final[dict[ElementType, type]] = {
     ElementType.BATTERY: BatteryConfigSchema,
     ElementType.BATTERY_SECTION: BatterySectionConfigSchema,
     ElementType.CONNECTION: ConnectionConfigSchema,
+    ElementType.DEFERRABLE_LOAD: DeferrableLoadConfigSchema,
     ElementType.GRID: GridConfigSchema,
     ElementType.INVERTER: InverterConfigSchema,
     ElementType.LOAD: LoadConfigSchema,

--- a/custom_components/haeo/core/schema/elements/deferrable_load.py
+++ b/custom_components/haeo/core/schema/elements/deferrable_load.py
@@ -1,0 +1,173 @@
+"""Deferrable load element schema definitions."""
+
+from typing import Annotated, Any, Final, Literal, NotRequired, TypedDict
+
+import numpy as np
+from numpy.typing import NDArray
+
+from custom_components.haeo.core.data.loader.calendar_resolver import CalendarBoundaryData
+from custom_components.haeo.core.model.const import OutputType
+from custom_components.haeo.core.schema import CalendarValue, ConstantValue, EntityValue, NoneValue
+from custom_components.haeo.core.schema.elements.element_type import ElementType
+from custom_components.haeo.core.schema.field_hints import CalendarFieldHint, FieldHint, SectionHints
+from custom_components.haeo.core.schema.sections import ConnectedCommonConfig, ConnectedCommonData
+
+ELEMENT_TYPE = ElementType.DEFERRABLE_LOAD
+
+# Section names
+SECTION_SCHEDULE: Final = "schedule"
+SECTION_POWER: Final = "power"
+SECTION_PRICING: Final = "pricing"
+
+# Schedule section field names
+CONF_WINDOW_CALENDAR: Final = "window_calendar"
+
+# Power section field names
+CONF_MAX_POWER: Final = "max_power"
+
+# Pricing section field names
+CONF_DEFICIT_PRICE: Final = "deficit_price"
+CONF_OVERAGE_PRICE: Final = "overage_price"
+
+# Default deficit price ($/kWh) pre-filled in the flow: high enough that the
+# load runs whenever physically possible, finite so it can never make the
+# optimization infeasible.
+DEFAULT_DEFICIT_PRICE: Final = 10.0
+
+OPTIONAL_INPUT_FIELDS: Final[frozenset[str]] = frozenset(
+    {
+        CONF_MAX_POWER,
+        CONF_OVERAGE_PRICE,
+    }
+)
+
+
+# --- Schedule section ---
+
+
+class ScheduleConfig(TypedDict):
+    """Run window schedule configuration."""
+
+    window_calendar: CalendarValue
+
+
+class ScheduleData(TypedDict):
+    """Loaded run window schedule."""
+
+    window_calendar: CalendarBoundaryData
+
+
+# --- Power section ---
+
+
+class PowerConfig(TypedDict, total=False):
+    """Power limit configuration."""
+
+    max_power: EntityValue | ConstantValue | NoneValue
+
+
+class PowerData(TypedDict, total=False):
+    """Loaded power limit values."""
+
+    max_power: NDArray[np.floating[Any]] | float
+
+
+# --- Pricing section ---
+
+
+class PricingConfig(TypedDict):
+    """Shortfall and overage pricing configuration."""
+
+    deficit_price: EntityValue | ConstantValue
+    overage_price: NotRequired[EntityValue | ConstantValue | NoneValue]
+
+
+class PricingData(TypedDict):
+    """Loaded pricing values."""
+
+    deficit_price: NDArray[np.floating[Any]] | float
+    overage_price: NotRequired[float]
+
+
+# --- Main element schemas ---
+
+
+class DeferrableLoadConfigSchema(ConnectedCommonConfig):
+    """Deferrable load element configuration as stored in Home Assistant."""
+
+    element_type: Literal[ElementType.DEFERRABLE_LOAD]
+    schedule: Annotated[
+        ScheduleConfig,
+        SectionHints(
+            {
+                CONF_WINDOW_CALENDAR: FieldHint(
+                    output_type=OutputType.ENERGY,
+                    time_series=True,
+                    boundaries=True,
+                    calendar=CalendarFieldHint(parser="number"),
+                ),
+            }
+        ),
+    ]
+    power: NotRequired[
+        Annotated[
+            PowerConfig,
+            SectionHints(
+                {
+                    CONF_MAX_POWER: FieldHint(
+                        output_type=OutputType.POWER_LIMIT,
+                        direction="-",
+                        time_series=True,
+                    ),
+                }
+            ),
+        ]
+    ]
+    pricing: Annotated[
+        PricingConfig,
+        SectionHints(
+            {
+                CONF_DEFICIT_PRICE: FieldHint(
+                    output_type=OutputType.PRICE,
+                    time_series=True,
+                    default_mode="value",
+                    default_value=DEFAULT_DEFICIT_PRICE,
+                ),
+                CONF_OVERAGE_PRICE: FieldHint(
+                    output_type=OutputType.PRICE,
+                    time_series=False,
+                ),
+            }
+        ),
+    ]
+
+
+class DeferrableLoadConfigData(ConnectedCommonData):
+    """Deferrable load element configuration with loaded values."""
+
+    element_type: Literal[ElementType.DEFERRABLE_LOAD]
+    schedule: ScheduleData
+    power: NotRequired[PowerData]
+    pricing: PricingData
+
+
+__all__ = [
+    "CONF_DEFICIT_PRICE",
+    "CONF_MAX_POWER",
+    "CONF_OVERAGE_PRICE",
+    "CONF_WINDOW_CALENDAR",
+    "DEFAULT_DEFICIT_PRICE",
+    "ELEMENT_TYPE",
+    "OPTIONAL_INPUT_FIELDS",
+    "SECTION_POWER",
+    "SECTION_PRICING",
+    "SECTION_SCHEDULE",
+    "DeferrableLoadConfigData",
+    "DeferrableLoadConfigSchema",
+    "PowerConfig",
+    "PowerData",
+    "PricingConfig",
+    "PricingData",
+    "ScheduleConfig",
+    "ScheduleData",
+]

--- a/custom_components/haeo/core/schema/elements/element_type.py
+++ b/custom_components/haeo/core/schema/elements/element_type.py
@@ -9,6 +9,7 @@ class ElementType(StrEnum):
     BATTERY = "battery"
     BATTERY_SECTION = "battery_section"
     CONNECTION = "connection"
+    DEFERRABLE_LOAD = "deferrable_load"
     GRID = "grid"
     INVERTER = "inverter"
     LOAD = "load"

--- a/custom_components/haeo/elements/__init__.py
+++ b/custom_components/haeo/elements/__init__.py
@@ -67,6 +67,12 @@ from custom_components.haeo.core.adapters.elements.connection import (
     ConnectionDeviceName,
     ConnectionOutputName,
 )
+from custom_components.haeo.core.adapters.elements.deferrable_load import (
+    DEFERRABLE_LOAD_DEVICE_NAMES,
+    DEFERRABLE_LOAD_ELEMENT_OUTPUT_NAMES,
+    DeferrableLoadDeviceName,
+    DeferrableLoadElementOutputName,
+)
 from custom_components.haeo.core.adapters.elements.grid import (
     GRID_DEVICE_NAMES,
     GRID_OUTPUT_NAMES,
@@ -117,6 +123,10 @@ from custom_components.haeo.core.schema.elements.connection import (
     OPTIONAL_INPUT_FIELDS as CONNECTION_OPTIONAL_INPUT_FIELDS,
 )
 from custom_components.haeo.core.schema.elements.connection import ConnectionConfigData
+from custom_components.haeo.core.schema.elements.deferrable_load import (
+    OPTIONAL_INPUT_FIELDS as DEFERRABLE_LOAD_OPTIONAL_INPUT_FIELDS,
+)
+from custom_components.haeo.core.schema.elements.deferrable_load import DeferrableLoadConfigData
 from custom_components.haeo.core.schema.elements.grid import OPTIONAL_INPUT_FIELDS as GRID_OPTIONAL_INPUT_FIELDS
 from custom_components.haeo.core.schema.elements.grid import GridConfigData
 from custom_components.haeo.core.schema.elements.inverter import OPTIONAL_INPUT_FIELDS as INVERTER_OPTIONAL_INPUT_FIELDS
@@ -147,6 +157,7 @@ type ElementOutputName = (
     | BatteryOutputName
     | BatterySectionOutputName
     | ConnectionOutputName
+    | DeferrableLoadElementOutputName
     | GridOutputName
     | LoadOutputName
     | NodeOutputName
@@ -159,6 +170,7 @@ ELEMENT_OUTPUT_NAMES: Final[frozenset[ElementOutputName]] = frozenset(
     | BATTERY_OUTPUT_NAMES
     | BATTERY_SECTION_OUTPUT_NAMES
     | CONNECTION_OUTPUT_NAMES
+    | DEFERRABLE_LOAD_ELEMENT_OUTPUT_NAMES
     | GRID_OUTPUT_NAMES
     | LOAD_OUTPUT_NAMES
     | NODE_OUTPUT_NAMES
@@ -171,6 +183,7 @@ type ElementDeviceName = (
     | BatteryDeviceName
     | BatterySectionDeviceName
     | ConnectionDeviceName
+    | DeferrableLoadDeviceName
     | GridDeviceName
     | LoadDeviceName
     | NodeDeviceName
@@ -186,6 +199,7 @@ ELEMENT_DEVICE_NAMES: Final[frozenset[ElementDeviceName]] = frozenset(
     | BATTERY_DEVICE_NAMES
     | BATTERY_SECTION_DEVICE_NAMES
     | CONNECTION_DEVICE_NAMES
+    | DEFERRABLE_LOAD_DEVICE_NAMES
     | GRID_DEVICE_NAMES
     | LOAD_DEVICE_NAMES
     | NODE_DEVICE_NAMES
@@ -199,6 +213,7 @@ ELEMENT_DEVICE_NAMES_BY_TYPE: Final[dict[str, frozenset[ElementDeviceName]]] = {
     ElementType.BATTERY: frozenset(BATTERY_DEVICE_NAMES),
     ElementType.BATTERY_SECTION: frozenset(BATTERY_SECTION_DEVICE_NAMES),
     ElementType.CONNECTION: frozenset(CONNECTION_DEVICE_NAMES),
+    ElementType.DEFERRABLE_LOAD: frozenset(DEFERRABLE_LOAD_DEVICE_NAMES),
     ElementType.GRID: frozenset(GRID_DEVICE_NAMES),
     ElementType.LOAD: frozenset(LOAD_DEVICE_NAMES),
     ElementType.NODE: frozenset(NODE_DEVICE_NAMES),
@@ -221,6 +236,7 @@ ELEMENT_CONFIG_DATA: Final[dict[ElementType, type]] = {
     ElementType.BATTERY: BatteryConfigData,
     ElementType.BATTERY_SECTION: BatterySectionConfigData,
     ElementType.CONNECTION: ConnectionConfigData,
+    ElementType.DEFERRABLE_LOAD: DeferrableLoadConfigData,
     ElementType.GRID: GridConfigData,
     ElementType.INVERTER: InverterConfigData,
     ElementType.LOAD: LoadConfigData,
@@ -233,6 +249,7 @@ ELEMENT_OPTIONAL_INPUT_FIELDS: Final[dict[ElementType, frozenset[str]]] = {
     ElementType.BATTERY: BATTERY_OPTIONAL_INPUT_FIELDS,
     ElementType.BATTERY_SECTION: BATTERY_SECTION_OPTIONAL_INPUT_FIELDS,
     ElementType.CONNECTION: CONNECTION_OPTIONAL_INPUT_FIELDS,
+    ElementType.DEFERRABLE_LOAD: DEFERRABLE_LOAD_OPTIONAL_INPUT_FIELDS,
     ElementType.GRID: GRID_OPTIONAL_INPUT_FIELDS,
     ElementType.INVERTER: INVERTER_OPTIONAL_INPUT_FIELDS,
     ElementType.LOAD: LOAD_OPTIONAL_INPUT_FIELDS,

--- a/custom_components/haeo/flows/__init__.py
+++ b/custom_components/haeo/flows/__init__.py
@@ -350,6 +350,7 @@ def get_element_flow_classes() -> dict[ElementType, type]:
     from custom_components.haeo.flows.elements.battery import BatterySubentryFlowHandler  # noqa: PLC0415
     from custom_components.haeo.flows.elements.battery_section import BatterySectionSubentryFlowHandler  # noqa: PLC0415
     from custom_components.haeo.flows.elements.connection import ConnectionSubentryFlowHandler  # noqa: PLC0415
+    from custom_components.haeo.flows.elements.deferrable_load import DeferrableLoadSubentryFlowHandler  # noqa: PLC0415
     from custom_components.haeo.flows.elements.grid import GridSubentryFlowHandler  # noqa: PLC0415
     from custom_components.haeo.flows.elements.inverter import InverterSubentryFlowHandler  # noqa: PLC0415
     from custom_components.haeo.flows.elements.load import LoadSubentryFlowHandler  # noqa: PLC0415
@@ -361,6 +362,7 @@ def get_element_flow_classes() -> dict[ElementType, type]:
         ElementType.BATTERY: BatterySubentryFlowHandler,
         ElementType.BATTERY_SECTION: BatterySectionSubentryFlowHandler,
         ElementType.CONNECTION: ConnectionSubentryFlowHandler,
+        ElementType.DEFERRABLE_LOAD: DeferrableLoadSubentryFlowHandler,
         ElementType.GRID: GridSubentryFlowHandler,
         ElementType.INVERTER: InverterSubentryFlowHandler,
         ElementType.LOAD: LoadSubentryFlowHandler,

--- a/custom_components/haeo/flows/elements/deferrable_load.py
+++ b/custom_components/haeo/flows/elements/deferrable_load.py
@@ -1,0 +1,199 @@
+"""Deferrable load element configuration flows."""
+
+from typing import Any
+
+from homeassistant.config_entries import ConfigSubentryFlow, SubentryFlowResult
+import voluptuous as vol
+
+from custom_components.haeo.core.const import CONF_ELEMENT_TYPE, CONF_NAME
+from custom_components.haeo.core.schema import get_connection_target_name, normalize_connection_target
+from custom_components.haeo.core.schema.elements.deferrable_load import (
+    CONF_DEFICIT_PRICE,
+    CONF_MAX_POWER,
+    CONF_OVERAGE_PRICE,
+    CONF_WINDOW_CALENDAR,
+    ELEMENT_TYPE,
+    SECTION_POWER,
+    SECTION_PRICING,
+    SECTION_SCHEDULE,
+)
+from custom_components.haeo.core.schema.sections import CONF_CONNECTION
+from custom_components.haeo.elements import get_input_field_schema_info, get_input_fields
+from custom_components.haeo.elements.input_fields import InputFieldGroups
+from custom_components.haeo.flows.element_flow import ElementFlowMixin, build_sectioned_inclusion_map
+from custom_components.haeo.flows.entity_metadata import extract_entity_metadata
+from custom_components.haeo.flows.field_schema import (
+    SectionDefinition,
+    build_sectioned_choose_defaults,
+    build_sectioned_choose_schema,
+    convert_sectioned_choose_data_to_config,
+    preprocess_sectioned_choose_input,
+    validate_sectioned_choose_fields,
+)
+from custom_components.haeo.sections import build_common_fields
+
+
+class DeferrableLoadSubentryFlowHandler(ElementFlowMixin, ConfigSubentryFlow):
+    """Handle deferrable load element configuration flows."""
+
+    def _get_sections(self) -> tuple[SectionDefinition, ...]:
+        """Return sections for the configuration step."""
+        return (
+            SectionDefinition(
+                key=SECTION_SCHEDULE,
+                fields=(CONF_WINDOW_CALENDAR,),
+                collapsed=False,
+            ),
+            SectionDefinition(
+                key=SECTION_PRICING,
+                fields=(CONF_DEFICIT_PRICE, CONF_OVERAGE_PRICE),
+                collapsed=False,
+            ),
+            SectionDefinition(
+                key=SECTION_POWER,
+                fields=(CONF_MAX_POWER,),
+                collapsed=True,
+            ),
+        )
+
+    async def async_step_user(self, user_input: dict[str, Any] | None = None) -> SubentryFlowResult:
+        """Handle user step: name, connection, schedule, and input configuration."""
+        return await self._async_step_user(user_input)
+
+    async def async_step_reconfigure(self, user_input: dict[str, Any] | None = None) -> SubentryFlowResult:
+        """Handle reconfigure step."""
+        return await self._async_step_user(user_input)
+
+    async def _async_step_user(self, user_input: dict[str, Any] | None) -> SubentryFlowResult:
+        """Shared logic for user and reconfigure steps."""
+        subentry = self._get_subentry()
+        subentry_data = dict(subentry.data) if subentry else None
+        participants = self._get_participant_names()
+        current_connection = get_connection_target_name(subentry_data.get(CONF_CONNECTION)) if subentry_data else None
+        default_name = await self._async_get_default_name(ELEMENT_TYPE)
+        if not isinstance(current_connection, str):
+            current_connection = participants[0] if participants else ""
+        input_fields = get_input_fields(ELEMENT_TYPE)
+
+        sections = self._get_sections()
+        user_input = preprocess_sectioned_choose_input(user_input, input_fields, sections)
+        errors = self._validate_user_input(user_input, input_fields)
+
+        if user_input is not None and not errors:
+            config = self._build_config(user_input)
+            return self._finalize(config, user_input)
+
+        entity_metadata = extract_entity_metadata(self.hass, self._get_entry())
+        section_inclusion_map = build_sectioned_inclusion_map(input_fields, entity_metadata)
+        schema = self._build_schema(
+            participants,
+            input_fields,
+            section_inclusion_map,
+            current_connection,
+            subentry_data,
+        )
+        defaults = (
+            user_input
+            if user_input is not None
+            else self._build_defaults(
+                default_name,
+                input_fields,
+                subentry_data,
+                current_connection,
+            )
+        )
+        schema = self.add_suggested_values_to_schema(schema, defaults)
+
+        return self.async_show_form(step_id="user", data_schema=schema, errors=errors)
+
+    def _build_schema(
+        self,
+        participants: list[str],
+        input_fields: InputFieldGroups,
+        section_inclusion_map: dict[str, dict[str, list[str]]],
+        current_connection: str | None = None,
+        subentry_data: dict[str, Any] | None = None,
+    ) -> vol.Schema:
+        """Build the schema with name, connection, and choose selectors for inputs."""
+        field_schema = get_input_field_schema_info(ELEMENT_TYPE, input_fields)
+        return build_sectioned_choose_schema(
+            self._get_sections(),
+            input_fields,
+            field_schema,
+            section_inclusion_map,
+            current_data=subentry_data,
+            top_level_entries=build_common_fields(
+                include_connection=True,
+                participants=participants,
+                current_connection=current_connection,
+            ),
+        )
+
+    def _build_defaults(
+        self,
+        default_name: str,
+        input_fields: InputFieldGroups,
+        subentry_data: dict[str, Any] | None = None,
+        connection_default: str | None = None,
+    ) -> dict[str, Any]:
+        """Build default values for the form."""
+        connection_default = (
+            connection_default
+            if connection_default is not None
+            else get_connection_target_name(subentry_data.get(CONF_CONNECTION))
+            if subentry_data
+            else None
+        )
+        return {
+            CONF_NAME: default_name if subentry_data is None else subentry_data.get(CONF_NAME),
+            CONF_CONNECTION: connection_default,
+            **build_sectioned_choose_defaults(
+                self._get_sections(),
+                input_fields,
+                current_data=subentry_data,
+            ),
+        }
+
+    def _validate_user_input(
+        self,
+        user_input: dict[str, Any] | None,
+        input_fields: InputFieldGroups,
+    ) -> dict[str, str] | None:
+        """Validate user input and return errors dict if any."""
+        if user_input is None:
+            return None
+        errors: dict[str, str] = {}
+        self._validate_name(user_input.get(CONF_NAME), errors)
+        field_schema = get_input_field_schema_info(ELEMENT_TYPE, input_fields)
+        errors.update(
+            validate_sectioned_choose_fields(
+                user_input,
+                input_fields,
+                field_schema,
+                self._get_sections(),
+            )
+        )
+        return errors if errors else None
+
+    def _build_config(self, user_input: dict[str, Any]) -> dict[str, Any]:
+        """Build final config dict from user input."""
+        input_fields = get_input_fields(ELEMENT_TYPE)
+        config_dict = convert_sectioned_choose_data_to_config(
+            user_input,
+            input_fields,
+            self._get_sections(),
+        )
+        return {
+            CONF_ELEMENT_TYPE: ELEMENT_TYPE,
+            CONF_NAME: user_input[CONF_NAME],
+            CONF_CONNECTION: normalize_connection_target(user_input[CONF_CONNECTION]),
+            **config_dict,
+        }
+
+    def _finalize(self, config: dict[str, Any], user_input: dict[str, Any]) -> SubentryFlowResult:
+        """Finalize the flow by creating or updating the entry."""
+        name = str(user_input[CONF_NAME])
+        subentry = self._get_subentry()
+        if subentry is not None:
+            return self.async_update_and_abort(self._get_entry(), subentry, title=name, data=config)
+        return self.async_create_entry(title=name, data=config)

--- a/custom_components/haeo/flows/elements/tests/test_deferrable_load_flow.py
+++ b/custom_components/haeo/flows/elements/tests/test_deferrable_load_flow.py
@@ -1,0 +1,71 @@
+"""Tests for deferrable load element config flow."""
+
+from typing import Any
+from unittest.mock import Mock
+
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from conftest import add_participant
+from custom_components.haeo.core.const import CONF_NAME
+from custom_components.haeo.core.schema import as_calendar_value, as_constant_value
+from custom_components.haeo.core.schema.elements import node
+from custom_components.haeo.core.schema.elements.deferrable_load import (
+    CONF_DEFICIT_PRICE,
+    CONF_MAX_POWER,
+    CONF_WINDOW_CALENDAR,
+    ELEMENT_TYPE,
+    SECTION_POWER,
+    SECTION_PRICING,
+    SECTION_SCHEDULE,
+)
+from custom_components.haeo.core.schema.sections import CONF_CONNECTION
+from custom_components.haeo.flows.conftest import create_flow
+
+
+def _user_input(**overrides: Any) -> dict[str, Any]:
+    """Build sectioned deferrable load user input."""
+    data = {
+        CONF_NAME: "Pool Pump",
+        CONF_CONNECTION: "TestNode",
+        SECTION_SCHEDULE: {CONF_WINDOW_CALENDAR: "calendar.pool_pump"},
+        SECTION_PRICING: {CONF_DEFICIT_PRICE: 10.0},
+        SECTION_POWER: {CONF_MAX_POWER: 1.5},
+    }
+    data.update(overrides)
+    return data
+
+
+async def test_user_step_creates_entry_with_calendar(
+    hass: HomeAssistant,
+    hub_entry: MockConfigEntry,
+) -> None:
+    """Submitting stores the calendar schema value and constants."""
+    add_participant(hass, hub_entry, "TestNode", node.ELEMENT_TYPE)
+
+    flow = create_flow(hass, hub_entry, ELEMENT_TYPE)
+    flow.async_create_entry = Mock(return_value={"type": FlowResultType.CREATE_ENTRY, "title": "Pool Pump", "data": {}})
+
+    result = await flow.async_step_user(user_input=_user_input())
+
+    assert result.get("type") == FlowResultType.CREATE_ENTRY
+    data = flow.async_create_entry.call_args.kwargs["data"]
+    assert data[SECTION_SCHEDULE][CONF_WINDOW_CALENDAR] == as_calendar_value("calendar.pool_pump")
+    assert data[SECTION_PRICING][CONF_DEFICIT_PRICE] == as_constant_value(10.0)
+    assert data[SECTION_POWER][CONF_MAX_POWER] == as_constant_value(1.5)
+
+
+async def test_missing_calendar_is_an_error(
+    hass: HomeAssistant,
+    hub_entry: MockConfigEntry,
+) -> None:
+    """The run window calendar is required."""
+    add_participant(hass, hub_entry, "TestNode", node.ELEMENT_TYPE)
+
+    flow = create_flow(hass, hub_entry, ELEMENT_TYPE)
+
+    result = await flow.async_step_user(user_input=_user_input(schedule={CONF_WINDOW_CALENDAR: None}))
+
+    assert result.get("type") == FlowResultType.FORM
+    assert CONF_WINDOW_CALENDAR in result.get("errors", {})

--- a/custom_components/haeo/flows/tests/test_data/deferrable_load.py
+++ b/custom_components/haeo/flows/tests/test_data/deferrable_load.py
@@ -1,0 +1,50 @@
+"""Test deferrable load config flow data for choose selector approach."""
+
+from custom_components.haeo.core.const import CONF_NAME
+from custom_components.haeo.core.schema import as_calendar_value, as_connection_target, as_constant_value
+from custom_components.haeo.core.schema.elements.deferrable_load import (
+    CONF_DEFICIT_PRICE,
+    CONF_MAX_POWER,
+    CONF_OVERAGE_PRICE,
+    CONF_WINDOW_CALENDAR,
+    SECTION_POWER,
+    SECTION_PRICING,
+    SECTION_SCHEDULE,
+)
+from custom_components.haeo.core.schema.sections import CONF_CONNECTION
+
+VALID_DATA = [
+    {
+        "description": "Pool pump with scheduled windows and power limit",
+        "config": {
+            CONF_NAME: "Pool Pump",
+            CONF_CONNECTION: as_connection_target("switchboard"),
+            SECTION_SCHEDULE: {
+                CONF_WINDOW_CALENDAR: as_calendar_value("calendar.pool_pump"),
+            },
+            SECTION_PRICING: {
+                CONF_DEFICIT_PRICE: as_constant_value(10.0),
+                CONF_OVERAGE_PRICE: as_constant_value(0.1),
+            },
+            SECTION_POWER: {
+                CONF_MAX_POWER: as_constant_value(1.5),
+            },
+        },
+    },
+    {
+        "description": "Minimal deferrable load - calendar and shortfall price only",
+        "config": {
+            CONF_NAME: "Hot Water",
+            CONF_CONNECTION: as_connection_target("switchboard"),
+            SECTION_SCHEDULE: {
+                CONF_WINDOW_CALENDAR: as_calendar_value("calendar.hot_water"),
+            },
+            SECTION_PRICING: {
+                CONF_DEFICIT_PRICE: as_constant_value(10.0),
+            },
+            SECTION_POWER: {},
+        },
+    },
+]
+
+INVALID_DATA: list[dict[str, object]] = []

--- a/custom_components/haeo/translations/en.json
+++ b/custom_components/haeo/translations/en.json
@@ -251,6 +251,39 @@
       },
       "abort": { "reconfigure_successful": "Configuration updated successfully" }
     },
+    "deferrable_load": {
+      "flow_title": "Deferrable Load",
+      "entry_type": "Deferrable Load",
+      "initiate_flow": { "user": "Deferrable Load", "reconfigure": "Deferrable Load" },
+      "step": {
+        "user": {
+          "title": "Deferrable Load Configuration",
+          "description": "Configure a load that must absorb scheduled amounts of energy within calendar windows",
+          "data": {
+            "connection": "Connection",
+            "deficit_price": "Shortfall price",
+            "max_power": "Max power",
+            "name": "Deferrable Load Name",
+            "overage_price": "Overage price",
+            "window_calendar": "Run window calendar"
+          },
+          "sections": {
+            "common": {
+              "data": { "connection": "Connection", "name": "Deferrable Load Name" },
+              "name": "Common settings"
+            },
+            "power": { "data": { "max_power": "Max power" }, "name": "Power" },
+            "pricing": {
+              "data": { "deficit_price": "Shortfall price", "overage_price": "Overage price" },
+              "name": "Pricing"
+            },
+            "schedule": { "data": { "window_calendar": "Run window calendar" }, "name": "Schedule" }
+          }
+        }
+      },
+      "error": { "missing_name": "Name is required", "name_exists": "A device with this name already exists" },
+      "abort": { "reconfigure_successful": "Configuration updated successfully" }
+    },
     "grid": {
       "flow_title": "Grid",
       "entry_type": "Grid",
@@ -457,6 +490,7 @@
     "battery": { "name": "{name}" },
     "battery_section": { "name": "{name}" },
     "connection": { "name": "{name}" },
+    "deferrable_load": { "name": "{name}" },
     "grid": { "name": "{name}" },
     "inverter": { "name": "{name}" },
     "load": { "name": "{name}" },
@@ -490,6 +524,9 @@
       "connection_max_power_target_source": { "name": "Max target to source power" },
       "connection_price_source_target": { "name": "Source to target price" },
       "connection_price_target_source": { "name": "Target to source price" },
+      "deferrable_load_deficit_price": { "name": "Shortfall price" },
+      "deferrable_load_max_power": { "name": "Max power" },
+      "deferrable_load_overage_price": { "name": "Overage price" },
       "grid_max_power_source_target": { "name": "Import limit" },
       "grid_max_power_target_source": { "name": "Export limit" },
       "grid_price_source_target": { "name": "Import price" },
@@ -526,6 +563,9 @@
       "battery_soc_min": { "name": "SOC min shadow price" },
       "battery_state_of_charge": { "name": "State of charge" },
       "connection_power": { "name": "{source} to {target} power" },
+      "deferrable_load_energy_absorbed": { "name": "Energy absorbed" },
+      "deferrable_load_energy_deficit": { "name": "Energy shortfall" },
+      "deferrable_load_power": { "name": "Power" },
       "grid_cost_import": { "name": "Import cost" },
       "grid_cost_net": { "name": "Net cost" },
       "grid_power_active": { "name": "Active power" },

--- a/docs/modeling/device-layer/deferrable_load.md
+++ b/docs/modeling/device-layer/deferrable_load.md
@@ -1,0 +1,106 @@
+# Deferrable load modeling
+
+The deferrable load device composes one deferrable load model element and one [Connection](../model-layer/connections/connection.md).
+
+## Model elements created
+
+```mermaid
+graph LR
+    subgraph deviceDL["Device:pool_pump"]
+        Load["Deferrable load: pool_pump"]
+        Conn["Connection: pool_pump:connection"]
+    end
+    Target[Connection target]
+    Target --> Conn
+    Conn --> Load
+```
+
+The adapter creates two model elements:
+
+| Model Element                                          | Name                | Purpose                                            |
+| ------------------------------------------------------ | ------------------- | -------------------------------------------------- |
+| Deferrable load                                        | `{name}`            | Per-window energy requirements with priced deficit |
+| [Connection](../model-layer/connections/connection.md) | `{name}:connection` | Network → load, open only while a window is open   |
+
+## Architecture details
+
+### Window scheduling
+
+Calendar events define run windows.
+For each window $i$ with start $s_i$, end $e_i$, and required energy $E_i$ (from the event text, kWh), two boundary-aligned cumulative profiles drive the load:
+
+- **Capacity** opens at each window's start: $C(t) = \sum_{i:\, s_i \le t} E_i$
+- **Requirement** is due by each window's end: $E_{\text{req}}(t) = \sum_{i:\, e_i \le t} E_i$
+
+The connection's power limit is masked by window presence, so power can only flow while a window is open, and is capped by the configured max power.
+
+### Priced shortfall
+
+The requirement is not a hard constraint.
+A non-decreasing deficit variable $D(t) \ge E_{\text{req}}(t) - E(t)$ tracks the locked-in shortfall — a missed deadline stays priced even if absorption later catches up — and each deficit increment is charged at the shortfall price for the boundary where it locks in:
+
+$$
+\text{cost} = \sum_t p_{\text{deficit}}(t) \cdot \left( D(t) - D(t-1) \right)
+$$
+
+Absorption beyond the total requirement is priced at the overage price.
+This keeps the optimization feasible when a window physically cannot fit its energy, while making the optimizer work to fit it.
+
+## Devices created
+
+The deferrable load element creates a single Home Assistant device:
+
+| Device          | Name     | Created when | Purpose                           |
+| --------------- | -------- | ------------ | --------------------------------- |
+| Deferrable Load | `{name}` | Always       | Power, absorbed energy, shortfall |
+
+## Parameter mapping
+
+| User configuration | Model element(s)               | Model parameter       | Notes                             |
+| ------------------ | ------------------------------ | --------------------- | --------------------------------- |
+| `window_calendar`  | Deferrable load `{name}`       | `capacity`/`required` | Cumulative window energy profiles |
+| `deficit_price`    | Deferrable load `{name}`       | `deficit_price`       | Defaults to \$10/kWh in the flow  |
+| `overage_price`    | Deferrable load `{name}`       | `overage_price`       | Optional                          |
+| `max_power`        | Connection `{name}:connection` | Power limit segment   | Masked by window presence         |
+
+## Output mapping
+
+The adapter maps model outputs to deferrable-load-specific sensor names:
+
+| Model output                      | Sensor name       | Description                      |
+| --------------------------------- | ----------------- | -------------------------------- |
+| Connection power                  | `power`           | Power drawn by the load          |
+| `DEFERRABLE_LOAD_ENERGY_ABSORBED` | `energy_absorbed` | Cumulative energy absorbed       |
+| `DEFERRABLE_LOAD_ENERGY_DEFICIT`  | `energy_deficit`  | Locked-in shortfall per deadline |
+
+See [Deferrable Load Configuration](../../user-guide/elements/deferrable_load.md#sensors-created) for complete sensor documentation.
+
+## Next steps
+
+<div class="grid cards" markdown>
+
+- :material-file-document:{ .lg .middle } **Deferrable load configuration**
+
+    ---
+
+    Configure deferrable loads in your Home Assistant setup.
+
+    [:material-arrow-right: Deferrable load configuration](../../user-guide/elements/deferrable_load.md)
+
+- :material-car-electric:{ .lg .middle } **EV modeling**
+
+    ---
+
+    The EV's trip sink uses the same deferrable load element.
+
+    [:material-arrow-right: EV modeling](ev.md)
+
+- :material-connection:{ .lg .middle } **Connection model**
+
+    ---
+
+    How power limits, efficiency, and pricing are applied.
+
+    [:material-arrow-right: Connection formulation](../model-layer/connections/connection.md)
+
+</div>

--- a/docs/modeling/device-layer/index.md
+++ b/docs/modeling/device-layer/index.md
@@ -46,6 +46,14 @@ This prevents naming collisions and groups related components visually in Home A
 
     [:material-arrow-right: Battery modeling](battery.md)
 
+- :material-timer-outline:{ .lg .middle } **Deferrable load**
+
+    ---
+
+    Calendar-scheduled energy requirements with priced shortfall.
+
+    [:material-arrow-right: Deferrable load modeling](deferrable_load.md)
+
 - :material-power-plug:{ .lg .middle } **Grid**
 
     ---

--- a/docs/user-guide/elements/deferrable_load.md
+++ b/docs/user-guide/elements/deferrable_load.md
@@ -1,0 +1,112 @@
+# Deferrable Load
+
+Deferrable loads are appliances that must consume a set amount of energy within scheduled time windows, but are flexible about exactly when inside each window — pool pumps, hot water systems, irrigation, or an EV charger driven in energy mode.
+
+You schedule the windows with a Home Assistant calendar, and HAEO decides when inside each window to run the load so the energy lands in the cheapest periods.
+The requirement is not a hard rule: if a window physically cannot fit the energy, the shortfall is priced instead of breaking the optimization.
+
+For mathematical details, see [Deferrable Load Modeling](../../modeling/device-layer/deferrable_load.md).
+
+## Configuration
+
+### Overview
+
+A deferrable load in HAEO represents:
+
+- **Run window calendar** from a Home Assistant calendar entity, with the required energy in each event's text
+- **Shortfall price** for energy the window fails to absorb
+- **Optional overage price** for absorbing more than required
+- **Optional max power** for the physical device
+
+## Configuration fields
+
+| Field                                   | Type   | Required | Default | Description                                  |
+| --------------------------------------- | ------ | -------- | ------- | -------------------------------------------- |
+| **[Name](#name)**                       | String | Yes      | -       | Unique identifier (e.g., "Pool Pump")        |
+| **[Connection](#connection)**           | Select | Yes      | -       | Node to connect to in your energy network    |
+| **[Run window calendar](#run-windows)** | Entity | Yes      | -       | Calendar entity with run window events       |
+| **[Shortfall price](#pricing)**         | Price  | Yes      | 10      | Cost per kWh the window fails to absorb      |
+| **[Overage price](#pricing)**           | Price  | No       | -       | Cost per kWh absorbed beyond the requirement |
+| **[Max power](#max-power)**             | Power  | No       | -       | Maximum power the device can draw            |
+
+### Name
+
+Choose a descriptive, friendly name.
+Home Assistant uses it for sensor names, so avoid symbols or abbreviations you would not want to see in the UI.
+
+### Connection
+
+Select the node in your energy network where the load is connected, typically your main switchboard.
+
+### Run windows
+
+Select a Home Assistant calendar entity that contains your run schedule.
+Each calendar event is one window:
+
+- **Start/end time**: When the load is allowed to run
+- **Event text**: The energy the window must absorb, in kWh (e.g., `8`)
+
+The number is read from the first of the location, summary, or description fields that parses as a plain number.
+Events without a parsable number are ignored.
+Power can only flow to the load while a window is open.
+
+!!! tip "Recurring schedules"
+
+    Use recurring calendar events for daily or weekly routines — a pool pump
+    that needs 8 kWh every day is one repeating event with `8` in the location.
+
+### Pricing
+
+- **Shortfall price**: the cost per kWh that a window fails to absorb by its end.
+    The default of \$10/kWh effectively means "always run when physically possible" — lower it to let expensive periods win (e.g. a pool pump that may skip a day when energy costs more than the missed cleaning is worth).
+- **Overage price**: optional cost per kWh absorbed beyond the total requirement.
+    Useful when running longer than needed carries a cost (wear, water use).
+
+A missed window stays priced even if a later window catches up — each window's requirement is due at its own deadline.
+
+### Max power
+
+Set the power the device draws while running (e.g. 1.5 kW for a pool pump).
+The optimizer spreads the window's energy across the window at up to this power.
+
+## Sensors created
+
+The deferrable load element creates one device with the following sensors:
+
+| Sensor           | Unit | Description                                    |
+| ---------------- | ---- | ---------------------------------------------- |
+| Power            | kW   | Power drawn by the load                        |
+| Energy absorbed  | kWh  | Cumulative energy absorbed toward requirements |
+| Energy shortfall | kWh  | Requirement the optimizer expects to miss      |
+
+All sensors include a `forecast` attribute with optimized future values — drive your appliance's switch from the power sensor's forecast.
+
+## Next steps
+
+<div class="grid cards" markdown>
+
+- :material-timer-outline:{ .lg .middle } **Deferrable load modeling**
+
+    ---
+
+    Mathematical formulation for deferrable loads.
+
+    [:material-arrow-right: Deferrable load modeling](../../modeling/device-layer/deferrable_load.md)
+
+- :material-car-electric:{ .lg .middle } **EV configuration**
+
+    ---
+
+    Trip-aware EV charging built on the same mechanism.
+
+    [:material-arrow-right: EV guide](ev.md)
+
+- :material-home-lightning-bolt:{ .lg .middle } **Automation examples**
+
+    ---
+
+    Use optimization results to control your appliances.
+
+    [:material-arrow-right: Automations](../automations.md)
+
+</div>

--- a/docs/user-guide/elements/index.md
+++ b/docs/user-guide/elements/index.md
@@ -80,6 +80,12 @@ Explore detailed configuration for each element type:
 
     [:material-arrow-right: Battery guide](battery.md)
 
+- :material-timer-outline:{ .lg .middle } __Deferrable load configuration__
+
+    Scheduled loads that must absorb set energy within calendar windows.
+
+    [:material-arrow-right: Deferrable load guide](deferrable_load.md)
+
 - :material-power-plug:{ .lg .middle } __Grid configuration__
 
     Import/export with dynamic or fixed pricing.

--- a/frontend/haeo-forecast-card/src/topology/layout.ts
+++ b/frontend/haeo-forecast-card/src/topology/layout.ts
@@ -78,6 +78,7 @@ export interface LayoutResult {
 
 export const NODE_STYLES: Record<string, { color: string; icon: string }> = {
   battery: { color: "#4CAF50", icon: "🔋" },
+  deferrable_load: { color: "#8BC34A", icon: "⏱️" },
   node: { color: "#90CAF9", icon: "⚡" },
   grid: { color: "#FF9800", icon: "🏭" },
   solar: { color: "#FFD600", icon: "☀️" },

--- a/frontend/haeo-forecast-card/src/topology/types.ts
+++ b/frontend/haeo-forecast-card/src/topology/types.ts
@@ -2,7 +2,7 @@
 
 export interface TopologyNode {
   name: string;
-  type: string; // "battery" | "grid" | "solar" | "inverter" | "load" | "node"
+  type: string; // "battery" | "deferrable_load" | "grid" | "solar" | "inverter" | "load" | "node"
   group: string;
   /** VLAN IDs this node produces on (omitted if untagged). */
   outbound_tags?: number[];

--- a/frontend/haeo-forecast-card/src/types.ts
+++ b/frontend/haeo-forecast-card/src/types.ts
@@ -22,6 +22,7 @@ export type ElementType =
   | "battery"
   | "battery_section"
   | "connection"
+  | "deferrable_load"
   | "grid"
   | "inverter"
   | "load"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -159,6 +159,7 @@ nav:
           - user-guide/elements/index.md
           - Battery: user-guide/elements/battery.md
           - Battery Section: user-guide/elements/battery_section.md
+          - Deferrable Load: user-guide/elements/deferrable_load.md
           - Grid: user-guide/elements/grid.md
           - Inverter: user-guide/elements/inverter.md
           - Load: user-guide/elements/load.md
@@ -193,6 +194,7 @@ nav:
           - modeling/device-layer/index.md
           - Battery: modeling/device-layer/battery.md
           - Battery Section: modeling/device-layer/battery_section.md
+          - Deferrable Load: modeling/device-layer/deferrable_load.md
           - Grid: modeling/device-layer/grid.md
           - Inverter: modeling/device-layer/inverter.md
           - Solar: modeling/device-layer/solar.md


### PR DESCRIPTION
:robot: Stacked on #494. (Replaces #499, which GitHub auto-closed as merged when the stack was reordered to put this element below the EV work.) Implements the energy-based deferrable load from #37, built on the model element from #494 (the same one the EV's trip sink uses).

## Summary

A new user-facing **Deferrable Load** element for appliances that must absorb a set amount of energy within scheduled windows — pool pumps, hot water, irrigation, or an EV charger driven in energy mode.

## Semantics

- **Run window calendar**: each calendar event is a window; the event text carries the required energy in kWh (location → summary → description, first field that parses as a number). Recurring events give daily/weekly routines.
- **Window gating**: power can only flow to the load while a window is open, capped by the optional **max power**.
- **Priced shortfall** (default \$10/kWh, pre-filled): a window that physically cannot fit its energy prices the deficit instead of breaking the optimization; a missed window stays priced even if a later one catches up. Lower the price to let expensive periods win ("skip the pool clean when energy costs more than it's worth").
- **Optional overage price** for absorbing beyond the requirement.

## Composition

Two model elements: the `deferrable_load` model element (cumulative capacity/requirement profiles from the calendar edges) and one window-masked connection. Sensors: **Power**, **Energy absorbed**, **Energy shortfall** — all with forecast attributes for driving the appliance's switch.

## Testing

- Adapter LP tests: window gating (zero flow outside windows), energy absorbed within the window at the cheapest feasible placement, too-small windows pricing the shortfall, unlimited-power gating, output mapping
- Flow tests: calendar schema value storage, required-calendar validation; parametrized element/translation suites pick the new type up automatically
- `uv run check`: all 11 gates pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core optimization mapping and LP feasibility via priced deficits; scope is a new element type with solid test coverage rather than changes to shared auth or payment paths.
> 
> **Overview**
> Adds a new **Deferrable Load** element so users can model appliances that must absorb scheduled energy inside calendar windows (pool pumps, hot water, etc.), with the optimizer choosing timing within each window.
> 
> Configuration is wired end-to-end: schema (`schedule` / `pricing` / optional `power`), a `DeferrableLoadAdapter` that builds the existing `deferrable_load` model element plus a window-masked `{name}:connection`, config flow, registry/element unions, English translations, docs, and topology/forecast card type support. Calendar events supply kWh per window; **shortfall** is priced (default $10/kWh) instead of hard-failing the LP; optional max power gates flow only while a window is open.
> 
> Sensors exposed: **Power**, **Energy absorbed**, **Energy shortfall** (with forecasts). Tests cover adapter structure, LP behavior (gating, shortfall pricing), availability, and flow validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cd46800d52ed7790140233a84a3abf74d8d5c50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->