### PR TITLE
test(topology-card): wait for the render instead of sleeping a fixed 500 ms

### DIFF
--- a/frontend/haeo-forecast-card/src/topology-card-controller.test.ts
+++ b/frontend/haeo-forecast-card/src/topology-card-controller.test.ts
@@ -30,6 +30,45 @@ function scenarioHass(scenario: { entityId: string; state: Record<string, unknow
   };
 }
 
+// Rendering the topology means loading the controller chunk and running an ELK layout,
+// which is slow enough that a fixed sleep races it — the same flake that was fixed in
+// topology-card.smoke.test.ts. Wait for the outcome instead. The timeouts are generous
+// because they are only reached when the test is genuinely failing.
+const RENDER_TIMEOUT_MS = 10_000;
+const RENDER_POLL_MS = 25;
+
+async function waitForTopologySvg(host: HTMLElement): Promise<void> {
+  await vi.waitFor(
+    () => {
+      expect(host.shadowRoot?.querySelector("svg")).toBeTruthy();
+    },
+    { timeout: RENDER_TIMEOUT_MS, interval: RENDER_POLL_MS }
+  );
+}
+
+/**
+ * Wait for the initial layout to finish dispatching, and report how many `ll-update`
+ * events it produced.
+ *
+ * The svg landing in the DOM is not the last thing to happen: `onLayoutSize` fires from
+ * an effect that runs after that commit, so a count read the moment the svg appears can
+ * still be one short. Wait until the count stops moving.
+ */
+async function waitForSettledUpdates(host: HTMLElement, updates: Event[]): Promise<number> {
+  await waitForTopologySvg(host);
+  let previous = -1;
+  await vi.waitFor(
+    () => {
+      const seen = updates.length;
+      const settled = seen === previous;
+      previous = seen;
+      expect(settled).toBe(true);
+    },
+    { timeout: RENDER_TIMEOUT_MS, interval: RENDER_POLL_MS }
+  );
+  return updates.length;
+}
+
 describe("TopologyCardController", () => {
   afterEach(() => {
     document.body.innerHTML = "";
@@ -53,11 +92,7 @@ describe("TopologyCardController", () => {
     controller.setHass(scenarioHass(scenario, "hub-alpha"));
     controller.connected();
 
-    await new Promise((resolve) => {
-      setTimeout(resolve, 500);
-    });
-
-    expect(host.shadowRoot?.querySelector("svg")).toBeTruthy();
+    await waitForTopologySvg(host);
   });
 
   it("reports grid options from the current layout height", () => {
@@ -107,17 +142,15 @@ describe("TopologyCardController", () => {
     controller.setHass(scenarioHass(scenario, "hub-alpha"));
     controller.connected();
 
-    await new Promise((resolve) => {
-      setTimeout(resolve, 500);
-    });
-
-    const initialCount = updates.length;
+    const initialCount = await waitForSettledUpdates(host, updates);
     controller.setConfig({
       type: "custom:haeo-topology-card",
       title: "Same card size",
       hub_entry_id: "hub-alpha",
     });
 
+    // Asserting a negative — nothing further is dispatched — so there is no outcome to
+    // wait for and this one stays a fixed sleep.
     await new Promise((resolve) => {
       setTimeout(resolve, 500);
     });

--- a/frontend/haeo-forecast-card/src/topology-card.smoke.test.ts
+++ b/frontend/haeo-forecast-card/src/topology-card.smoke.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import scenarioOutputs from "../../../tests/scenarios/scenario1/outputs.json";
 import type { HassLike } from "./series";
@@ -60,6 +60,31 @@ async function waitForTopologyController(): Promise<void> {
   });
 }
 
+// Rendering the topology means loading the controller chunk and running an ELK
+// layout, which is slow enough that a fixed sleep races it: measured at 600-700 ms
+// under full-suite parallel load, against sleeps of 500 ms. Wait for the outcome
+// instead. The timeout is generous because it is only reached when the test fails.
+const RENDER_TIMEOUT_MS = 10_000;
+const RENDER_POLL_MS = 25;
+
+async function waitForTopologySvg(element: HaeoTopologyCardElement): Promise<void> {
+  await vi.waitFor(
+    () => {
+      expect(element.shadowRoot?.querySelector("svg")).toBeTruthy();
+    },
+    { timeout: RENDER_TIMEOUT_MS, interval: RENDER_POLL_MS }
+  );
+}
+
+async function waitForShadowText(element: HaeoTopologyCardElement, text: string): Promise<void> {
+  await vi.waitFor(
+    () => {
+      expect(element.shadowRoot?.textContent).toContain(text);
+    },
+    { timeout: RENDER_TIMEOUT_MS, interval: RENDER_POLL_MS }
+  );
+}
+
 describe("haeo-topology-card smoke", () => {
   afterEach(() => {
     document.body.innerHTML = "";
@@ -91,12 +116,8 @@ describe("haeo-topology-card smoke", () => {
     });
     element.hass = scenarioHass(scenario, "hub-alpha");
     document.body.appendChild(element);
-    await new Promise((resolve) => {
-      setTimeout(resolve, 500);
-    });
 
-    const svg = element.shadowRoot?.querySelector("svg");
-    expect(svg).toBeTruthy();
+    await waitForTopologySvg(element);
     element.remove();
   });
 
@@ -106,10 +127,8 @@ describe("haeo-topology-card smoke", () => {
       type: "custom:haeo-topology-card",
     });
     document.body.appendChild(element);
-    await new Promise((resolve) => {
-      setTimeout(resolve, 20);
-    });
-    expect(element.shadowRoot?.textContent).toContain("Configure a HAEO hub in the card editor");
+
+    await waitForShadowText(element, "Configure a HAEO hub in the card editor");
     element.remove();
   });
 
@@ -159,16 +178,20 @@ describe("haeo-topology-card smoke", () => {
     });
     element.hass = scenarioHass(scenario, "hub-alpha");
     document.body.appendChild(element);
-    await new Promise((resolve) => {
-      setTimeout(resolve, 500);
-    });
 
-    expect(updates.length).toBeGreaterThan(0);
+    await vi.waitFor(
+      () => {
+        expect(updates.length).toBeGreaterThan(0);
+      },
+      { timeout: RENDER_TIMEOUT_MS, interval: RENDER_POLL_MS }
+    );
     const initialCount = updates.length;
     element.setConfig({
       type: "custom:haeo-topology-card",
       hub_entry_id: "hub-alpha",
     });
+    // Asserting that nothing further is dispatched, so this one has to be a settle
+    // delay: there is no outcome to wait for.
     await new Promise((resolve) => {
       setTimeout(resolve, 500);
     });
@@ -209,19 +232,14 @@ describe("haeo-topology-card smoke", () => {
       },
     };
     document.body.appendChild(element);
-    await new Promise((resolve) => {
-      setTimeout(resolve, 500);
-    });
+    await waitForTopologySvg(element);
 
     element.setConfig({
       type: "custom:haeo-topology-card",
       hub_entry_id: "hub-beta",
     });
-    await new Promise((resolve) => {
-      setTimeout(resolve, 500);
-    });
 
-    expect(element.shadowRoot?.querySelector("svg")).toBeTruthy();
+    await waitForTopologySvg(element);
     element.remove();
   });
 
@@ -240,20 +258,15 @@ describe("haeo-topology-card smoke", () => {
     });
     element.hass = scenarioHass(scenario, "hub-alpha");
     document.body.appendChild(element);
-    await new Promise((resolve) => {
-      setTimeout(resolve, 500);
-    });
+    await waitForTopologySvg(element);
 
     element.setConfig({
       type: "custom:haeo-topology-card",
       title: "Second title",
       hub_entry_id: "hub-alpha",
     });
-    await new Promise((resolve) => {
-      setTimeout(resolve, 20);
-    });
 
-    expect(element.shadowRoot?.textContent).toContain("Second title");
+    await waitForShadowText(element, "Second title");
     expect(element.shadowRoot?.querySelector("svg")).toBeTruthy();
     element.remove();
   });
@@ -271,11 +284,8 @@ describe("haeo-topology-card smoke", () => {
     });
     element.hass = scenarioHass(scenario, "hub-alpha");
     document.body.appendChild(element);
-    await new Promise((resolve) => {
-      setTimeout(resolve, 20);
-    });
 
-    expect(element.shadowRoot?.textContent).toContain("Configure a HAEO hub in the card editor");
+    await waitForShadowText(element, "Configure a HAEO hub in the card editor");
     expect(element.shadowRoot?.querySelector("svg")).toBeNull();
     element.remove();
   });
@@ -328,18 +338,12 @@ describe("haeo-topology-card smoke", () => {
     element.hass = scenarioHass(scenario, "hub-alpha");
     document.body.appendChild(element);
     await waitForTopologyController();
-    await new Promise((resolve) => {
-      setTimeout(resolve, 500);
-    });
-    expect(element.shadowRoot?.querySelector("svg")).toBeTruthy();
+    await waitForTopologySvg(element);
 
     element.remove();
     document.body.appendChild(element);
     await waitForTopologyController();
-    await new Promise((resolve) => {
-      setTimeout(resolve, 500);
-    });
-    expect(element.shadowRoot?.querySelector("svg")).toBeTruthy();
+    await waitForTopologySvg(element);
     element.remove();
   });
 });


### PR DESCRIPTION
The `frontend-card-check` gate is flaky on `main`, independently of any change. This fixes it.

## Reproducing on an unmodified checkout

`python3 tools/check.py frontend` runs `npm --prefix frontend/haeo-forecast-card run check`, which runs `test:coverage`. On a clean `main` that fails most runs:

```
run 1:  Tests  2 failed | 189 passed (191)
run 2:  Tests  1 failed | 190 passed (191)
```

Always in `src/topology-card.smoke.test.ts`, and always these two:

- `renders svg when topology data is provided`
- `dispatches ll-update when layout height changes`

Both pass when the file is run in isolation, which is what makes this look intermittent rather than broken.

## Cause

The tests sleep a fixed 500 ms and then assert that an svg has been rendered:

```ts
document.body.appendChild(element);
await new Promise((resolve) => {
  setTimeout(resolve, 500);
});

const svg = element.shadowRoot?.querySelector("svg");
expect(svg).toBeTruthy();
```

Rendering the topology means loading the controller chunk and running an ELK layout. Instrumenting that first test to poll rather than sleep, and printing when the svg actually arrived, gave this across repeated full-suite runs:

```
TIMING svg appeared after 700 ms
TIMING svg appeared after 600 ms
TIMING svg appeared after 600 ms
```

So the margin against a 500 ms sleep is negative under full-suite parallel load. That is why it fails most runs rather than occasionally, and why the coverage path is worse than plain `vitest run`: v8 instrumentation slows the layout further.

## The change

Every wait that gates on an outcome now waits for that outcome, via `vi.waitFor` with a 10 s ceiling and a 25 ms poll. The ceiling is generous on purpose: it is only ever reached when the test genuinely fails, so a passing run is now faster than the fixed sleeps it replaces, not slower.

Two helpers carry it, so the intent reads at each call site:

```ts
await waitForTopologySvg(element);
await waitForShadowText(element, "Second title");
```

One wait is deliberately left as a fixed sleep, with a comment saying why: the second half of the `ll-update` test asserts that nothing further is dispatched, and a negative assertion has no outcome to wait for.

No production code is touched. The card itself is unchanged.

## Verification

- Five consecutive full-suite runs: 191 passed, 191 total, every time.
- Three consecutive `npm run check` runs, which is what the CI gate calls: 191 passed, coverage thresholds met, every time.
- `typecheck`, `eslint` and `prettier --check` all clean.

Baseline for comparison is one or two failures per run before the change.


## Second commit: the sibling file had the same sleeps

`src/topology-card-controller.test.ts` exercises the same controller through `TopologyCardController` directly rather than through the custom element, and carries the identical fixed 500 ms sleeps. It was missed on the first pass.

It fails on its own schedule rather than the smoke test's, which is why it did not show up in the baseline above. One of six `vitest run --coverage` runs failed:

```
FAIL  src/topology-card-controller.test.ts > TopologyCardController
      > does not dispatch ll-update when layout height keeps the same card size
AssertionError: expected 1 to be +0
```

That is the initial layout's own `ll-update` arriving after the 500 ms window that was supposed to contain it, and being counted against the second half of the test.

The same treatment applies, with one addition. Waiting for the svg is not sufficient to read the `ll-update` baseline: `onLayoutSize` fires from an effect that runs after the svg is committed, so a count read the moment the svg appears can still be one short. `waitForSettledUpdates` waits for the svg and then for the count to stop moving. The negative assertion in the same test stays a fixed sleep, for the reason given above.

Verified with eight consecutive `vitest run --coverage` runs and three consecutive `npm run check` runs on this branch, 191 passing every time.
