### PR TITLE
fix(#501): snap sub-1e-9 fused forecast values to zero

### DIFF
--- a/custom_components/haeo/core/data/util/forecast_fuser.py
+++ b/custom_components/haeo/core/data/util/forecast_fuser.py
@@ -73,6 +73,16 @@ def fuse_to_boundaries(
     # Interpolate at boundary times
     values = np.interp(horizon_times, block_array["timestamp"], block_array["value"])
 
+    # Snap float-noise magnitudes to zero (issue #501). Cycle-wrapping in
+    # _build_extended_block applies np.mod to epoch-scale timestamps, shifting
+    # step edges by ~1e-7 s; interpolating a 0<->x price step at such an edge
+    # yields values like 1e-11. As objective costs these are harmless, but
+    # _constrain_objective turns the objective into a matrix row where HiGHS
+    # rejects |a_ij| < small_matrix_value (1e-9) with a warning that highspy
+    # escalates to "Error adding constraint" - orphaning the lex row and
+    # wedging every subsequent solve as Infeasible.
+    values[np.abs(values) < 1e-9] = 0.0
+
     # Replace position 0 with present_value if provided
     result = [float(v) for v in values]
     if present_value is not None:
@@ -137,7 +147,11 @@ def fuse_to_intervals(
 
         # Trapezoidal integration: area under curve divided by duration
         area = np.trapezoid(values, times)
-        result.append(float(area / interval_duration))
+        interval_value = float(area / interval_duration)
+        # Snap float-noise magnitudes to zero (see fuse_to_boundaries, issue #501).
+        if abs(interval_value) < 1e-9:
+            interval_value = 0.0
+        result.append(interval_value)
 
     # Replace first interval with present_value if provided
     if present_value is not None:

--- a/custom_components/haeo/core/data/util/tests/test_forecast_fuser.py
+++ b/custom_components/haeo/core/data/util/tests/test_forecast_fuser.py
@@ -253,3 +253,54 @@ def test_fuse_to_boundaries_raises_when_no_data() -> None:
     """Test that missing both forecast_series and present_value raises ValueError."""
     with pytest.raises(ValueError, match="Either forecast_series or present_value must be provided"):
         fuse_to_boundaries(None, [], [0, 1000, 2000])
+
+
+def test_fuse_to_boundaries_snaps_float_noise_to_zero() -> None:
+    """Regression for issue #501.
+
+    Cycle-wrapping in ``_build_extended_block`` applies ``np.mod`` to
+    epoch-scale timestamps, which shifts step-edge times by ~1e-7 s.
+    Interpolating a 0<->x price step near such an edge produces values like
+    1e-11 instead of exact 0.0. Those tiny values are harmless as objective
+    costs, but ``_constrain_objective`` reifies the objective as a matrix
+    row, and HiGHS rejects coefficients below ``small_matrix_value`` (1e-9),
+    which highspy escalates to ``Error adding constraint`` -- orphaning the
+    lex row and wedging every subsequent solve as Infeasible. The fuser
+    therefore snaps ``|v| < 1e-9`` to exact 0.0 before the value can become
+    an LP coefficient.
+
+    We synthesise the failure by placing a boundary a small fraction of the
+    way up a 0 -> 0.35 ramp so that ``np.interp`` returns a sub-1e-9 value;
+    without the snap, position 1 is a float-noise ghost like 3.5e-12.
+    """
+    forecast_series = [(0, 0.0), (1000, 0.0), (1001, 0.35), (2000, 0.35)]
+    # Boundary sits 1e-11 s past the step start: interp yields ~3.5e-12.
+    horizon_times = [0, 1000 + 1e-11, 2000]
+
+    result = fuse_to_boundaries(None, forecast_series, horizon_times)
+
+    assert result[1] == 0.0, f"expected exact 0.0, got {result[1]!r}"
+    for i, v in enumerate(result):
+        assert v == 0.0 or abs(v) >= 1e-9, (
+            f"position {i}: value {v!r} is a sub-1e-9 nonzero (issue #501 signature)"
+        )
+
+
+def test_fuse_to_intervals_snaps_float_noise_to_zero() -> None:
+    """Regression for issue #501 on the trapezoidal branch.
+
+    Same failure mode as ``fuse_to_boundaries`` -- a narrow interval that
+    barely enters a 0 -> x ramp yields a trapezoidal average below 1e-9 and
+    must be snapped to exact 0.0.
+    """
+    forecast_series = [(0, 0.0), (1000, 0.0), (1001, 0.35), (2000, 0.35)]
+    # Interval [1000, 1000 + 2e-11] straddles a sliver of the ramp; trapezoidal
+    # average lands at ~3.5e-12 without the snap.
+    horizon_times = [0, 1000.0, 1000.0 + 2e-11, 2000]
+
+    result = fuse_to_intervals(None, forecast_series, horizon_times)
+
+    for i, v in enumerate(result):
+        assert v == 0.0 or abs(v) >= 1e-9, (
+            f"interval {i}: value {v!r} is a sub-1e-9 nonzero (issue #501 signature)"
+        )


### PR DESCRIPTION
## Summary

Fixes #501: float-noise sub-1e-9 fused prices trigger a HiGHS row warning in the lex constraint, orphaning the row and wedging the solver into permanent `Infeasible` (reload/restart do not recover).

Snaps `|v| < 1e-9` to exact `0.0` in both `fuse_to_boundaries` (post-`np.interp`) and `fuse_to_intervals` (post-trapezoidal average) so the tiny values never reach the LP as matrix coefficients.

Diagnosis, root-cause analysis, and original patch credit: @kymocode (#501).

## Mechanism (from #501)

1. `_build_extended_block` in `forecast_fuser.py` cycle-wraps forecasts with `np.mod(timestamp + start_offset, cover_seconds)` on epoch-scale floats (~1.79e9), shifting step-edge timestamps by O(1e-7 s).
2. `np.interp` / trapezoidal averaging at a `0 <-> non-zero` step edge (e.g. Flow Power's happy-hour export tariff, `$0.00` outside a window / `$0.35` inside) then produces values like `1.159e-11` instead of exact `0.0`.
3. As phase-1 objective *costs* these are harmless -- phase 1 solves optimally. But `_constrain_objective` reifies the primary objective as a matrix row (`objective <= optimal_value`). HiGHS rejects matrix entries with `|a_ij| < small_matrix_value` (default `1e-9`) with a warning, which highspy escalates on any non-`kOk` status to `Error adding constraint`.
4. The partially-added row is orphaned (`self._lex_constraint` never assigned), so `_relax_lex_constraint` can't remove it, and every subsequent phase-1 solve is infeasible against the stale bound. Config-entry reload and full HA restart do not recover while the forecast content stays in the bad regime.

This is complementary to the constraint-management hardening in #484/#485. Those fix the *aftermath*; this fixes the *input-side trigger*, so the pathological coefficient never enters the model in the first place.

## Change

```python
# fuse_to_boundaries, after np.interp:
values[np.abs(values) < 1e-9] = 0.0

# fuse_to_intervals, after trapezoidal average:
interval_value = float(area / interval_duration)
if abs(interval_value) < 1e-9:
    interval_value = 0.0
```

Threshold `1e-9` matches HiGHS's `small_matrix_value` default -- anything the solver would reject as a matrix entry gets zeroed before it can become one.

## Tests

Two new regressions in `test_forecast_fuser.py`:

- `test_fuse_to_boundaries_snaps_float_noise_to_zero`
- `test_fuse_to_intervals_snaps_float_noise_to_zero`

Both construct a `0 -> 0.35` ramp and place a horizon boundary (or interval sliver) a small fraction of the way up it. Without the snap, `np.interp` / trapezoidal averaging returns `~3.5e-12`; both tests assert no result value is a sub-1e-9 non-zero. Verified to **fail without the patch and pass with it** (the assertion prints the exact `3.5015546018257734e-12` produced without the fix).

Full HAEO suite: **1746 passed, 2 skipped** on `v0.4.1 + patch`.

## Live verification

On a system running v0.4.1, all five HAEO output sensors went `unavailable` simultaneously at `2026-08-15T08:00:14.234608+10:00` and stayed dark for **50 min 12 s** while the coordinator alternated between `Infeasible` and `Error adding constraint`. Pulling `number.grid_export_price` via the HA MCP just before applying the patch showed the pathology in the 192-point forecast attribute exactly as #501 describes:

```text
2026-08-15T08:41:00+10:00  value= 0.0
2026-08-15T08:42:00+10:00  value= 0.0
2026-08-15T08:43:00+10:00  value= 0.0
2026-08-15T08:44:00+10:00  value=-7.549921671549479e-12   <-- #501 float-noise ghost
2026-08-15T08:45:00+10:00  value=-0.0038
2026-08-15T08:46:00+10:00  value=-0.0038
2026-08-15T08:47:00+10:00  value=-0.0038
```

One ghost point at a `0 -> -0.0038` step edge -- three orders of magnitude below HiGHS's `small_matrix_value` (`1e-9`) -- was the sole input-side pathology in this wedge. The `number.grid_import_price` forecast at the same instant contained no sub-1e-9 non-zeros (`min |v| > 0 = 0.0234`), so the export step edge is the only place the bug could have entered the LP.

Applying the patch in Studio Code Server and restarting HA restored solver output within a single solve cycle (first fresh sensor update at `2026-08-15T08:50:25.749779+10:00`). Post-recovery MCP verification of the same forecast attribute:

| Metric | Pre-patch | Post-patch |
|---|---|---|
| forecast points | 192 | 192 |
| exact zeros | 6 | 3 |
| sub-1e-9 non-zeros | **1** (`-7.549921671549479e-12` at 08:44) | **0** |
| min \|v\| > 0 | `7.55e-12` | `0.0026` |
| solver state | wedged | producing output |

All five HAEO output sensors returned to healthy numeric states with 192- or 193-point forecasts, and no `Error adding constraint` / `Infeasible` alternation has been observed since the restart.

## Related

- #484 / #485 -- constraint-management hardening (aftermath fix)
- #501 -- issue with full diagnosis and the original patch by @kymocode

## Base

`v0.4.x` (same track as the current stable line).
